### PR TITLE
feat(engine): LocalStorage persistence — Issue #9

### DIFF
--- a/packages/engine/src/__tests__/localStorage.test.ts
+++ b/packages/engine/src/__tests__/localStorage.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Unit tests for localStorage persistence module.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Each test maps to an acceptance criterion from Issue #9.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ExpressionBuilder } from '@infinicanvas/protocol';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import {
+  saveCanvasState,
+  loadCanvasState,
+  STORAGE_KEY,
+} from '../persistence/localStorage.js';
+import type { PersistedCanvasState } from '../persistence/localStorage.js';
+import type { Camera } from '../types/index.js';
+
+// ── Test fixtures ──────────────────────────────────────────
+
+const testAuthor = { type: 'human' as const, id: 'user-1', name: 'Test User' };
+const builder = new ExpressionBuilder(testAuthor);
+
+function makeRectangle(id: string): VisualExpression {
+  return { ...builder.rectangle(100, 200, 300, 150).label('Rect').build(), id };
+}
+
+function makeTestState(): PersistedCanvasState {
+  const expr = makeRectangle('rect-1');
+  return {
+    expressions: { 'rect-1': expr },
+    expressionOrder: ['rect-1'],
+    camera: { x: 10, y: 20, zoom: 1.5 },
+  };
+}
+
+// ── Mock localStorage ──────────────────────────────────────
+
+let storage: Record<string, string>;
+
+function createMockStorage(): Storage {
+  return {
+    getItem: vi.fn((key: string) => storage[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      storage[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete storage[key];
+    }),
+    clear: vi.fn(() => {
+      storage = {};
+    }),
+    get length() {
+      return Object.keys(storage).length;
+    },
+    key: vi.fn((index: number) => Object.keys(storage)[index] ?? null),
+  };
+}
+
+beforeEach(() => {
+  storage = {};
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: createMockStorage(),
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── AC8: Storage key ───────────────────────────────────────
+
+describe('STORAGE_KEY', () => {
+  it('[AC8] uses the key "infinicanvas:state"', () => {
+    expect(STORAGE_KEY).toBe('infinicanvas:state');
+  });
+});
+
+// ── AC10: Serialize / deserialize roundtrip ────────────────
+
+describe('saveCanvasState + loadCanvasState roundtrip', () => {
+  it('[AC10] serializes and deserializes state correctly', () => {
+    const state = makeTestState();
+
+    saveCanvasState(state);
+    const loaded = loadCanvasState();
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.expressionOrder).toEqual(['rect-1']);
+    expect(loaded!.expressions['rect-1']!.id).toBe('rect-1');
+    expect(loaded!.expressions['rect-1']!.kind).toBe('rectangle');
+  });
+
+  it('[AC4] preserves camera state through roundtrip', () => {
+    const state = makeTestState();
+
+    saveCanvasState(state);
+    const loaded = loadCanvasState();
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.camera).toEqual({ x: 10, y: 20, zoom: 1.5 });
+  });
+
+  it('preserves expression data through roundtrip', () => {
+    const state = makeTestState();
+
+    saveCanvasState(state);
+    const loaded = loadCanvasState();
+
+    const original = state.expressions['rect-1']!;
+    const restored = loaded!.expressions['rect-1']!;
+    expect(restored.position).toEqual(original.position);
+    expect(restored.size).toEqual(original.size);
+    expect(restored.style).toEqual(original.style);
+  });
+
+  it('handles multiple expressions', () => {
+    const rect1 = makeRectangle('rect-1');
+    const rect2 = makeRectangle('rect-2');
+    const state: PersistedCanvasState = {
+      expressions: { 'rect-1': rect1, 'rect-2': rect2 },
+      expressionOrder: ['rect-1', 'rect-2'],
+      camera: { x: 0, y: 0, zoom: 1 },
+    };
+
+    saveCanvasState(state);
+    const loaded = loadCanvasState();
+
+    expect(loaded).not.toBeNull();
+    expect(Object.keys(loaded!.expressions)).toHaveLength(2);
+    expect(loaded!.expressionOrder).toEqual(['rect-1', 'rect-2']);
+  });
+
+  it('handles empty state', () => {
+    const state: PersistedCanvasState = {
+      expressions: {},
+      expressionOrder: [],
+      camera: { x: 0, y: 0, zoom: 1 },
+    };
+
+    saveCanvasState(state);
+    const loaded = loadCanvasState();
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.expressions).toEqual({});
+    expect(loaded!.expressionOrder).toEqual([]);
+    expect(loaded!.camera).toEqual({ x: 0, y: 0, zoom: 1 });
+  });
+});
+
+// ── AC9: Undo/redo NOT persisted ───────────────────────────
+
+describe('AC9: excludes transient state', () => {
+  it('[AC9] does NOT persist undo/redo history, selection, or operationLog', () => {
+    const state = makeTestState();
+    saveCanvasState(state);
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+
+    const parsed = JSON.parse(raw!) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty('selectedIds');
+    expect(parsed).not.toHaveProperty('activeTool');
+    expect(parsed).not.toHaveProperty('operationLog');
+    expect(parsed).not.toHaveProperty('canUndo');
+    expect(parsed).not.toHaveProperty('canRedo');
+  });
+});
+
+// ── AC8: Storage key used correctly ────────────────────────
+
+describe('saveCanvasState', () => {
+  it('[AC8] writes to the correct storage key', () => {
+    const state = makeTestState();
+    saveCanvasState(state);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'infinicanvas:state',
+      expect.any(String),
+    );
+  });
+});
+
+// ── AC3 + AC10: Missing key → null ─────────────────────────
+
+describe('loadCanvasState — missing key', () => {
+  it('[AC3] returns null when no saved state exists', () => {
+    const result = loadCanvasState();
+    expect(result).toBeNull();
+  });
+
+  it('[AC3] returns null when storage contains empty string', () => {
+    storage[STORAGE_KEY] = '';
+    const result = loadCanvasState();
+    expect(result).toBeNull();
+  });
+});
+
+// ── AC5: Corrupt data → warn + null ────────────────────────
+
+describe('loadCanvasState — corrupt data', () => {
+  it('[AC5] returns null for invalid JSON and logs warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    storage[STORAGE_KEY] = '{not valid json!!!';
+
+    const result = loadCanvasState();
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[persistence]'),
+      expect.anything(),
+    );
+  });
+
+  it('[AC5] returns null when parsed data is not an object', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    storage[STORAGE_KEY] = '"just a string"';
+
+    const result = loadCanvasState();
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('[AC5] returns null when expressions field is missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    storage[STORAGE_KEY] = JSON.stringify({ camera: { x: 0, y: 0, zoom: 1 } });
+
+    const result = loadCanvasState();
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('[AC5] returns null when expressionOrder is missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    storage[STORAGE_KEY] = JSON.stringify({
+      expressions: {},
+      camera: { x: 0, y: 0, zoom: 1 },
+    });
+
+    const result = loadCanvasState();
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('[AC5] returns null when camera is missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    storage[STORAGE_KEY] = JSON.stringify({
+      expressions: {},
+      expressionOrder: [],
+    });
+
+    const result = loadCanvasState();
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('[AC5] returns null when camera has invalid zoom', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    storage[STORAGE_KEY] = JSON.stringify({
+      expressions: {},
+      expressionOrder: [],
+      camera: { x: 0, y: 0, zoom: 'invalid' },
+    });
+
+    const result = loadCanvasState();
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+// ── AC6: Quota exceeded → error, continue ──────────────────
+
+describe('saveCanvasState — quota exceeded', () => {
+  it('[AC6] logs error and does not throw when quota is exceeded', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const quotaError = new DOMException('quota exceeded', 'QuotaExceededError');
+    vi.mocked(localStorage.setItem).mockImplementation(() => {
+      throw quotaError;
+    });
+
+    expect(() => saveCanvasState(makeTestState())).not.toThrow();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[persistence]'),
+      expect.anything(),
+    );
+  });
+});
+
+// ── AC7: localStorage unavailable → catch, continue ────────
+
+describe('saveCanvasState — localStorage unavailable', () => {
+  it('[AC7] does not throw when localStorage is unavailable on save', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      get() {
+        throw new Error('localStorage is disabled');
+      },
+      configurable: true,
+    });
+
+    expect(() => saveCanvasState(makeTestState())).not.toThrow();
+  });
+});
+
+describe('loadCanvasState — localStorage unavailable', () => {
+  it('[AC7] returns null when localStorage is unavailable on load', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      get() {
+        throw new Error('localStorage is disabled');
+      },
+      configurable: true,
+    });
+
+    const result = loadCanvasState();
+    expect(result).toBeNull();
+  });
+});

--- a/packages/engine/src/__tests__/useAutoSave.test.ts
+++ b/packages/engine/src/__tests__/useAutoSave.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the useAutoSave hook.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Tests auto-save behavior: debouncing, selective persistence, and error handling.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ExpressionBuilder } from '@infinicanvas/protocol';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import { useCanvasStore } from '../store/canvasStore.js';
+import { STORAGE_KEY } from '../persistence/localStorage.js';
+import { subscribeAutoSave, DEBOUNCE_MS } from '../hooks/useAutoSave.js';
+
+// ── Test fixtures ──────────────────────────────────────────
+
+const testAuthor = { type: 'human' as const, id: 'user-1', name: 'Test User' };
+const builder = new ExpressionBuilder(testAuthor);
+
+function makeRectangle(id: string): VisualExpression {
+  return { ...builder.rectangle(100, 200, 300, 150).label('Rect').build(), id };
+}
+
+// ── Mock localStorage ──────────────────────────────────────
+
+let storage: Record<string, string>;
+
+function createMockStorage(): Storage {
+  return {
+    getItem: vi.fn((key: string) => storage[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      storage[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete storage[key];
+    }),
+    clear: vi.fn(() => {
+      storage = {};
+    }),
+    get length() {
+      return Object.keys(storage).length;
+    },
+    key: vi.fn((index: number) => Object.keys(storage)[index] ?? null),
+  };
+}
+
+// ── Setup & teardown ───────────────────────────────────────
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  storage = {};
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: createMockStorage(),
+    writable: true,
+    configurable: true,
+  });
+  useCanvasStore.setState({
+    expressions: {},
+    expressionOrder: [],
+    selectedIds: new Set<string>(),
+    activeTool: 'select',
+    camera: { x: 0, y: 0, zoom: 1 },
+    operationLog: [],
+    canUndo: false,
+    canRedo: false,
+  });
+  useCanvasStore.getState().clearHistory();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ── AC1: Auto-save after 2s of inactivity ──────────────────
+
+describe('subscribeAutoSave — debounced persistence', () => {
+  it('[AC1] exports DEBOUNCE_MS as 2000', () => {
+    expect(DEBOUNCE_MS).toBe(2000);
+  });
+
+  it('[AC1] saves to localStorage after debounce delay', () => {
+    const unsubscribe = subscribeAutoSave();
+
+    useCanvasStore.getState().addExpression(makeRectangle('rect-1'));
+
+    // Before debounce fires, nothing saved
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+
+    // After debounce fires
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY,
+      expect.any(String),
+    );
+
+    unsubscribe();
+  });
+
+  it('[AC1] debounces multiple rapid changes into a single save', () => {
+    const unsubscribe = subscribeAutoSave();
+
+    // Make 3 rapid changes
+    useCanvasStore.getState().addExpression(makeRectangle('rect-1'));
+    vi.advanceTimersByTime(500);
+    useCanvasStore.getState().addExpression(makeRectangle('rect-2'));
+    vi.advanceTimersByTime(500);
+    useCanvasStore.getState().addExpression(makeRectangle('rect-3'));
+
+    // Wait for the full debounce period from last change
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    // Should save only once with all 3 expressions
+    const setCalls = vi.mocked(localStorage.setItem).mock.calls.filter(
+      ([key]) => key === STORAGE_KEY,
+    );
+    expect(setCalls).toHaveLength(1);
+
+    const saved = JSON.parse(setCalls[0]![1]!) as Record<string, unknown>;
+    const expressions = saved.expressions as Record<string, unknown>;
+    expect(Object.keys(expressions)).toHaveLength(3);
+
+    unsubscribe();
+  });
+
+  it('does not save before debounce period elapses', () => {
+    const unsubscribe = subscribeAutoSave();
+
+    useCanvasStore.getState().addExpression(makeRectangle('rect-1'));
+    vi.advanceTimersByTime(DEBOUNCE_MS - 1);
+
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it('[AC4] saves camera changes', () => {
+    const unsubscribe = subscribeAutoSave();
+
+    useCanvasStore.getState().setCamera({ x: 100, y: 200, zoom: 2 });
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY,
+      expect.any(String),
+    );
+
+    const saved = JSON.parse(
+      vi.mocked(localStorage.setItem).mock.calls[0]![1]!,
+    ) as Record<string, unknown>;
+    expect(saved.camera).toEqual({ x: 100, y: 200, zoom: 2 });
+
+    unsubscribe();
+  });
+});
+
+// ── AC9: Selective persistence ─────────────────────────────
+
+describe('subscribeAutoSave — excludes transient state', () => {
+  it('[AC9] does NOT persist selection, activeTool, operationLog, or undo state', () => {
+    const unsubscribe = subscribeAutoSave();
+
+    useCanvasStore.getState().addExpression(makeRectangle('rect-1'));
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+    useCanvasStore.getState().setActiveTool('rectangle');
+
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    const raw = vi.mocked(localStorage.setItem).mock.calls.find(
+      ([key]) => key === STORAGE_KEY,
+    );
+    expect(raw).toBeDefined();
+
+    const saved = JSON.parse(raw![1]!) as Record<string, unknown>;
+    expect(saved).not.toHaveProperty('selectedIds');
+    expect(saved).not.toHaveProperty('activeTool');
+    expect(saved).not.toHaveProperty('operationLog');
+    expect(saved).not.toHaveProperty('canUndo');
+    expect(saved).not.toHaveProperty('canRedo');
+
+    unsubscribe();
+  });
+});
+
+// ── Unsubscribe ────────────────────────────────────────────
+
+describe('subscribeAutoSave — cleanup', () => {
+  it('stops saving after unsubscribe', () => {
+    const unsubscribe = subscribeAutoSave();
+    unsubscribe();
+
+    useCanvasStore.getState().addExpression(makeRectangle('rect-1'));
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('clears pending debounce timer on unsubscribe', () => {
+    const unsubscribe = subscribeAutoSave();
+
+    useCanvasStore.getState().addExpression(makeRectangle('rect-1'));
+    vi.advanceTimersByTime(500); // Partial debounce
+
+    unsubscribe();
+
+    vi.advanceTimersByTime(DEBOUNCE_MS); // Full debounce after unsub
+
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+  });
+});
+
+// ── Error handling ─────────────────────────────────────────
+
+describe('subscribeAutoSave — error handling', () => {
+  it('continues operating after a save error', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const unsubscribe = subscribeAutoSave();
+
+    // First save fails
+    vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+      throw new DOMException('quota exceeded', 'QuotaExceededError');
+    });
+
+    useCanvasStore.getState().addExpression(makeRectangle('rect-1'));
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(errorSpy).toHaveBeenCalled();
+
+    // Restore normal behavior — next save should succeed
+    vi.mocked(localStorage.setItem).mockImplementation((key: string, value: string) => {
+      storage[key] = value;
+    });
+
+    useCanvasStore.getState().addExpression(makeRectangle('rect-2'));
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(storage[STORAGE_KEY]).toBeDefined();
+
+    unsubscribe();
+  });
+});

--- a/packages/engine/src/hooks/useAutoSave.ts
+++ b/packages/engine/src/hooks/useAutoSave.ts
@@ -1,0 +1,87 @@
+/**
+ * Auto-save hook — subscribes to Zustand store changes and
+ * debounces saves to localStorage.
+ *
+ * Subscribes to expressions, expressionOrder, and camera.
+ * Debounces saves by 2000ms after the last change. [AC1]
+ * Does NOT persist undo/redo history, selection, or operationLog. [AC9]
+ *
+ * @module
+ */
+
+import { useCanvasStore } from '../store/canvasStore.js';
+import { saveCanvasState } from '../persistence/localStorage.js';
+import type { PersistedCanvasState } from '../persistence/localStorage.js';
+
+/** Debounce delay in milliseconds for auto-save. [AC1] */
+export const DEBOUNCE_MS = 2000;
+
+/**
+ * Subscribe to Zustand store changes and auto-save with debounce.
+ *
+ * Listens for changes to expressions, expressionOrder, and camera.
+ * Changes to selection, activeTool, operationLog, and undo state
+ * are ignored. [AC9]
+ *
+ * Returns an unsubscribe function that stops the subscription
+ * and clears any pending debounce timer.
+ *
+ * This is a vanilla (non-React) subscriber so it can be used
+ * outside of React components (e.g., store initialization). [SOLID: SRP]
+ *
+ * @returns Unsubscribe function to stop auto-save
+ */
+export function subscribeAutoSave(): () => void {
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+
+  /** Track previous values to detect actual changes. [CLEAN-CODE] */
+  let prevExpressions = useCanvasStore.getState().expressions;
+  let prevOrder = useCanvasStore.getState().expressionOrder;
+  let prevCamera = useCanvasStore.getState().camera;
+
+  /** Select only the persistable fields from the store. [AC9] */
+  function selectPersistedState(): PersistedCanvasState {
+    const state = useCanvasStore.getState();
+    return {
+      expressions: state.expressions,
+      expressionOrder: state.expressionOrder,
+      camera: state.camera,
+    };
+  }
+
+  /** Debounced save — resets timer on each call. [AC1] */
+  function debouncedSave(): void {
+    if (timerId !== null) {
+      clearTimeout(timerId);
+    }
+    timerId = setTimeout(() => {
+      timerId = null;
+      saveCanvasState(selectPersistedState());
+    }, DEBOUNCE_MS);
+  }
+
+  // Zustand v5 subscribe(listener) — fires on every state change.
+  // We manually check if the persisted fields actually changed.
+  const unsubscribe = useCanvasStore.subscribe((state) => {
+    const changed =
+      state.expressions !== prevExpressions ||
+      state.expressionOrder !== prevOrder ||
+      state.camera !== prevCamera;
+
+    if (changed) {
+      prevExpressions = state.expressions;
+      prevOrder = state.expressionOrder;
+      prevCamera = state.camera;
+      debouncedSave();
+    }
+  });
+
+  return () => {
+    // Clear pending debounce timer [CLEAN-CODE]
+    if (timerId !== null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+    unsubscribe();
+  };
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -63,12 +63,17 @@ export {
 } from './interaction/selectionManager.js';
 export type { Marquee } from './interaction/selectionManager.js';
 
+// ── Persistence ────────────────────────────────────────────
+export { saveCanvasState, loadCanvasState, STORAGE_KEY } from './persistence/localStorage.js';
+export type { PersistedCanvasState } from './persistence/localStorage.js';
+
 // ── Hooks ──────────────────────────────────────────────────
 export { useCanvasInteraction } from './hooks/useCanvasInteraction.js';
 export type { CanvasInteraction } from './hooks/useCanvasInteraction.js';
 export { useUndoRedoShortcuts } from './hooks/useUndoRedoShortcuts.js';
 export { useSelectionInteraction } from './hooks/useSelectionInteraction.js';
 export type { SelectionInteraction, MarqueeRect } from './hooks/useSelectionInteraction.js';
+export { subscribeAutoSave, DEBOUNCE_MS } from './hooks/useAutoSave.js';
 export { createGatewayConnection } from './hooks/useGatewayConnection.js';
 export type {
   GatewayConnectionOptions,

--- a/packages/engine/src/persistence/localStorage.ts
+++ b/packages/engine/src/persistence/localStorage.ts
@@ -1,0 +1,149 @@
+/**
+ * LocalStorage persistence for canvas state.
+ *
+ * Serializes/deserializes the minimal canvas state (expressions, order,
+ * camera) to localStorage. Transient state (selection, undo history,
+ * operationLog) is intentionally excluded. [YAGNI] [AC9]
+ *
+ * Error handling strategy:
+ * - Corrupt JSON → console.warn, return null [AC5]
+ * - Quota exceeded → console.error, continue [AC6]
+ * - localStorage unavailable → catch, continue [AC7]
+ *
+ * @module
+ */
+
+import type { VisualExpression } from '@infinicanvas/protocol';
+import type { Camera } from '../types/index.js';
+
+/** The localStorage key used for persisted canvas state. [AC8] */
+export const STORAGE_KEY = 'infinicanvas:state';
+
+/** Shape of the persisted state — only the fields worth saving. [AC9] */
+export interface PersistedCanvasState {
+  expressions: Record<string, VisualExpression>;
+  expressionOrder: string[];
+  camera: Camera;
+}
+
+/**
+ * Serialize and save canvas state to localStorage.
+ *
+ * Only persists expressions, expressionOrder, and camera.
+ * Undo/redo history, selection, and operationLog are excluded. [AC9]
+ *
+ * @param state - The canvas state subset to persist
+ */
+export function saveCanvasState(state: PersistedCanvasState): void {
+  try {
+    const json = JSON.stringify({
+      expressions: state.expressions,
+      expressionOrder: state.expressionOrder,
+      camera: state.camera,
+    });
+    localStorage.setItem(STORAGE_KEY, json);
+  } catch (error: unknown) {
+    if (isDOMException(error, 'QuotaExceededError')) {
+      console.error('[persistence] Storage quota exceeded — state not saved.', error);
+    } else {
+      console.error('[persistence] Failed to save canvas state.', error);
+    }
+  }
+}
+
+/**
+ * Load and validate canvas state from localStorage.
+ *
+ * Returns null (and logs a warning) if:
+ * - No saved state exists [AC3]
+ * - Data is corrupt JSON [AC5]
+ * - Data fails structural validation [AC5]
+ * - localStorage is unavailable [AC7]
+ *
+ * @returns The persisted state, or null if unavailable/invalid
+ */
+export function loadCanvasState(): PersistedCanvasState | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null || raw === '') {
+      return null;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (parseError: unknown) {
+      console.warn('[persistence] Corrupt JSON in saved state — starting fresh.', parseError);
+      return null;
+    }
+
+    if (!isValidPersistedState(parsed)) {
+      console.warn(
+        '[persistence] Invalid saved state structure — starting fresh.',
+        parsed,
+      );
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    // localStorage unavailable [AC7]
+    return null;
+  }
+}
+
+/**
+ * Structural validation for persisted state. [CLEAN-CODE]
+ *
+ * Checks that the parsed data has the required shape:
+ * - expressions: object (Record)
+ * - expressionOrder: array of strings
+ * - camera: { x: number, y: number, zoom: number }
+ */
+function isValidPersistedState(data: unknown): data is PersistedCanvasState {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return false;
+  }
+
+  const record = data as Record<string, unknown>;
+
+  if (
+    typeof record.expressions !== 'object' ||
+    record.expressions === null ||
+    Array.isArray(record.expressions)
+  ) {
+    return false;
+  }
+
+  if (!Array.isArray(record.expressionOrder)) {
+    return false;
+  }
+
+  if (!isValidCamera(record.camera)) {
+    return false;
+  }
+
+  return true;
+}
+
+/** Validate camera shape: { x: number, y: number, zoom: number }. */
+function isValidCamera(camera: unknown): camera is Camera {
+  if (typeof camera !== 'object' || camera === null) {
+    return false;
+  }
+
+  const cam = camera as Record<string, unknown>;
+  return (
+    typeof cam.x === 'number' &&
+    typeof cam.y === 'number' &&
+    typeof cam.zoom === 'number' &&
+    Number.isFinite(cam.x) &&
+    Number.isFinite(cam.y) &&
+    Number.isFinite(cam.zoom)
+  );
+}
+
+/** Type guard for DOMException with a specific name. */
+function isDOMException(error: unknown, name: string): boolean {
+  return error instanceof DOMException && error.name === name;
+}


### PR DESCRIPTION
Debounced auto-save (2s), load on startup, camera persistence, corrupt/quota/unavailable error handling. 28 new tests, 471 total. Closes #9