### PR TITLE
feat(engine): Undo/Redo via snapshot history — Issue #8

### DIFF
--- a/packages/engine/src/__tests__/canvasStore.integration.test.ts
+++ b/packages/engine/src/__tests__/canvasStore.integration.test.ts
@@ -53,7 +53,10 @@ beforeEach(() => {
     activeTool: 'select',
     camera: { x: 0, y: 0, zoom: 1 },
     operationLog: [],
+    canUndo: false,
+    canRedo: false,
   });
+  useCanvasStore.getState().clearHistory();
 });
 
 // ── AC4: Store state shape contract ──────────────────────────
@@ -69,6 +72,8 @@ describe('Store state shape [CONTRACT][AC4]', () => {
     expect(state).toHaveProperty('activeTool');
     expect(state).toHaveProperty('camera');
     expect(state).toHaveProperty('operationLog');
+    expect(state).toHaveProperty('canUndo');
+    expect(state).toHaveProperty('canRedo');
 
     // Type validation
     expect(typeof state.expressions).toBe('object');
@@ -79,6 +84,8 @@ describe('Store state shape [CONTRACT][AC4]', () => {
     expect(typeof state.camera.y).toBe('number');
     expect(typeof state.camera.zoom).toBe('number');
     expect(Array.isArray(state.operationLog)).toBe(true);
+    expect(typeof state.canUndo).toBe('boolean');
+    expect(typeof state.canRedo).toBe('boolean');
   });
 
   it('[CONTRACT] store exposes all required action methods', () => {
@@ -91,6 +98,9 @@ describe('Store state shape [CONTRACT][AC4]', () => {
     expect(typeof state.setSelectedIds).toBe('function');
     expect(typeof state.setActiveTool).toBe('function');
     expect(typeof state.setCamera).toBe('function');
+    expect(typeof state.undo).toBe('function');
+    expect(typeof state.redo).toBe('function');
+    expect(typeof state.clearHistory).toBe('function');
   });
 });
 

--- a/packages/engine/src/__tests__/canvasStore.test.ts
+++ b/packages/engine/src/__tests__/canvasStore.test.ts
@@ -50,7 +50,10 @@ beforeEach(() => {
     activeTool: 'select',
     camera: { x: 0, y: 0, zoom: 1 },
     operationLog: [],
+    canUndo: false,
+    canRedo: false,
   });
+  useCanvasStore.getState().clearHistory();
 });
 
 // ── AC5: addExpression ─────────────────────────────────────

--- a/packages/engine/src/__tests__/canvasStoreUndo.test.ts
+++ b/packages/engine/src/__tests__/canvasStoreUndo.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Unit tests for undo/redo integration in canvasStore.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Acceptance criteria from Issue #8.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ExpressionBuilder } from '@infinicanvas/protocol';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import { useCanvasStore } from '../store/canvasStore.js';
+import type { Camera } from '../types/index.js';
+
+// ── Test fixtures ──────────────────────────────────────────
+
+const testAuthor = { type: 'human' as const, id: 'user-1', name: 'Test User' };
+const builder = new ExpressionBuilder(testAuthor);
+
+function makeRectangle(id: string) {
+  const expr = builder.rectangle(100, 200, 300, 150).label('Test').build();
+  return { ...expr, id };
+}
+
+function makeEllipse(id: string) {
+  const expr = builder.ellipse(50, 50, 200, 200).label('Ellipse').build();
+  return { ...expr, id };
+}
+
+// ── Store reset before each test ───────────────────────────
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    expressions: {},
+    expressionOrder: [],
+    selectedIds: new Set<string>(),
+    activeTool: 'select',
+    camera: { x: 0, y: 0, zoom: 1 },
+    operationLog: [],
+  });
+  // Reset history by getting a fresh store — need to call internal reset
+  // The store should expose a way to reset history, or we reset via setState
+  useCanvasStore.getState().clearHistory?.();
+});
+
+// ── AC1: Ctrl+Z undoes last action ─────────────────────────
+
+describe('store undo [AC1]', () => {
+  it('undo restores expressions after addExpression', () => {
+    const { addExpression, undo } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+
+    useCanvasStore.getState().undo();
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']).toBeUndefined();
+    expect(state.expressionOrder).toEqual([]);
+  });
+
+  it('undo restores position after updateExpression', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+
+    const originalPos = { ...useCanvasStore.getState().expressions['r1']!.position };
+    useCanvasStore.getState().updateExpression('r1', { position: { x: 999, y: 888 } });
+
+    useCanvasStore.getState().undo();
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']!.position).toEqual(originalPos);
+  });
+
+  it('undo restores expressions after deleteExpressions', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+    addExpression(makeEllipse('e1'));
+
+    useCanvasStore.getState().deleteExpressions(['r1']);
+
+    useCanvasStore.getState().undo();
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']).toBeDefined();
+    expect(state.expressions['e1']).toBeDefined();
+    expect(state.expressionOrder).toEqual(['r1', 'e1']);
+  });
+
+  it('undo restores z-order (expressionOrder)', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+    addExpression(makeEllipse('e1'));
+    addExpression(makeRectangle('r2'));
+
+    // Delete middle element
+    useCanvasStore.getState().deleteExpressions(['e1']);
+
+    useCanvasStore.getState().undo();
+
+    const state = useCanvasStore.getState();
+    expect(state.expressionOrder).toEqual(['r1', 'e1', 'r2']);
+  });
+
+  it('undo restores styles', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+
+    const originalStyle = { ...useCanvasStore.getState().expressions['r1']!.style };
+    useCanvasStore.getState().updateExpression('r1', {
+      style: { ...originalStyle, opacity: 0.5 },
+    });
+
+    useCanvasStore.getState().undo();
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']!.style.opacity).toEqual(originalStyle.opacity);
+  });
+});
+
+// ── AC2: Redo restores next state ──────────────────────────
+
+describe('store redo [AC2]', () => {
+  it('redo restores state after undo', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+
+    useCanvasStore.getState().undo();
+    expect(useCanvasStore.getState().expressions['r1']).toBeUndefined();
+
+    useCanvasStore.getState().redo();
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']).toBeDefined();
+    expect(state.expressionOrder).toEqual(['r1']);
+  });
+
+  it('redo restores position after undo of update', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+
+    useCanvasStore.getState().updateExpression('r1', { position: { x: 999, y: 888 } });
+
+    useCanvasStore.getState().undo();
+    useCanvasStore.getState().redo();
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']!.position).toEqual({ x: 999, y: 888 });
+  });
+});
+
+// ── AC3: Multiple sequential undos ─────────────────────────
+
+describe('multiple sequential undos [AC3]', () => {
+  it('undoes multiple add actions in reverse order', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+    addExpression(makeEllipse('e1'));
+    addExpression(makeRectangle('r2'));
+
+    // Undo r2
+    useCanvasStore.getState().undo();
+    expect(useCanvasStore.getState().expressionOrder).toEqual(['r1', 'e1']);
+
+    // Undo e1
+    useCanvasStore.getState().undo();
+    expect(useCanvasStore.getState().expressionOrder).toEqual(['r1']);
+
+    // Undo r1
+    useCanvasStore.getState().undo();
+    expect(useCanvasStore.getState().expressionOrder).toEqual([]);
+  });
+
+  it('multiple undos followed by multiple redos restore full state', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+    addExpression(makeEllipse('e1'));
+
+    // Undo both
+    useCanvasStore.getState().undo();
+    useCanvasStore.getState().undo();
+    expect(useCanvasStore.getState().expressionOrder).toEqual([]);
+
+    // Redo both
+    useCanvasStore.getState().redo();
+    expect(useCanvasStore.getState().expressionOrder).toEqual(['r1']);
+
+    useCanvasStore.getState().redo();
+    expect(useCanvasStore.getState().expressionOrder).toEqual(['r1', 'e1']);
+  });
+});
+
+// ── AC4: New action after undo clears redo ─────────────────
+
+describe('new action after undo clears redo [AC4]', () => {
+  it('new addExpression after undo makes redo impossible', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+    addExpression(makeEllipse('e1'));
+
+    // Undo e1
+    useCanvasStore.getState().undo();
+    expect(useCanvasStore.getState().canRedo).toBe(true);
+
+    // New action diverges history
+    useCanvasStore.getState().addExpression(makeRectangle('r2'));
+    expect(useCanvasStore.getState().canRedo).toBe(false);
+
+    // Redo should be no-op
+    useCanvasStore.getState().redo();
+    expect(useCanvasStore.getState().expressionOrder).toEqual(['r1', 'r2']);
+  });
+});
+
+// ── AC5: Max 100 snapshots ─────────────────────────────────
+
+describe('max snapshot limit in store [AC5]', () => {
+  it('limits undo history to 100 snapshots', () => {
+    const { addExpression } = useCanvasStore.getState();
+
+    // Add 105 expressions (each pushes a snapshot)
+    for (let i = 0; i < 105; i++) {
+      useCanvasStore.getState().addExpression(makeRectangle(`r${i}`));
+    }
+
+    // Undo all the way back
+    let undoCount = 0;
+    while (useCanvasStore.getState().canUndo) {
+      useCanvasStore.getState().undo();
+      undoCount++;
+    }
+
+    // Should only be able to undo 100 times (max)
+    expect(undoCount).toBe(100);
+  });
+});
+
+// ── AC6: Undo at start → no-op ────────────────────────────
+
+describe('undo at start [AC6]', () => {
+  it('undo on empty canvas is a no-op', () => {
+    useCanvasStore.getState().undo();
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions).toEqual({});
+    expect(state.expressionOrder).toEqual([]);
+  });
+
+  it('undo does not throw', () => {
+    expect(() => useCanvasStore.getState().undo()).not.toThrow();
+  });
+});
+
+// ── AC7: Redo at end → no-op ──────────────────────────────
+
+describe('redo at end [AC7]', () => {
+  it('redo with no undo history is a no-op', () => {
+    const { addExpression } = useCanvasStore.getState();
+    addExpression(makeRectangle('r1'));
+
+    useCanvasStore.getState().redo();
+
+    const state = useCanvasStore.getState();
+    expect(state.expressionOrder).toEqual(['r1']);
+  });
+
+  it('redo does not throw', () => {
+    expect(() => useCanvasStore.getState().redo()).not.toThrow();
+  });
+});
+
+// ── AC8: Snapshots on content mutations only ───────────────
+
+describe('snapshot triggers [AC8]', () => {
+  it('addExpression pushes a snapshot (enables undo)', () => {
+    useCanvasStore.getState().addExpression(makeRectangle('r1'));
+    expect(useCanvasStore.getState().canUndo).toBe(true);
+  });
+
+  it('updateExpression pushes a snapshot (enables undo)', () => {
+    useCanvasStore.getState().addExpression(makeRectangle('r1'));
+    // Clear undo state from the add
+    const undoCountAfterAdd = useCanvasStore.getState().canUndo;
+
+    useCanvasStore.getState().updateExpression('r1', { position: { x: 0, y: 0 } });
+    expect(useCanvasStore.getState().canUndo).toBe(true);
+  });
+
+  it('deleteExpressions pushes a snapshot (enables undo)', () => {
+    useCanvasStore.getState().addExpression(makeRectangle('r1'));
+    useCanvasStore.getState().deleteExpressions(['r1']);
+    expect(useCanvasStore.getState().canUndo).toBe(true);
+  });
+
+  it('setSelectedIds does NOT push a snapshot', () => {
+    useCanvasStore.getState().setSelectedIds(new Set(['some-id']));
+    expect(useCanvasStore.getState().canUndo).toBe(false);
+  });
+
+  it('setActiveTool does NOT push a snapshot', () => {
+    useCanvasStore.getState().setActiveTool('rectangle');
+    expect(useCanvasStore.getState().canUndo).toBe(false);
+  });
+
+  it('setCamera does NOT push a snapshot', () => {
+    useCanvasStore.getState().setCamera({ x: 100, y: 200, zoom: 2 });
+    expect(useCanvasStore.getState().canUndo).toBe(false);
+  });
+});
+
+// ── AC9: canUndo and canRedo booleans in store ─────────────
+
+describe('canUndo and canRedo in store [AC9]', () => {
+  it('canUndo is false initially', () => {
+    expect(useCanvasStore.getState().canUndo).toBe(false);
+  });
+
+  it('canRedo is false initially', () => {
+    expect(useCanvasStore.getState().canRedo).toBe(false);
+  });
+
+  it('canUndo becomes true after content mutation', () => {
+    useCanvasStore.getState().addExpression(makeRectangle('r1'));
+    expect(useCanvasStore.getState().canUndo).toBe(true);
+  });
+
+  it('canRedo becomes true after undo', () => {
+    useCanvasStore.getState().addExpression(makeRectangle('r1'));
+    useCanvasStore.getState().undo();
+    expect(useCanvasStore.getState().canRedo).toBe(true);
+  });
+
+  it('canRedo becomes false after new action following undo', () => {
+    useCanvasStore.getState().addExpression(makeRectangle('r1'));
+    useCanvasStore.getState().undo();
+    useCanvasStore.getState().addExpression(makeEllipse('e1'));
+    expect(useCanvasStore.getState().canRedo).toBe(false);
+  });
+});
+
+// ── Edge cases ─────────────────────────────────────────────
+
+describe('edge cases', () => {
+  it('invalid addExpression does not push snapshot', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const invalidExpr = { id: 'bad', kind: 'rectangle' } as never;
+    useCanvasStore.getState().addExpression(invalidExpr);
+
+    expect(useCanvasStore.getState().canUndo).toBe(false);
+
+    warnSpy.mockRestore();
+  });
+
+  it('updateExpression on non-existent id does not push snapshot', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    useCanvasStore.getState().updateExpression('nonexistent', { position: { x: 1, y: 2 } });
+    expect(useCanvasStore.getState().canUndo).toBe(false);
+
+    warnSpy.mockRestore();
+  });
+
+  it('deleteExpressions with empty array does not push snapshot', () => {
+    useCanvasStore.getState().deleteExpressions([]);
+    expect(useCanvasStore.getState().canUndo).toBe(false);
+  });
+
+  it('deleteExpressions with non-existent ids does not push snapshot', () => {
+    useCanvasStore.getState().deleteExpressions(['ghost1', 'ghost2']);
+    expect(useCanvasStore.getState().canUndo).toBe(false);
+  });
+
+  it('undo/redo preserves operationLog (does not rollback ops)', () => {
+    // Operation log is append-only for collaboration — undo should NOT erase it
+    useCanvasStore.getState().addExpression(makeRectangle('r1'));
+    const opsAfterAdd = useCanvasStore.getState().operationLog.length;
+
+    useCanvasStore.getState().undo();
+
+    // operationLog should still contain the create op (or more)
+    expect(useCanvasStore.getState().operationLog.length).toBeGreaterThanOrEqual(opsAfterAdd);
+  });
+});

--- a/packages/engine/src/__tests__/historyManager.test.ts
+++ b/packages/engine/src/__tests__/historyManager.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Unit tests for HistoryManager — snapshot-based undo/redo.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Each test maps to an acceptance criterion from Issue #8.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { HistoryManager } from '../history/historyManager.js';
+import type { CanvasSnapshot } from '../history/historyManager.js';
+import { ExpressionBuilder } from '@infinicanvas/protocol';
+import type { VisualExpression } from '@infinicanvas/protocol';
+
+// ── Test fixtures ──────────────────────────────────────────
+
+const testAuthor = { type: 'human' as const, id: 'user-1', name: 'Test User' };
+const builder = new ExpressionBuilder(testAuthor);
+
+function makeExpression(id: string): VisualExpression {
+  const expr = builder.rectangle(100, 200, 300, 150).label('Test').build();
+  return { ...expr, id };
+}
+
+function makeSnapshot(ids: string[]): CanvasSnapshot {
+  const expressions: Record<string, VisualExpression> = {};
+  for (const id of ids) {
+    expressions[id] = makeExpression(id);
+  }
+  return { expressions, expressionOrder: [...ids] };
+}
+
+const emptySnapshot: CanvasSnapshot = { expressions: {}, expressionOrder: [] };
+
+// ── Tests ──────────────────────────────────────────────────
+
+let manager: HistoryManager;
+
+beforeEach(() => {
+  manager = new HistoryManager();
+});
+
+// ── AC9: canUndo and canRedo booleans ──────────────────────
+
+describe('canUndo / canRedo', () => {
+  it('canUndo returns false when undo stack is empty', () => {
+    expect(manager.canUndo()).toBe(false);
+  });
+
+  it('canRedo returns false when redo stack is empty', () => {
+    expect(manager.canRedo()).toBe(false);
+  });
+
+  it('canUndo returns true after pushing a snapshot', () => {
+    manager.pushSnapshot(makeSnapshot(['r1']));
+    expect(manager.canUndo()).toBe(true);
+  });
+
+  it('canRedo returns true after an undo', () => {
+    manager.pushSnapshot(makeSnapshot(['r1']));
+    manager.undo(makeSnapshot(['r1', 'r2']));
+    expect(manager.canRedo()).toBe(true);
+  });
+});
+
+// ── AC1: Undo restores previous state ──────────────────────
+
+describe('undo', () => {
+  it('returns the previous snapshot when undoing [AC1]', () => {
+    const snap1 = makeSnapshot(['r1']);
+    manager.pushSnapshot(snap1);
+
+    const currentState = makeSnapshot(['r1', 'r2']);
+    const result = manager.undo(currentState);
+
+    expect(result).not.toBeNull();
+    expect(result!.expressionOrder).toEqual(['r1']);
+    expect(result!.expressions['r1']).toBeDefined();
+    expect(result!.expressions['r2']).toBeUndefined();
+  });
+
+  it('restores expressions, positions, styles, and z-order [AC1]', () => {
+    const snap = makeSnapshot(['r1']);
+    snap.expressions['r1']!.position = { x: 42, y: 99 };
+    manager.pushSnapshot(snap);
+
+    const current = makeSnapshot(['r1']);
+    current.expressions['r1']!.position = { x: 500, y: 600 };
+
+    const result = manager.undo(current);
+    expect(result!.expressions['r1']!.position).toEqual({ x: 42, y: 99 });
+  });
+
+  it('pushes current state to redo stack on undo', () => {
+    manager.pushSnapshot(makeSnapshot(['r1']));
+    manager.undo(makeSnapshot(['r1', 'r2']));
+
+    expect(manager.canRedo()).toBe(true);
+  });
+});
+
+// ── AC6: Undo at start → no-op ────────────────────────────
+
+describe('undo at empty stack [AC6]', () => {
+  it('returns null when undo stack is empty', () => {
+    const result = manager.undo(makeSnapshot(['r1']));
+    expect(result).toBeNull();
+  });
+
+  it('does not modify redo stack when undo returns null', () => {
+    manager.undo(makeSnapshot(['r1']));
+    expect(manager.canRedo()).toBe(false);
+  });
+});
+
+// ── AC2: Redo restores next state ──────────────────────────
+
+describe('redo', () => {
+  it('returns the next snapshot when redoing [AC2]', () => {
+    manager.pushSnapshot(makeSnapshot(['r1']));
+    const currentAfterAdd = makeSnapshot(['r1', 'r2']);
+    manager.undo(currentAfterAdd);
+
+    // Now redo from the undone state
+    const undoneState = makeSnapshot(['r1']);
+    const result = manager.redo(undoneState);
+
+    expect(result).not.toBeNull();
+    expect(result!.expressionOrder).toEqual(['r1', 'r2']);
+  });
+
+  it('pushes current state to undo stack on redo', () => {
+    manager.pushSnapshot(makeSnapshot(['r1']));
+    manager.undo(makeSnapshot(['r1', 'r2']));
+
+    // Before redo: undo stack should have been emptied by undo
+    const undoneState = makeSnapshot(['r1']);
+    manager.redo(undoneState);
+
+    expect(manager.canUndo()).toBe(true);
+  });
+});
+
+// ── AC7: Redo at end → no-op ──────────────────────────────
+
+describe('redo at empty stack [AC7]', () => {
+  it('returns null when redo stack is empty', () => {
+    const result = manager.redo(makeSnapshot(['r1']));
+    expect(result).toBeNull();
+  });
+
+  it('does not modify undo stack when redo returns null', () => {
+    manager.redo(makeSnapshot(['r1']));
+    expect(manager.canUndo()).toBe(false);
+  });
+});
+
+// ── AC3: Multiple sequential undos ─────────────────────────
+
+describe('multiple sequential undos [AC3]', () => {
+  it('undoes multiple actions in reverse order', () => {
+    const snap0 = makeSnapshot([]);         // initial empty
+    const snap1 = makeSnapshot(['r1']);      // after adding r1
+    const snap2 = makeSnapshot(['r1', 'r2']); // after adding r2
+
+    manager.pushSnapshot(snap0);
+    manager.pushSnapshot(snap1);
+
+    const current = makeSnapshot(['r1', 'r2', 'r3']);
+
+    // Undo 3rd action → should get snap2... wait, we only pushed snap0 and snap1
+    // Let me think about this more carefully:
+    // push snap0 (before action 1)
+    // push snap1 (before action 2)
+    // push snap2 (before action 3) -- not pushed yet
+    // Actually, let me push all three snapshots
+
+    // Reset
+    manager = new HistoryManager();
+    manager.pushSnapshot(makeSnapshot([]));
+    manager.pushSnapshot(makeSnapshot(['r1']));
+    manager.pushSnapshot(makeSnapshot(['r1', 'r2']));
+
+    const currentFinal = makeSnapshot(['r1', 'r2', 'r3']);
+
+    // Undo once → get snapshot before last action
+    const undo1 = manager.undo(currentFinal);
+    expect(undo1!.expressionOrder).toEqual(['r1', 'r2']);
+
+    // Undo again → get snapshot before second action
+    const undo2 = manager.undo(undo1!);
+    expect(undo2!.expressionOrder).toEqual(['r1']);
+
+    // Undo again → get initial empty state
+    const undo3 = manager.undo(undo2!);
+    expect(undo3!.expressionOrder).toEqual([]);
+
+    // Undo again → no more history
+    const undo4 = manager.undo(undo3!);
+    expect(undo4).toBeNull();
+  });
+});
+
+// ── AC4: New action after undo clears redo stack ───────────
+
+describe('new action after undo clears redo [AC4]', () => {
+  it('clears redo stack when new snapshot is pushed after undo', () => {
+    manager.pushSnapshot(makeSnapshot(['r1']));
+    manager.pushSnapshot(makeSnapshot(['r1', 'r2']));
+    manager.pushSnapshot(makeSnapshot(['r1', 'r2', 'r3']));
+
+    const current = makeSnapshot(['r1', 'r2', 'r3', 'r4']);
+
+    // Undo twice
+    const undo1 = manager.undo(current);
+    manager.undo(undo1!);
+
+    expect(manager.canRedo()).toBe(true);
+
+    // Push new snapshot (new action diverges history)
+    manager.pushSnapshot(makeSnapshot(['r1', 'r2', 'new']));
+
+    // Redo should be impossible — new branch started
+    expect(manager.canRedo()).toBe(false);
+  });
+});
+
+// ── AC5: Max 100 snapshots, oldest dropped ─────────────────
+
+describe('max snapshot limit [AC5]', () => {
+  it('keeps at most 100 snapshots in undo stack', () => {
+    // Push 101 snapshots
+    for (let i = 0; i <= 100; i++) {
+      manager.pushSnapshot(makeSnapshot([`r${i}`]));
+    }
+
+    // Undo 100 times should work (max stack size)
+    let undoCount = 0;
+    let state: CanvasSnapshot | null = makeSnapshot(['final']);
+    while (state !== null) {
+      state = manager.undo(state);
+      if (state !== null) undoCount++;
+    }
+
+    expect(undoCount).toBe(100);
+  });
+
+  it('drops oldest snapshot when 101st is pushed', () => {
+    // Push 101 snapshots with identifiable content
+    for (let i = 0; i <= 100; i++) {
+      manager.pushSnapshot(makeSnapshot([`r${i}`]));
+    }
+
+    // The first snapshot (r0) should have been evicted
+    // Undo all the way back - should NOT reach r0
+    let state: CanvasSnapshot | null = makeSnapshot(['final']);
+    let oldest: CanvasSnapshot | null = null;
+    while (state !== null) {
+      oldest = state;
+      state = manager.undo(state);
+    }
+
+    // Oldest reachable should be r1 (r0 was evicted)
+    expect(oldest!.expressionOrder).toEqual(['r1']);
+  });
+});
+
+// ── Deep clone verification ────────────────────────────────
+
+describe('deep clone isolation', () => {
+  it('snapshot is independent of original — mutating original does not affect snapshot', () => {
+    const original = makeSnapshot(['r1']);
+    manager.pushSnapshot(original);
+
+    // Mutate the original after pushing
+    original.expressions['r1']!.position = { x: 999, y: 999 };
+    original.expressionOrder.push('mutated');
+
+    // Undo should return the snapshot as it was when pushed
+    const result = manager.undo(makeSnapshot(['current']));
+    expect(result!.expressions['r1']!.position).not.toEqual({ x: 999, y: 999 });
+    expect(result!.expressionOrder).not.toContain('mutated');
+  });
+
+  it('returned snapshot is independent — mutating it does not affect internal state', () => {
+    manager.pushSnapshot(makeSnapshot(['r1']));
+    manager.pushSnapshot(makeSnapshot(['r1', 'r2']));
+
+    const current = makeSnapshot(['r1', 'r2', 'r3']);
+    const undone = manager.undo(current);
+
+    // Mutate the returned snapshot
+    undone!.expressionOrder.push('evil');
+    undone!.expressions['evil'] = makeExpression('evil');
+
+    // Redo should give back the original current state, unaffected
+    const redone = manager.redo(undone!);
+    expect(redone!.expressionOrder).not.toContain('evil');
+  });
+});
+
+// ── Full undo/redo cycle ───────────────────────────────────
+
+describe('full undo/redo cycle', () => {
+  it('push → undo → redo produces consistent round-trip [AC1, AC2]', () => {
+    const snapBefore = makeSnapshot(['r1']);
+    manager.pushSnapshot(snapBefore);
+
+    const current = makeSnapshot(['r1', 'r2']);
+
+    // Undo
+    const undone = manager.undo(current);
+    expect(undone!.expressionOrder).toEqual(['r1']);
+
+    // Redo from the undone state
+    const redone = manager.redo(undone!);
+    expect(redone!.expressionOrder).toEqual(['r1', 'r2']);
+  });
+
+  it('push 3 → undo 2 → new action → redo → should be no-op [AC4]', () => {
+    manager.pushSnapshot(emptySnapshot);
+    manager.pushSnapshot(makeSnapshot(['r1']));
+    manager.pushSnapshot(makeSnapshot(['r1', 'r2']));
+
+    const current = makeSnapshot(['r1', 'r2', 'r3']);
+
+    // Undo 2 times
+    const undo1 = manager.undo(current);
+    const undo2 = manager.undo(undo1!);
+
+    // New action: push new snapshot (diverges history)
+    manager.pushSnapshot(undo2!);
+
+    // Try redo → should be no-op (redo was cleared)
+    const result = manager.redo(makeSnapshot(['r1', 'new-thing']));
+    expect(result).toBeNull();
+  });
+});
+
+// ── Constructor options ────────────────────────────────────
+
+describe('constructor options', () => {
+  it('accepts custom maxSize', () => {
+    const small = new HistoryManager(5);
+
+    for (let i = 0; i < 10; i++) {
+      small.pushSnapshot(makeSnapshot([`r${i}`]));
+    }
+
+    let undoCount = 0;
+    let state: CanvasSnapshot | null = makeSnapshot(['final']);
+    while (state !== null) {
+      state = small.undo(state);
+      if (state !== null) undoCount++;
+    }
+
+    expect(undoCount).toBe(5);
+  });
+});

--- a/packages/engine/src/__tests__/useUndoRedoShortcuts.test.tsx
+++ b/packages/engine/src/__tests__/useUndoRedoShortcuts.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for useUndoRedoShortcuts hook — keyboard shortcuts.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Acceptance criteria from Issue #8.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useUndoRedoShortcuts } from '../hooks/useUndoRedoShortcuts.js';
+import { useCanvasStore } from '../store/canvasStore.js';
+
+// ── Store reset ────────────────────────────────────────────
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    expressions: {},
+    expressionOrder: [],
+    selectedIds: new Set<string>(),
+    activeTool: 'select',
+    camera: { x: 0, y: 0, zoom: 1 },
+    operationLog: [],
+  });
+  useCanvasStore.getState().clearHistory?.();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Helper to dispatch keyboard events ─────────────────────
+
+function fireKeydown(key: string, options: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...options,
+  });
+  document.dispatchEvent(event);
+  return event;
+}
+
+// ── Tests ──────────────────────────────────────────────────
+
+describe('useUndoRedoShortcuts', () => {
+  it('registers keydown listener on mount', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const { unmount } = renderHook(() => useUndoRedoShortcuts());
+
+    expect(addSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    unmount();
+  });
+
+  it('removes keydown listener on unmount', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = renderHook(() => useUndoRedoShortcuts());
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+  });
+
+  describe('Ctrl+Z triggers undo', () => {
+    it('calls undo on Ctrl+Z', () => {
+      const undoSpy = vi.fn();
+      useCanvasStore.setState({ undo: undoSpy } as any);
+
+      renderHook(() => useUndoRedoShortcuts());
+
+      fireKeydown('z', { ctrlKey: true });
+
+      expect(undoSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls undo on Cmd+Z (Mac)', () => {
+      const undoSpy = vi.fn();
+      useCanvasStore.setState({ undo: undoSpy } as any);
+
+      renderHook(() => useUndoRedoShortcuts());
+
+      fireKeydown('z', { metaKey: true });
+
+      expect(undoSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Ctrl+Shift+Z / Ctrl+Y triggers redo', () => {
+    it('calls redo on Ctrl+Shift+Z', () => {
+      const redoSpy = vi.fn();
+      useCanvasStore.setState({ redo: redoSpy } as any);
+
+      renderHook(() => useUndoRedoShortcuts());
+
+      fireKeydown('z', { ctrlKey: true, shiftKey: true });
+
+      expect(redoSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls redo on Cmd+Shift+Z (Mac)', () => {
+      const redoSpy = vi.fn();
+      useCanvasStore.setState({ redo: redoSpy } as any);
+
+      renderHook(() => useUndoRedoShortcuts());
+
+      fireKeydown('z', { metaKey: true, shiftKey: true });
+
+      expect(redoSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls redo on Ctrl+Y', () => {
+      const redoSpy = vi.fn();
+      useCanvasStore.setState({ redo: redoSpy } as any);
+
+      renderHook(() => useUndoRedoShortcuts());
+
+      fireKeydown('y', { ctrlKey: true });
+
+      expect(redoSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls redo on Cmd+Y (Mac)', () => {
+      const redoSpy = vi.fn();
+      useCanvasStore.setState({ redo: redoSpy } as any);
+
+      renderHook(() => useUndoRedoShortcuts());
+
+      fireKeydown('y', { metaKey: true });
+
+      expect(redoSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('prevents default browser behavior', () => {
+    it('prevents default on Ctrl+Z', () => {
+      renderHook(() => useUndoRedoShortcuts());
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'z',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      const preventSpy = vi.spyOn(event, 'preventDefault');
+      document.dispatchEvent(event);
+
+      expect(preventSpy).toHaveBeenCalled();
+    });
+
+    it('prevents default on Ctrl+Shift+Z', () => {
+      renderHook(() => useUndoRedoShortcuts());
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'z',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      const preventSpy = vi.spyOn(event, 'preventDefault');
+      document.dispatchEvent(event);
+
+      expect(preventSpy).toHaveBeenCalled();
+    });
+
+    it('prevents default on Ctrl+Y', () => {
+      renderHook(() => useUndoRedoShortcuts());
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'y',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      const preventSpy = vi.spyOn(event, 'preventDefault');
+      document.dispatchEvent(event);
+
+      expect(preventSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('does NOT trigger on unrelated keys', () => {
+    it('does not call undo/redo on plain Z', () => {
+      const undoSpy = vi.fn();
+      const redoSpy = vi.fn();
+      useCanvasStore.setState({ undo: undoSpy, redo: redoSpy } as any);
+
+      renderHook(() => useUndoRedoShortcuts());
+
+      fireKeydown('z');
+
+      expect(undoSpy).not.toHaveBeenCalled();
+      expect(redoSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not call undo/redo on Ctrl+A', () => {
+      const undoSpy = vi.fn();
+      const redoSpy = vi.fn();
+      useCanvasStore.setState({ undo: undoSpy, redo: redoSpy } as any);
+
+      renderHook(() => useUndoRedoShortcuts());
+
+      fireKeydown('a', { ctrlKey: true });
+
+      expect(undoSpy).not.toHaveBeenCalled();
+      expect(redoSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Ctrl+Shift+Z is redo, NOT undo', () => {
+    it('does not call undo when Shift is also pressed', () => {
+      const undoSpy = vi.fn();
+      useCanvasStore.setState({ undo: undoSpy } as any);
+
+      renderHook(() => useUndoRedoShortcuts());
+
+      fireKeydown('z', { ctrlKey: true, shiftKey: true });
+
+      expect(undoSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/engine/src/components/Canvas.tsx
+++ b/packages/engine/src/components/Canvas.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { ErrorBoundary } from './ErrorBoundary.js';
 import { useCanvasInteraction } from '../hooks/useCanvasInteraction.js';
+import { useUndoRedoShortcuts } from '../hooks/useUndoRedoShortcuts.js';
 import { useCanvasStore } from '../store/canvasStore.js';
 import { createRenderLoop } from '../renderer/renderLoop.js';
 import type { RenderLoop } from '../renderer/renderLoop.js';
@@ -28,6 +29,9 @@ function CanvasInner() {
   const containerRef = useRef<HTMLDivElement>(null);
   const renderLoopRef = useRef<RenderLoop | null>(null);
   const { canvasRef, cursor } = useCanvasInteraction();
+
+  // Register global undo/redo keyboard shortcuts [AC1, AC2]
+  useUndoRedoShortcuts();
 
   const updateCanvasSize = useCallback(() => {
     const canvas = canvasRef.current;

--- a/packages/engine/src/history/historyManager.ts
+++ b/packages/engine/src/history/historyManager.ts
@@ -1,0 +1,118 @@
+/**
+ * HistoryManager — snapshot-based undo/redo system.
+ *
+ * Maintains two stacks (undo and redo) of deep-cloned canvas snapshots.
+ * Each snapshot captures `expressions` and `expressionOrder` before a
+ * content mutation occurs.
+ *
+ * Design decisions [CLEAN-CODE] [SRP]:
+ * - Pure class with no framework dependency (testable in isolation)
+ * - Deep clones on push/pop to prevent reference aliasing
+ * - Configurable max stack size (default 100) [YAGNI exception: ticket requirement]
+ *
+ * @module
+ */
+
+import type { VisualExpression } from '@infinicanvas/protocol';
+
+/** Immutable snapshot of canvas content state. */
+export interface CanvasSnapshot {
+  /** All expressions on the canvas, keyed by ID. */
+  expressions: Record<string, VisualExpression>;
+  /** Ordered list of expression IDs representing z-order (back to front). */
+  expressionOrder: string[];
+}
+
+/** Default maximum number of snapshots in the undo stack. */
+const DEFAULT_MAX_SIZE = 100;
+
+/**
+ * Deep-clone a CanvasSnapshot to prevent reference aliasing.
+ *
+ * Uses structuredClone for a reliable deep copy that handles
+ * nested objects, arrays, and all VisualExpression fields.
+ */
+function cloneSnapshot(snapshot: CanvasSnapshot): CanvasSnapshot {
+  return structuredClone(snapshot);
+}
+
+/**
+ * Snapshot-based undo/redo history manager.
+ *
+ * Usage:
+ * 1. Before each content mutation, call `pushSnapshot(currentState)`
+ * 2. To undo, call `undo(currentState)` — returns previous state or null
+ * 3. To redo, call `redo(currentState)` — returns next state or null
+ *
+ * Invariants:
+ * - Undo stack never exceeds `maxSize` entries
+ * - Pushing a new snapshot clears the redo stack (history diverges)
+ * - All snapshots are deep-cloned on entry and exit
+ */
+export class HistoryManager {
+  private undoStack: CanvasSnapshot[] = [];
+  private redoStack: CanvasSnapshot[] = [];
+  private readonly maxSize: number;
+
+  constructor(maxSize: number = DEFAULT_MAX_SIZE) {
+    this.maxSize = maxSize;
+  }
+
+  /**
+   * Push a snapshot onto the undo stack.
+   * Clears the redo stack (new action diverges history). [AC4]
+   * Evicts oldest snapshot if stack exceeds maxSize. [AC5]
+   */
+  pushSnapshot(snapshot: CanvasSnapshot): void {
+    this.undoStack.push(cloneSnapshot(snapshot));
+    this.redoStack = [];
+
+    if (this.undoStack.length > this.maxSize) {
+      this.undoStack.shift();
+    }
+  }
+
+  /**
+   * Undo: pop from undo stack, push current state to redo stack.
+   * Returns the previous snapshot, or null if nothing to undo. [AC6]
+   */
+  undo(currentState: CanvasSnapshot): CanvasSnapshot | null {
+    const previous = this.undoStack.pop();
+    if (!previous) {
+      return null;
+    }
+
+    this.redoStack.push(cloneSnapshot(currentState));
+    return cloneSnapshot(previous);
+  }
+
+  /**
+   * Redo: pop from redo stack, push current state to undo stack.
+   * Returns the next snapshot, or null if nothing to redo. [AC7]
+   */
+  redo(currentState: CanvasSnapshot): CanvasSnapshot | null {
+    const next = this.redoStack.pop();
+    if (!next) {
+      return null;
+    }
+
+    this.undoStack.push(cloneSnapshot(currentState));
+    return cloneSnapshot(next);
+  }
+
+  /** Whether undo is available. [AC9] */
+  canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  /** Whether redo is available. [AC9] */
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  /** Reset all history stacks. */
+  clear(): void {
+    this.undoStack = [];
+    this.redoStack = [];
+  }
+}

--- a/packages/engine/src/hooks/useUndoRedoShortcuts.ts
+++ b/packages/engine/src/hooks/useUndoRedoShortcuts.ts
@@ -1,0 +1,56 @@
+/**
+ * useUndoRedoShortcuts — keyboard shortcuts for undo/redo.
+ *
+ * Registers global keydown listeners for:
+ * - Ctrl+Z / Cmd+Z → undo
+ * - Ctrl+Shift+Z / Cmd+Shift+Z → redo
+ * - Ctrl+Y / Cmd+Y → redo
+ *
+ * Prevents default browser behavior for these key combinations.
+ *
+ * @module
+ */
+
+import { useEffect } from 'react';
+import { useCanvasStore } from '../store/canvasStore.js';
+
+/**
+ * Hook that registers global keyboard shortcuts for undo/redo.
+ *
+ * Call this in your root Canvas or App component. The hook manages
+ * its own lifecycle — listeners are added on mount, removed on unmount.
+ */
+export function useUndoRedoShortcuts(): void {
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent): void {
+      const isModifier = event.ctrlKey || event.metaKey;
+      if (!isModifier) return;
+
+      const key = event.key.toLowerCase();
+
+      // Ctrl+Shift+Z / Cmd+Shift+Z → redo (check shift FIRST to avoid undo match)
+      if (key === 'z' && event.shiftKey) {
+        event.preventDefault();
+        useCanvasStore.getState().redo();
+        return;
+      }
+
+      // Ctrl+Z / Cmd+Z → undo
+      if (key === 'z' && !event.shiftKey) {
+        event.preventDefault();
+        useCanvasStore.getState().undo();
+        return;
+      }
+
+      // Ctrl+Y / Cmd+Y → redo
+      if (key === 'y') {
+        event.preventDefault();
+        useCanvasStore.getState().redo();
+        return;
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -10,6 +10,10 @@
 // ── State store ────────────────────────────────────────────
 export { useCanvasStore } from './store/canvasStore.js';
 
+// ── History ────────────────────────────────────────────────
+export { HistoryManager } from './history/historyManager.js';
+export type { CanvasSnapshot } from './history/historyManager.js';
+
 // ── Camera math ────────────────────────────────────────────
 export {
   screenToWorld,
@@ -26,6 +30,7 @@ export type { RenderLoop } from './renderer/renderLoop.js';
 // ── Hooks ──────────────────────────────────────────────────
 export { useCanvasInteraction } from './hooks/useCanvasInteraction.js';
 export type { CanvasInteraction } from './hooks/useCanvasInteraction.js';
+export { useUndoRedoShortcuts } from './hooks/useUndoRedoShortcuts.js';
 
 // ── Components ─────────────────────────────────────────────
 export { Canvas } from './components/Canvas.js';

--- a/packages/engine/src/store/canvasStore.ts
+++ b/packages/engine/src/store/canvasStore.ts
@@ -3,8 +3,9 @@
  *
  * Manages all canvas state: expressions, selection, tools, camera, and
  * the protocol operation log. Mutation actions that affect canvas content
- * (add, update, delete) emit ProtocolOperations for collaboration tracking.
- * UI-only actions (selection, tool, camera) do NOT emit operations.
+ * (add, update, delete) emit ProtocolOperations for collaboration tracking
+ * and push undo snapshots for history navigation.
+ * UI-only actions (selection, tool, camera) do NOT emit operations or snapshots.
  *
  * @module
  */
@@ -22,6 +23,8 @@ import type {
   AuthorInfo,
 } from '@infinicanvas/protocol';
 import type { CanvasState, CanvasActions, ToolType, Camera } from '../types/index.js';
+import { HistoryManager } from '../history/historyManager.js';
+import type { CanvasSnapshot } from '../history/historyManager.js';
 
 // Enable immer support for Set/Map (used by selectedIds: Set<string>)
 enableMapSet();
@@ -43,6 +46,9 @@ const MAX_ZOOM = 100;
 
 /** Fields that cannot be changed via updateExpression. */
 const IMMUTABLE_FIELDS = new Set(['id', 'kind', 'meta']);
+
+/** Shared history manager instance (lives outside Zustand to avoid serialization). */
+const historyManager = new HistoryManager();
 
 /** Creates a ProtocolOperation with unique ID and current timestamp. */
 function createOperation(
@@ -66,8 +72,21 @@ function pushOperation(log: ProtocolOperation[], op: ProtocolOperation): void {
   }
 }
 
+/** Extract a snapshot from the current canvas state (expressions + z-order). */
+function captureSnapshot(state: CanvasState): CanvasSnapshot {
+  // Build a plain-object clone of expressions (immer draft → plain)
+  const expressions: Record<string, VisualExpression> = {};
+  for (const [id, expr] of Object.entries(state.expressions)) {
+    expressions[id] = structuredClone(expr as VisualExpression);
+  }
+  return {
+    expressions,
+    expressionOrder: [...state.expressionOrder],
+  };
+}
+
 export const useCanvasStore = create<CanvasState & CanvasActions>()(
-  immer((set) => ({
+  immer((set, get) => ({
     // ── Initial state ────────────────────────────────────────
     expressions: {},
     expressionOrder: [],
@@ -75,8 +94,10 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
     activeTool: 'select' as ToolType,
     camera: { x: 0, y: 0, zoom: 1 },
     operationLog: [],
+    canUndo: false,
+    canRedo: false,
 
-    // ── Content mutations (emit ProtocolOperations) ──────────
+    // ── Content mutations (emit ProtocolOperations + push snapshots) ──
 
     addExpression: (expression: VisualExpression) => {
       const result = visualExpressionSchema.safeParse(expression);
@@ -88,11 +109,16 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
         return;
       }
 
-      set((state) => {
-        if (state.expressions[expression.id]) {
-          return;
-        }
+      // Check for duplicate before snapshotting [AC8]
+      const currentState = get();
+      if (currentState.expressions[expression.id]) {
+        return;
+      }
 
+      // Push snapshot BEFORE mutation [AC8]
+      historyManager.pushSnapshot(captureSnapshot(currentState));
+
+      set((state) => {
         state.expressions[expression.id] = expression;
         state.expressionOrder.push(expression.id);
 
@@ -105,18 +131,30 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
           data: expression.data,
         });
         pushOperation(state.operationLog, operation);
+
+        state.canUndo = historyManager.canUndo();
+        state.canRedo = historyManager.canRedo();
       });
     },
 
     updateExpression: (id: string, partial: Partial<VisualExpression>) => {
+      const currentState = get();
+      const existing = currentState.expressions[id];
+      if (!existing) {
+        console.warn(
+          `[canvasStore] Cannot update non-existent expression: ${id}`,
+        );
+        return;
+      }
+
+      // Push snapshot BEFORE mutation [AC8]
+      historyManager.pushSnapshot(captureSnapshot(currentState));
+
+      let reverted = false;
+
       set((state) => {
-        const existing = state.expressions[id];
-        if (!existing) {
-          console.warn(
-            `[canvasStore] Cannot update non-existent expression: ${id}`,
-          );
-          return;
-        }
+        const expr = state.expressions[id];
+        if (!expr) return;
 
         // Strip immutable fields to protect invariants
         const safeUpdates: Record<string, unknown> = {};
@@ -129,21 +167,22 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
         // Snapshot original values for rollback
         const originals: Record<string, unknown> = {};
         for (const key of Object.keys(safeUpdates)) {
-          originals[key] = (existing as Record<string, unknown>)[key];
+          originals[key] = (expr as Record<string, unknown>)[key];
         }
 
         // Apply safe updates
-        Object.assign(existing, safeUpdates);
+        Object.assign(expr, safeUpdates);
 
         // Post-merge validation — revert if result is invalid
-        const merged = visualExpressionSchema.safeParse(existing);
+        const merged = visualExpressionSchema.safeParse(expr);
         if (!merged.success) {
           // Rollback draft to original values
-          Object.assign(existing, originals);
+          Object.assign(expr, originals);
           console.warn(
             `[canvasStore] Update would produce invalid expression, reverting:`,
             merged.error.issues,
           );
+          reverted = true;
           return;
         }
 
@@ -161,7 +200,19 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
           changes,
         });
         pushOperation(state.operationLog, operation);
+
+        state.canUndo = historyManager.canUndo();
+        state.canRedo = historyManager.canRedo();
       });
+
+      // If the update was reverted (validation failed), undo the snapshot push
+      if (reverted) {
+        historyManager.undo(captureSnapshot(get()));
+        set((state) => {
+          state.canUndo = historyManager.canUndo();
+          state.canRedo = historyManager.canRedo();
+        });
+      }
     },
 
     deleteExpressions: (ids: string[]) => {
@@ -169,13 +220,18 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
         return;
       }
 
-      set((state) => {
-        // Filter to only IDs that actually exist
-        const existingIds = ids.filter((id) => id in state.expressions);
-        if (existingIds.length === 0) {
-          return;
-        }
+      const currentState = get();
 
+      // Filter to only IDs that actually exist
+      const existingIds = ids.filter((id) => id in currentState.expressions);
+      if (existingIds.length === 0) {
+        return;
+      }
+
+      // Push snapshot BEFORE mutation [AC8]
+      historyManager.pushSnapshot(captureSnapshot(currentState));
+
+      set((state) => {
         const idSet = new Set(existingIds);
 
         for (const id of existingIds) {
@@ -192,10 +248,51 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
           expressionIds: [...existingIds],
         });
         pushOperation(state.operationLog, operation);
+
+        state.canUndo = historyManager.canUndo();
+        state.canRedo = historyManager.canRedo();
       });
     },
 
-    // ── UI-only state (NO ProtocolOperations) ────────────────
+    // ── Undo/Redo actions ────────────────────────────────────
+
+    undo: () => {
+      const currentState = get();
+      const snapshot = historyManager.undo(captureSnapshot(currentState));
+      if (!snapshot) return;
+
+      set((state) => {
+        // Restore expressions and z-order from snapshot
+        state.expressions = snapshot.expressions;
+        state.expressionOrder = snapshot.expressionOrder;
+        state.canUndo = historyManager.canUndo();
+        state.canRedo = historyManager.canRedo();
+      });
+    },
+
+    redo: () => {
+      const currentState = get();
+      const snapshot = historyManager.redo(captureSnapshot(currentState));
+      if (!snapshot) return;
+
+      set((state) => {
+        // Restore expressions and z-order from snapshot
+        state.expressions = snapshot.expressions;
+        state.expressionOrder = snapshot.expressionOrder;
+        state.canUndo = historyManager.canUndo();
+        state.canRedo = historyManager.canRedo();
+      });
+    },
+
+    clearHistory: () => {
+      historyManager.clear();
+      set((state) => {
+        state.canUndo = false;
+        state.canRedo = false;
+      });
+    },
+
+    // ── UI-only state (NO ProtocolOperations, NO snapshots) ──
 
     setSelectedIds: (ids: Set<string>) => {
       set((state) => {

--- a/packages/engine/src/types/index.ts
+++ b/packages/engine/src/types/index.ts
@@ -54,4 +54,14 @@ export interface CanvasActions {
   setActiveTool: (tool: ToolType) => void;
   /** Set the camera viewport state. */
   setCamera: (camera: Camera) => void;
+  /** Undo the last content mutation, restoring previous canvas state. */
+  undo: () => void;
+  /** Redo the last undone action, restoring next canvas state. */
+  redo: () => void;
+  /** Whether there are actions to undo. */
+  canUndo: boolean;
+  /** Whether there are actions to redo. */
+  canRedo: boolean;
+  /** Reset undo/redo history stacks. */
+  clearHistory: () => void;
 }


### PR DESCRIPTION
Snapshot-based undo/redo with HistoryManager class, Zustand store integration, and Ctrl+Z/Ctrl+Shift+Z keyboard shortcuts. Max 100 snapshots, canUndo/canRedo booleans. 67 new tests, 328 total passing. Closes #8