### PR TITLE
feat(mcp-server): Canvas MCP tools for AI agents — Issue #31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -998,6 +998,18 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@infinicanvas/agents": {
       "resolved": "packages/agents",
       "link": true
@@ -1012,6 +1024,10 @@
     },
     "node_modules/@infinicanvas/gateway": {
       "resolved": "packages/gateway",
+      "link": true
+    },
+    "node_modules/@infinicanvas/mcp-server": {
+      "resolved": "packages/mcp-server",
       "link": true
     },
     "node_modules/@infinicanvas/protocol": {
@@ -1066,6 +1082,46 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1763,6 +1819,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1771,6 +1840,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -1841,6 +1943,30 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -1875,6 +2001,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1883,6 +2018,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1933,12 +2097,83 @@
         "node": ">= 16"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -2012,7 +2247,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2043,6 +2277,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2061,12 +2304,41 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2081,12 +2353,42 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -2140,6 +2442,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2148,6 +2456,36 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -2159,6 +2497,89 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2178,6 +2599,45 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2193,6 +2653,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2201,6 +2670,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2216,11 +2722,56 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -2233,6 +2784,26 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -2263,6 +2834,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -2283,12 +2870,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -2350,6 +2982,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -2420,12 +3064,67 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -2441,7 +3140,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2462,12 +3160,63 @@
         "node": "^18 || >=20"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -2482,11 +3231,39 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
       "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
       "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2529,6 +3306,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/points-on-curve": {
@@ -2611,6 +3397,19 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2619,6 +3418,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -2682,7 +3520,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2755,6 +3592,28 @@
         "points-on-path": "^0.2.1"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -2787,6 +3646,150 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2810,6 +3813,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -2932,6 +3944,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -2978,6 +3999,20 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3009,6 +4044,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3038,6 +4082,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -3259,6 +4312,21 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3275,6 +4343,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",
@@ -3328,6 +4402,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zustand": {
@@ -3976,6 +5059,25 @@
         "@infinicanvas/protocol": "*",
         "nanoid": "^5.0.9",
         "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/ws": "^8.5.14",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "packages/mcp-server": {
+      "name": "@infinicanvas/mcp-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@infinicanvas/protocol": "*",
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "nanoid": "^5.0.9",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "infinicanvas-mcp": "dist/server.js"
       },
       "devDependencies": {
         "@types/ws": "^8.5.14",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@infinicanvas/mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "MCP server — canvas tools for AI agents via Model Context Protocol",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "bin": {
+    "infinicanvas-mcp": "./dist/server.js"
+  },
+  "scripts": {
+    "start": "tsx src/server.ts",
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@infinicanvas/protocol": "*",
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "nanoid": "^5.0.9",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.5.14",
+    "typescript": "^5.7.0",
+    "tsx": "^4.19.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/mcp-server/src/__tests__/compositeTools.test.ts
+++ b/packages/mcp-server/src/__tests__/compositeTools.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Tests for composite expression tools.
+ *
+ * Verifies that each composite tool builds correct VisualExpression
+ * objects with proper data payloads and sizing.
+ *
+ * @module
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VisualExpression, FlowchartData, SequenceDiagramData, MindMapData, ReasoningChainData, WireframeData, RoadmapData, KanbanData } from '@infinicanvas/protocol';
+import type { IGatewayClient } from '../gatewayClient.js';
+import {
+  buildFlowchart,
+  buildSequenceDiagram,
+  buildMindMap,
+  buildReasoningChain,
+  buildWireframe,
+  buildRoadmap,
+  buildKanban,
+  executeDrawFlowchart,
+  executeDrawSequenceDiagram,
+  executeDrawMindMap,
+  executeDrawReasoningChain,
+  executeDrawWireframe,
+  executeDrawRoadmap,
+  executeDrawKanban,
+} from '../tools/compositeTools.js';
+
+// ── Mock gateway client ────────────────────────────────────
+
+function createMockClient(): IGatewayClient {
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    getSessionId: vi.fn().mockReturnValue('test-session'),
+    sendCreate: vi.fn().mockResolvedValue(undefined),
+    sendDelete: vi.fn().mockResolvedValue(undefined),
+    sendMorph: vi.fn().mockResolvedValue(undefined),
+    sendStyle: vi.fn().mockResolvedValue(undefined),
+    getState: vi.fn().mockReturnValue([]),
+  };
+}
+
+// ── Flowchart ──────────────────────────────────────────────
+
+describe('buildFlowchart', () => {
+  it('creates a flowchart with nodes and edges', () => {
+    const expr = buildFlowchart({
+      title: 'Auth Flow',
+      nodes: [
+        { id: 'start', label: 'Start' },
+        { id: 'login', label: 'Login' },
+        { id: 'end', label: 'End' },
+      ],
+      edges: [
+        { from: 'start', to: 'login' },
+        { from: 'login', to: 'end', label: 'success' },
+      ],
+    });
+
+    expect(expr.kind).toBe('flowchart');
+    const data = expr.data as FlowchartData;
+    expect(data.title).toBe('Auth Flow');
+    expect(data.nodes).toHaveLength(3);
+    expect(data.edges).toHaveLength(2);
+    expect(data.direction).toBe('TB');
+  });
+
+  it('applies default rect shape to nodes without shape', () => {
+    const expr = buildFlowchart({
+      title: 'Test',
+      nodes: [{ id: 'n1', label: 'Node' }],
+      edges: [],
+    });
+
+    const data = expr.data as FlowchartData;
+    expect(data.nodes[0]!.shape).toBe('rect');
+  });
+
+  it('preserves custom node shapes', () => {
+    const expr = buildFlowchart({
+      title: 'Test',
+      nodes: [
+        { id: 'n1', label: 'Decision', shape: 'diamond' },
+        { id: 'n2', label: 'Start', shape: 'ellipse' },
+      ],
+      edges: [],
+    });
+
+    const data = expr.data as FlowchartData;
+    expect(data.nodes[0]!.shape).toBe('diamond');
+    expect(data.nodes[1]!.shape).toBe('ellipse');
+  });
+
+  it('uses custom direction', () => {
+    const expr = buildFlowchart({
+      title: 'LR Flow',
+      nodes: [{ id: 'n1', label: 'A' }],
+      edges: [],
+      direction: 'LR',
+    });
+
+    const data = expr.data as FlowchartData;
+    expect(data.direction).toBe('LR');
+  });
+
+  it('positions at custom coordinates', () => {
+    const expr = buildFlowchart({
+      title: 'Test',
+      nodes: [{ id: 'n1', label: 'A' }],
+      edges: [],
+      x: 500,
+      y: 300,
+    });
+
+    expect(expr.position).toEqual({ x: 500, y: 300 });
+  });
+
+  it('throws error when no nodes provided', () => {
+    expect(() => buildFlowchart({
+      title: 'Empty',
+      nodes: [],
+      edges: [],
+    })).toThrow('Flowchart requires at least one node');
+  });
+
+  it('calculates size based on node count', () => {
+    const small = buildFlowchart({
+      title: 'Small',
+      nodes: [{ id: 'n1', label: 'A' }],
+      edges: [],
+    });
+    const large = buildFlowchart({
+      title: 'Large',
+      nodes: Array.from({ length: 9 }, (_, i) => ({ id: `n${i}`, label: `Node ${i}` })),
+      edges: [],
+    });
+
+    expect(large.size.width).toBeGreaterThan(small.size.width);
+    expect(large.size.height).toBeGreaterThan(small.size.height);
+  });
+});
+
+describe('executeDrawFlowchart', () => {
+  it('sends create and returns confirmation message', async () => {
+    const client = createMockClient();
+    const result = await executeDrawFlowchart(client, {
+      title: 'Test Flow',
+      nodes: [
+        { id: 'a', label: 'A' },
+        { id: 'b', label: 'B' },
+      ],
+      edges: [{ from: 'a', to: 'b' }],
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain("'Test Flow'");
+    expect(result).toContain('2 nodes');
+    expect(result).toContain('1 edges');
+  });
+});
+
+// ── Sequence Diagram ───────────────────────────────────────
+
+describe('buildSequenceDiagram', () => {
+  it('creates a sequence diagram with participants and messages', () => {
+    const expr = buildSequenceDiagram({
+      title: 'Login Sequence',
+      participants: [
+        { id: 'client', name: 'Client' },
+        { id: 'server', name: 'Server' },
+      ],
+      messages: [
+        { from: 'client', to: 'server', label: 'POST /login' },
+        { from: 'server', to: 'client', label: '200 OK', type: 'reply' },
+      ],
+    });
+
+    expect(expr.kind).toBe('sequence-diagram');
+    const data = expr.data as SequenceDiagramData;
+    expect(data.title).toBe('Login Sequence');
+    expect(data.participants).toHaveLength(2);
+    expect(data.messages).toHaveLength(2);
+  });
+
+  it('defaults message type to sync', () => {
+    const expr = buildSequenceDiagram({
+      title: 'Test',
+      participants: [{ id: 'a', name: 'A' }],
+      messages: [{ from: 'a', to: 'a', label: 'self-call' }],
+    });
+
+    const data = expr.data as SequenceDiagramData;
+    expect(data.messages[0]!.type).toBe('sync');
+  });
+
+  it('throws when no participants provided', () => {
+    expect(() => buildSequenceDiagram({
+      title: 'Empty',
+      participants: [],
+      messages: [],
+    })).toThrow('Sequence diagram requires at least one participant');
+  });
+
+  it('sizes based on participant and message count', () => {
+    const expr = buildSequenceDiagram({
+      title: 'Test',
+      participants: [
+        { id: 'a', name: 'A' },
+        { id: 'b', name: 'B' },
+        { id: 'c', name: 'C' },
+      ],
+      messages: [
+        { from: 'a', to: 'b', label: 'm1' },
+        { from: 'b', to: 'c', label: 'm2' },
+      ],
+    });
+
+    // Width grows with participants, height with messages
+    expect(expr.size.width).toBeGreaterThan(400);
+    expect(expr.size.height).toBeGreaterThan(200);
+  });
+});
+
+describe('executeDrawSequenceDiagram', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeDrawSequenceDiagram(client, {
+      title: 'Auth',
+      participants: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }],
+      messages: [{ from: 'a', to: 'b', label: 'request' }],
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain("'Auth'");
+    expect(result).toContain('2 participants');
+    expect(result).toContain('1 messages');
+  });
+});
+
+// ── Mind Map ───────────────────────────────────────────────
+
+describe('buildMindMap', () => {
+  it('creates a mind map with branches', () => {
+    const expr = buildMindMap({
+      centralTopic: 'AI',
+      branches: [
+        { id: 'ml', label: 'Machine Learning', children: [] },
+        {
+          id: 'dl', label: 'Deep Learning', children: [
+            { id: 'cnn', label: 'CNN', children: [] },
+            { id: 'rnn', label: 'RNN', children: [] },
+          ],
+        },
+      ],
+    });
+
+    expect(expr.kind).toBe('mind-map');
+    const data = expr.data as MindMapData;
+    expect(data.centralTopic).toBe('AI');
+    expect(data.branches).toHaveLength(2);
+    expect(data.branches[1]!.children).toHaveLength(2);
+  });
+
+  it('throws when no branches provided', () => {
+    expect(() => buildMindMap({
+      centralTopic: 'Empty',
+      branches: [],
+    })).toThrow('Mind map requires at least one branch');
+  });
+});
+
+describe('executeDrawMindMap', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeDrawMindMap(client, {
+      centralTopic: 'Testing',
+      branches: [{ id: 'b1', label: 'Unit', children: [] }],
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain("'Testing'");
+    expect(result).toContain('1 branches');
+  });
+});
+
+// ── Reasoning Chain ────────────────────────────────────────
+
+describe('buildReasoningChain', () => {
+  it('creates a reasoning chain with steps and answer', () => {
+    const expr = buildReasoningChain({
+      question: 'Why use TypeScript?',
+      steps: [
+        { title: 'Type Safety', content: 'Catches bugs at compile time' },
+        { title: 'IDE Support', content: 'Better autocomplete and refactoring' },
+      ],
+      finalAnswer: 'TypeScript improves code quality and developer productivity.',
+    });
+
+    expect(expr.kind).toBe('reasoning-chain');
+    const data = expr.data as ReasoningChainData;
+    expect(data.question).toBe('Why use TypeScript?');
+    expect(data.steps).toHaveLength(2);
+    expect(data.finalAnswer).toContain('TypeScript');
+  });
+
+  it('throws when no steps provided', () => {
+    expect(() => buildReasoningChain({
+      question: 'Empty?',
+      steps: [],
+      finalAnswer: 'No answer',
+    })).toThrow('Reasoning chain requires at least one step');
+  });
+
+  it('sizes vertically based on step count', () => {
+    const short = buildReasoningChain({
+      question: 'Q?',
+      steps: [{ title: 'S1', content: 'C1' }],
+      finalAnswer: 'A',
+    });
+    const long = buildReasoningChain({
+      question: 'Q?',
+      steps: Array.from({ length: 5 }, (_, i) => ({
+        title: `Step ${i}`,
+        content: `Content ${i}`,
+      })),
+      finalAnswer: 'A',
+    });
+
+    expect(long.size.height).toBeGreaterThan(short.size.height);
+  });
+});
+
+describe('executeDrawReasoningChain', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeDrawReasoningChain(client, {
+      question: 'Why TDD?',
+      steps: [{ title: 'Red', content: 'Write failing test' }],
+      finalAnswer: 'TDD ensures correctness.',
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain("'Why TDD?'");
+    expect(result).toContain('1 steps');
+  });
+});
+
+// ── Wireframe ──────────────────────────────────────────────
+
+describe('buildWireframe', () => {
+  it('creates a wireframe with components', () => {
+    const expr = buildWireframe({
+      title: 'Login Page',
+      screenSize: { width: 375, height: 812 },
+      components: [
+        { type: 'input', label: 'Email', x: 20, y: 100, width: 335, height: 44 },
+        { type: 'input', label: 'Password', x: 20, y: 164, width: 335, height: 44 },
+        { type: 'button', label: 'Sign In', x: 20, y: 228, width: 335, height: 44 },
+      ],
+    });
+
+    expect(expr.kind).toBe('wireframe');
+    const data = expr.data as WireframeData;
+    expect(data.title).toBe('Login Page');
+    expect(data.screenSize).toEqual({ width: 375, height: 812 });
+    expect(data.components).toHaveLength(3);
+  });
+
+  it('sizes to screen dimensions', () => {
+    const expr = buildWireframe({
+      title: 'Test',
+      screenSize: { width: 1024, height: 768 },
+      components: [],
+    });
+
+    expect(expr.size).toEqual({ width: 1024, height: 768 });
+  });
+
+  it('auto-generates component IDs', () => {
+    const expr = buildWireframe({
+      title: 'Test',
+      screenSize: { width: 375, height: 812 },
+      components: [
+        { type: 'button', label: 'A', x: 0, y: 0, width: 100, height: 40 },
+        { type: 'button', label: 'B', x: 0, y: 50, width: 100, height: 40 },
+      ],
+    });
+
+    const data = expr.data as WireframeData;
+    expect(data.components[0]!.id).toBe('comp-0');
+    expect(data.components[1]!.id).toBe('comp-1');
+  });
+});
+
+describe('executeDrawWireframe', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeDrawWireframe(client, {
+      title: 'Dashboard',
+      screenSize: { width: 1024, height: 768 },
+      components: [
+        { type: 'nav', label: 'Top Nav', x: 0, y: 0, width: 1024, height: 60 },
+      ],
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain("'Dashboard'");
+    expect(result).toContain('1024×768');
+    expect(result).toContain('1 components');
+  });
+});
+
+// ── Roadmap ────────────────────────────────────────────────
+
+describe('buildRoadmap', () => {
+  it('creates a roadmap with phases and items', () => {
+    const expr = buildRoadmap({
+      title: 'Q1 Roadmap',
+      phases: [
+        {
+          id: 'p1', name: 'Phase 1', items: [
+            { id: 'i1', title: 'Design', status: 'done' },
+            { id: 'i2', title: 'Implement', status: 'in-progress' },
+          ],
+        },
+        {
+          id: 'p2', name: 'Phase 2', items: [
+            { id: 'i3', title: 'Test', status: 'planned' },
+          ],
+        },
+      ],
+    });
+
+    expect(expr.kind).toBe('roadmap');
+    const data = expr.data as RoadmapData;
+    expect(data.title).toBe('Q1 Roadmap');
+    expect(data.phases).toHaveLength(2);
+    expect(data.orientation).toBe('horizontal');
+  });
+
+  it('supports vertical orientation', () => {
+    const expr = buildRoadmap({
+      title: 'Test',
+      orientation: 'vertical',
+      phases: [{ id: 'p1', name: 'P1', items: [{ id: 'i1', title: 'I1', status: 'planned' }] }],
+    });
+
+    const data = expr.data as RoadmapData;
+    expect(data.orientation).toBe('vertical');
+  });
+
+  it('throws when no phases provided', () => {
+    expect(() => buildRoadmap({
+      title: 'Empty',
+      phases: [],
+    })).toThrow('Roadmap requires at least one phase');
+  });
+});
+
+describe('executeDrawRoadmap', () => {
+  it('sends create and returns confirmation with counts', async () => {
+    const client = createMockClient();
+    const result = await executeDrawRoadmap(client, {
+      title: 'MVP',
+      phases: [
+        {
+          id: 'p1', name: 'P1', items: [
+            { id: 'i1', title: 'A', status: 'planned' },
+            { id: 'i2', title: 'B', status: 'done' },
+          ],
+        },
+      ],
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain("'MVP'");
+    expect(result).toContain('1 phases');
+    expect(result).toContain('2 items');
+  });
+});
+
+// ── Kanban ─────────────────────────────────────────────────
+
+describe('buildKanban', () => {
+  it('creates a kanban board with columns and cards', () => {
+    const expr = buildKanban({
+      title: 'Sprint Board',
+      columns: [
+        {
+          id: 'todo', title: 'To Do', cards: [
+            { id: 'c1', title: 'Task 1', description: 'First task' },
+          ],
+        },
+        {
+          id: 'doing', title: 'In Progress', cards: [
+            { id: 'c2', title: 'Task 2' },
+          ],
+        },
+        { id: 'done', title: 'Done', cards: [] },
+      ],
+    });
+
+    expect(expr.kind).toBe('kanban');
+    const data = expr.data as KanbanData;
+    expect(data.title).toBe('Sprint Board');
+    expect(data.columns).toHaveLength(3);
+    expect(data.columns[0]!.cards).toHaveLength(1);
+    expect(data.columns[0]!.cards[0]!.description).toBe('First task');
+  });
+
+  it('throws when no columns provided', () => {
+    expect(() => buildKanban({
+      title: 'Empty',
+      columns: [],
+    })).toThrow('Kanban board requires at least one column');
+  });
+
+  it('sizes based on column and card count', () => {
+    const small = buildKanban({
+      title: 'Small',
+      columns: [{ id: 'c1', title: 'Col', cards: [{ id: 'c', title: 'Card' }] }],
+    });
+    const large = buildKanban({
+      title: 'Large',
+      columns: Array.from({ length: 5 }, (_, i) => ({
+        id: `col-${i}`,
+        title: `Column ${i}`,
+        cards: Array.from({ length: 3 }, (_, j) => ({
+          id: `card-${i}-${j}`,
+          title: `Card ${j}`,
+        })),
+      })),
+    });
+
+    expect(large.size.width).toBeGreaterThan(small.size.width);
+  });
+});
+
+describe('executeDrawKanban', () => {
+  it('sends create and returns confirmation with counts', async () => {
+    const client = createMockClient();
+    const result = await executeDrawKanban(client, {
+      title: 'Board',
+      columns: [
+        { id: 'c1', title: 'Todo', cards: [{ id: '1', title: 'A' }, { id: '2', title: 'B' }] },
+        { id: 'c2', title: 'Done', cards: [{ id: '3', title: 'C' }] },
+      ],
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain("'Board'");
+    expect(result).toContain('2 columns');
+    expect(result).toContain('3 cards');
+  });
+});
+
+// ── Cross-cutting concerns ─────────────────────────────────
+
+describe('composite tools cross-cutting', () => {
+  it('all expressions default to position (0,0) when not specified', () => {
+    const flowchart = buildFlowchart({ title: 'T', nodes: [{ id: 'n', label: 'N' }], edges: [] });
+    const kanban = buildKanban({ title: 'T', columns: [{ id: 'c', title: 'C', cards: [] }] });
+
+    expect(flowchart.position).toEqual({ x: 0, y: 0 });
+    expect(kanban.position).toEqual({ x: 0, y: 0 });
+  });
+
+  it('all expressions use custom positions when specified', () => {
+    const flowchart = buildFlowchart({ title: 'T', nodes: [{ id: 'n', label: 'N' }], edges: [], x: 100, y: 200 });
+
+    expect(flowchart.position).toEqual({ x: 100, y: 200 });
+  });
+
+  it('each expression has MCP author info', () => {
+    const expr = buildFlowchart({ title: 'T', nodes: [{ id: 'n', label: 'N' }], edges: [] });
+
+    expect(expr.meta.author).toEqual({
+      type: 'agent',
+      id: 'mcp-server',
+      name: 'InfiniCanvas MCP',
+      provider: 'mcp',
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/managementTools.test.ts
+++ b/packages/mcp-server/src/__tests__/managementTools.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for management tools and annotation tools.
+ *
+ * Verifies canvas state formatting, clear operations,
+ * morph functionality, and annotation creation.
+ *
+ * @module
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import type { IGatewayClient } from '../gatewayClient.js';
+import {
+  formatCanvasState,
+  executeGetState,
+  executeClear,
+  executeMorph,
+} from '../tools/managementTools.js';
+import {
+  buildAnnotation,
+  buildHighlight,
+  buildComment,
+  executeAnnotate,
+  executeHighlight,
+  executeAddComment,
+} from '../tools/annotationTools.js';
+import { DEFAULT_STYLE, MCP_AUTHOR } from '../defaults.js';
+
+// ── Test helpers ───────────────────────────────────────────
+
+function createExpression(overrides: Partial<VisualExpression> & { id: string; kind: VisualExpression['kind'] }): VisualExpression {
+  const now = Date.now();
+  return {
+    position: { x: 0, y: 0 },
+    size: { width: 100, height: 100 },
+    angle: 0,
+    style: { ...DEFAULT_STYLE },
+    meta: {
+      author: MCP_AUTHOR,
+      createdAt: now,
+      updatedAt: now,
+      tags: [],
+      locked: false,
+    },
+    data: { kind: 'rectangle' as const, label: undefined },
+    ...overrides,
+  };
+}
+
+function createMockClient(expressions: VisualExpression[] = []): IGatewayClient {
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    getSessionId: vi.fn().mockReturnValue('test-session'),
+    sendCreate: vi.fn().mockResolvedValue(undefined),
+    sendDelete: vi.fn().mockResolvedValue(undefined),
+    sendMorph: vi.fn().mockResolvedValue(undefined),
+    sendStyle: vi.fn().mockResolvedValue(undefined),
+    getState: vi.fn().mockReturnValue(expressions),
+  };
+}
+
+// ── formatCanvasState ──────────────────────────────────────
+
+describe('formatCanvasState', () => {
+  it('returns empty message for empty canvas', () => {
+    const result = formatCanvasState([]);
+    expect(result).toContain('Canvas is empty');
+  });
+
+  it('lists expressions with IDs and kinds', () => {
+    const expressions = [
+      createExpression({
+        id: 'rect-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Box' },
+        position: { x: 100, y: 200 },
+        size: { width: 300, height: 150 },
+      }),
+    ];
+
+    const result = formatCanvasState(expressions);
+    expect(result).toContain('1 expression(s)');
+    expect(result).toContain('rect-1');
+    expect(result).toContain('rectangle');
+    expect(result).toContain('"Box"');
+    expect(result).toContain('(100, 200)');
+    expect(result).toContain('300×150');
+  });
+
+  it('handles multiple expression types', () => {
+    const expressions = [
+      createExpression({
+        id: 'r1', kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'A' },
+      }),
+      createExpression({
+        id: 't1', kind: 'text',
+        data: { kind: 'text', text: 'Hello', fontSize: 16, fontFamily: 'sans-serif', textAlign: 'left' as const },
+      }),
+      createExpression({
+        id: 'f1', kind: 'flowchart',
+        data: { kind: 'flowchart', title: 'Flow', nodes: [], edges: [], direction: 'TB' as const },
+      }),
+    ];
+
+    const result = formatCanvasState(expressions);
+    expect(result).toContain('3 expression(s)');
+    expect(result).toContain('rectangle');
+    expect(result).toContain('text');
+    expect(result).toContain('flowchart');
+  });
+
+  it('truncates long labels', () => {
+    const longText = 'A'.repeat(100);
+    const expressions = [
+      createExpression({
+        id: 't1', kind: 'text',
+        data: { kind: 'text', text: longText, fontSize: 16, fontFamily: 'sans-serif', textAlign: 'left' as const },
+      }),
+    ];
+
+    const result = formatCanvasState(expressions);
+    expect(result).toContain('…');
+  });
+
+  it('shows highlight element count', () => {
+    const expressions = [
+      createExpression({
+        id: 'h1', kind: 'highlight',
+        data: { kind: 'highlight', targetExpressionIds: ['a', 'b', 'c'], color: '#FF0' },
+      }),
+    ];
+
+    const result = formatCanvasState(expressions);
+    expect(result).toContain('3 elements');
+  });
+});
+
+// ── executeGetState ────────────────────────────────────────
+
+describe('executeGetState', () => {
+  it('returns formatted state from gateway client', async () => {
+    const expressions = [
+      createExpression({
+        id: 'r1', kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Test' },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const result = await executeGetState(client);
+    expect(result).toContain('1 expression(s)');
+    expect(result).toContain('rectangle');
+  });
+
+  it('returns empty message when canvas is empty', async () => {
+    const client = createMockClient([]);
+    const result = await executeGetState(client);
+    expect(result).toContain('Canvas is empty');
+  });
+});
+
+// ── executeClear ───────────────────────────────────────────
+
+describe('executeClear', () => {
+  it('deletes all expressions and returns confirmation', async () => {
+    const expressions = [
+      createExpression({ id: 'r1', kind: 'rectangle', data: { kind: 'rectangle' } }),
+      createExpression({ id: 'r2', kind: 'rectangle', data: { kind: 'rectangle' } }),
+    ];
+    const client = createMockClient(expressions);
+
+    const result = await executeClear(client);
+    expect(client.sendDelete).toHaveBeenCalledWith(['r1', 'r2']);
+    expect(result).toContain('Cleared canvas');
+    expect(result).toContain('2 expression(s)');
+  });
+
+  it('handles already empty canvas', async () => {
+    const client = createMockClient([]);
+    const result = await executeClear(client);
+    expect(client.sendDelete).not.toHaveBeenCalled();
+    expect(result).toContain('already empty');
+  });
+});
+
+// ── executeMorph ───────────────────────────────────────────
+
+describe('executeMorph', () => {
+  it('morphs expression from one kind to another', async () => {
+    const expressions = [
+      createExpression({
+        id: 'r1', kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Box' },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const result = await executeMorph(client, { elementId: 'r1', toKind: 'ellipse' });
+    expect(client.sendMorph).toHaveBeenCalledWith(
+      'r1',
+      'rectangle',
+      'ellipse',
+      { kind: 'ellipse', label: 'Box' },
+    );
+    expect(result).toContain('Morphed');
+    expect(result).toContain('rectangle');
+    expect(result).toContain('ellipse');
+  });
+
+  it('returns message when already the target kind', async () => {
+    const expressions = [
+      createExpression({ id: 'r1', kind: 'rectangle', data: { kind: 'rectangle' } }),
+    ];
+    const client = createMockClient(expressions);
+
+    const result = await executeMorph(client, { elementId: 'r1', toKind: 'rectangle' });
+    expect(client.sendMorph).not.toHaveBeenCalled();
+    expect(result).toContain('already a rectangle');
+  });
+
+  it('throws when expression not found', async () => {
+    const client = createMockClient([]);
+
+    await expect(
+      executeMorph(client, { elementId: 'nonexistent', toKind: 'ellipse' }),
+    ).rejects.toThrow("Expression 'nonexistent' not found on canvas");
+  });
+
+  it('preserves label when morphing between shapes', async () => {
+    const expressions = [
+      createExpression({
+        id: 'r1', kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Keep me' },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    await executeMorph(client, { elementId: 'r1', toKind: 'diamond' });
+
+    expect(client.sendMorph).toHaveBeenCalledWith(
+      'r1',
+      'rectangle',
+      'diamond',
+      { kind: 'diamond', label: 'Keep me' },
+    );
+  });
+});
+
+// ── Annotation tools ───────────────────────────────────────
+
+describe('buildAnnotation', () => {
+  it('creates a callout annotation', () => {
+    const expr = buildAnnotation({
+      targetId: 'target-1',
+      text: 'Important!',
+    });
+
+    expect(expr.kind).toBe('callout');
+    expect(expr.data).toEqual({
+      kind: 'callout',
+      text: 'Important!',
+      targetExpressionId: 'target-1',
+      position: 'right',
+    });
+  });
+
+  it('uses custom position', () => {
+    const expr = buildAnnotation({
+      targetId: 'target-1',
+      text: 'Above',
+      position: 'top',
+    });
+
+    expect((expr.data as { position: string }).position).toBe('top');
+  });
+});
+
+describe('buildHighlight', () => {
+  it('creates a highlight for multiple elements', () => {
+    const expr = buildHighlight({
+      elementIds: ['a', 'b', 'c'],
+    });
+
+    expect(expr.kind).toBe('highlight');
+    expect(expr.data).toEqual({
+      kind: 'highlight',
+      targetExpressionIds: ['a', 'b', 'c'],
+      color: '#FFEB3B',
+    });
+  });
+
+  it('uses custom color', () => {
+    const expr = buildHighlight({
+      elementIds: ['a'],
+      color: '#FF0000',
+    });
+
+    expect((expr.data as { color: string }).color).toBe('#FF0000');
+  });
+
+  it('throws when no element IDs provided', () => {
+    expect(() => buildHighlight({ elementIds: [] })).toThrow(
+      'Highlight requires at least one element ID',
+    );
+  });
+});
+
+describe('buildComment', () => {
+  it('creates an unresolved comment', () => {
+    const expr = buildComment({
+      targetId: 'target-1',
+      text: 'Needs review',
+    });
+
+    expect(expr.kind).toBe('comment');
+    expect(expr.data).toEqual({
+      kind: 'comment',
+      text: 'Needs review',
+      targetExpressionId: 'target-1',
+      resolved: false,
+    });
+  });
+});
+
+describe('executeAnnotate', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeAnnotate(client, {
+      targetId: 'elem-1',
+      text: 'Check this',
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain('annotation');
+    expect(result).toContain("'Check this'");
+    expect(result).toContain('elem-1');
+  });
+});
+
+describe('executeHighlight', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeHighlight(client, {
+      elementIds: ['a', 'b'],
+      color: '#FF0000',
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain('Highlighted');
+    expect(result).toContain('2 elements');
+    expect(result).toContain('#FF0000');
+  });
+});
+
+describe('executeAddComment', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeAddComment(client, {
+      targetId: 'elem-1',
+      text: 'Fix this bug',
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain('comment');
+    expect(result).toContain("'Fix this bug'");
+    expect(result).toContain('elem-1');
+  });
+});

--- a/packages/mcp-server/src/__tests__/primitiveTools.test.ts
+++ b/packages/mcp-server/src/__tests__/primitiveTools.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for primitive expression tools.
+ *
+ * Verifies that each primitive tool builds correct VisualExpression
+ * objects and sends them to the gateway client.
+ *
+ * @module
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import type { IGatewayClient } from '../gatewayClient.js';
+import {
+  buildRectangle,
+  buildEllipse,
+  buildLine,
+  buildArrow,
+  buildText,
+  buildStickyNote,
+  executeDrawRectangle,
+  executeDrawEllipse,
+  executeDrawLine,
+  executeDrawArrow,
+  executeDrawText,
+  executeAddStickyNote,
+} from '../tools/primitiveTools.js';
+import { DEFAULT_STYLE } from '../defaults.js';
+
+// ── Mock gateway client ────────────────────────────────────
+
+function createMockClient(): IGatewayClient {
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    getSessionId: vi.fn().mockReturnValue('test-session'),
+    sendCreate: vi.fn().mockResolvedValue(undefined),
+    sendDelete: vi.fn().mockResolvedValue(undefined),
+    sendMorph: vi.fn().mockResolvedValue(undefined),
+    sendStyle: vi.fn().mockResolvedValue(undefined),
+    getState: vi.fn().mockReturnValue([]),
+  };
+}
+
+// ── Rectangle ──────────────────────────────────────────────
+
+describe('buildRectangle', () => {
+  it('creates a rectangle with required params', () => {
+    const expr = buildRectangle({ x: 100, y: 200, width: 300, height: 150 });
+
+    expect(expr.kind).toBe('rectangle');
+    expect(expr.position).toEqual({ x: 100, y: 200 });
+    expect(expr.size).toEqual({ width: 300, height: 150 });
+    expect(expr.data).toEqual({ kind: 'rectangle', label: undefined });
+    expect(expr.id).toBeDefined();
+    expect(expr.angle).toBe(0);
+    expect(expr.meta.author.type).toBe('agent');
+    expect(expr.meta.author.id).toBe('mcp-server');
+    expect(expr.meta.locked).toBe(false);
+  });
+
+  it('applies optional label', () => {
+    const expr = buildRectangle({ x: 0, y: 0, width: 100, height: 100, label: 'My Box' });
+
+    expect(expr.data).toEqual({ kind: 'rectangle', label: 'My Box' });
+  });
+
+  it('applies optional style overrides', () => {
+    const expr = buildRectangle({
+      x: 0, y: 0, width: 100, height: 100,
+      strokeColor: '#FF0000',
+      backgroundColor: '#00FF00',
+      fillStyle: 'solid',
+    });
+
+    expect(expr.style.strokeColor).toBe('#FF0000');
+    expect(expr.style.backgroundColor).toBe('#00FF00');
+    expect(expr.style.fillStyle).toBe('solid');
+    // Other defaults preserved
+    expect(expr.style.strokeWidth).toBe(DEFAULT_STYLE.strokeWidth);
+    expect(expr.style.roughness).toBe(DEFAULT_STYLE.roughness);
+  });
+
+  it('uses default style when no overrides provided', () => {
+    const expr = buildRectangle({ x: 0, y: 0, width: 100, height: 100 });
+
+    expect(expr.style.strokeColor).toBe(DEFAULT_STYLE.strokeColor);
+    expect(expr.style.backgroundColor).toBe(DEFAULT_STYLE.backgroundColor);
+    expect(expr.style.fillStyle).toBe(DEFAULT_STYLE.fillStyle);
+  });
+});
+
+describe('executeDrawRectangle', () => {
+  let client: IGatewayClient;
+
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  it('sends create operation and returns confirmation', async () => {
+    const result = await executeDrawRectangle(client, {
+      x: 100, y: 200, width: 300, height: 150, label: 'Test',
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    const sentExpr = (client.sendCreate as ReturnType<typeof vi.fn>).mock.calls[0]![0] as VisualExpression;
+    expect(sentExpr.kind).toBe('rectangle');
+    expect(result).toContain('Created rectangle');
+    expect(result).toContain("'Test'");
+    expect(result).toContain('300×150');
+  });
+
+  it('omits label in message when not provided', async () => {
+    const result = await executeDrawRectangle(client, {
+      x: 0, y: 0, width: 100, height: 100,
+    });
+
+    expect(result).not.toContain("'");
+    expect(result).toContain('Created rectangle');
+  });
+});
+
+// ── Ellipse ────────────────────────────────────────────────
+
+describe('buildEllipse', () => {
+  it('creates an ellipse with required params', () => {
+    const expr = buildEllipse({ x: 50, y: 50, width: 200, height: 200 });
+
+    expect(expr.kind).toBe('ellipse');
+    expect(expr.position).toEqual({ x: 50, y: 50 });
+    expect(expr.size).toEqual({ width: 200, height: 200 });
+    expect(expr.data).toEqual({ kind: 'ellipse', label: undefined });
+  });
+
+  it('applies optional label', () => {
+    const expr = buildEllipse({ x: 0, y: 0, width: 100, height: 100, label: 'Circle' });
+
+    expect(expr.data).toEqual({ kind: 'ellipse', label: 'Circle' });
+  });
+});
+
+describe('executeDrawEllipse', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeDrawEllipse(client, {
+      x: 0, y: 0, width: 100, height: 100, label: 'O',
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain('Created ellipse');
+    expect(result).toContain("'O'");
+  });
+});
+
+// ── Line ───────────────────────────────────────────────────
+
+describe('buildLine', () => {
+  it('creates a line from points', () => {
+    const points: [number, number][] = [[0, 0], [100, 100], [200, 50]];
+    const expr = buildLine({ points });
+
+    expect(expr.kind).toBe('line');
+    expect(expr.data).toEqual({ kind: 'line', points });
+    expect(expr.position).toEqual({ x: 0, y: 0 });
+    expect(expr.size).toEqual({ width: 200, height: 100 });
+  });
+
+  it('computes correct bounding box for non-origin points', () => {
+    const points: [number, number][] = [[50, 100], [150, 300]];
+    const expr = buildLine({ points });
+
+    expect(expr.position).toEqual({ x: 50, y: 100 });
+    expect(expr.size).toEqual({ width: 100, height: 200 });
+  });
+
+  it('throws error for fewer than 2 points', () => {
+    expect(() => buildLine({ points: [[0, 0]] })).toThrow('Line requires at least 2 points');
+  });
+
+  it('throws error for empty points', () => {
+    expect(() => buildLine({ points: [] })).toThrow('Line requires at least 2 points');
+  });
+});
+
+describe('executeDrawLine', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeDrawLine(client, {
+      points: [[0, 0], [100, 100]],
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain('Created line');
+    expect(result).toContain('2 points');
+  });
+});
+
+// ── Arrow ──────────────────────────────────────────────────
+
+describe('buildArrow', () => {
+  it('creates an arrow with end arrowhead', () => {
+    const points: [number, number][] = [[0, 0], [100, 100]];
+    const expr = buildArrow({ points });
+
+    expect(expr.kind).toBe('arrow');
+    expect(expr.data).toEqual({
+      kind: 'arrow',
+      points,
+      endArrowhead: true,
+    });
+  });
+
+  it('throws error for fewer than 2 points', () => {
+    expect(() => buildArrow({ points: [[0, 0]] })).toThrow('Arrow requires at least 2 points');
+  });
+});
+
+describe('executeDrawArrow', () => {
+  it('sends create and returns confirmation with label', async () => {
+    const client = createMockClient();
+    const result = await executeDrawArrow(client, {
+      points: [[0, 0], [100, 0]],
+      label: 'Next',
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain('Created arrow');
+    expect(result).toContain("'Next'");
+  });
+});
+
+// ── Text ───────────────────────────────────────────────────
+
+describe('buildText', () => {
+  it('creates a text expression with defaults', () => {
+    const expr = buildText({ x: 10, y: 20, text: 'Hello World' });
+
+    expect(expr.kind).toBe('text');
+    expect(expr.position).toEqual({ x: 10, y: 20 });
+    expect(expr.data).toEqual({
+      kind: 'text',
+      text: 'Hello World',
+      fontSize: 16,
+      fontFamily: 'sans-serif',
+      textAlign: 'left',
+    });
+  });
+
+  it('applies custom font size and family', () => {
+    const expr = buildText({
+      x: 0, y: 0, text: 'Big text',
+      fontSize: 32, fontFamily: 'monospace',
+    });
+
+    expect(expr.data).toEqual({
+      kind: 'text',
+      text: 'Big text',
+      fontSize: 32,
+      fontFamily: 'monospace',
+      textAlign: 'left',
+    });
+  });
+
+  it('estimates size based on text length', () => {
+    const shortExpr = buildText({ x: 0, y: 0, text: 'Hi' });
+    const longExpr = buildText({ x: 0, y: 0, text: 'This is a much longer text for testing' });
+
+    expect(longExpr.size.width).toBeGreaterThan(shortExpr.size.width);
+  });
+});
+
+describe('executeDrawText', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeDrawText(client, {
+      x: 10, y: 20, text: 'Hello World',
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain('Created text');
+    expect(result).toContain("'Hello World'");
+  });
+
+  it('truncates long text in confirmation message', async () => {
+    const client = createMockClient();
+    const longText = 'A'.repeat(60);
+    const result = await executeDrawText(client, {
+      x: 0, y: 0, text: longText,
+    });
+
+    expect(result).toContain('…');
+    expect(result.length).toBeLessThan(longText.length + 100);
+  });
+});
+
+// ── Sticky Note ────────────────────────────────────────────
+
+describe('buildStickyNote', () => {
+  it('creates a sticky note with default color', () => {
+    const expr = buildStickyNote({ x: 100, y: 100, text: 'Remember this' });
+
+    expect(expr.kind).toBe('sticky-note');
+    expect(expr.position).toEqual({ x: 100, y: 100 });
+    expect(expr.size).toEqual({ width: 200, height: 200 });
+    expect((expr.data as { kind: 'sticky-note'; text: string; color: string }).text).toBe('Remember this');
+    expect((expr.data as { kind: 'sticky-note'; text: string; color: string }).color).toBeDefined();
+    expect(expr.style.fillStyle).toBe('solid');
+  });
+
+  it('applies custom color', () => {
+    const expr = buildStickyNote({
+      x: 0, y: 0, text: 'Note', color: '#FF5722',
+    });
+
+    expect((expr.data as { kind: 'sticky-note'; text: string; color: string }).color).toBe('#FF5722');
+    expect(expr.style.backgroundColor).toBe('#FF5722');
+  });
+});
+
+describe('executeAddStickyNote', () => {
+  it('sends create and returns confirmation', async () => {
+    const client = createMockClient();
+    const result = await executeAddStickyNote(client, {
+      x: 50, y: 50, text: 'TODO: Fix bug',
+    });
+
+    expect(client.sendCreate).toHaveBeenCalledOnce();
+    expect(result).toContain('Created sticky note');
+    expect(result).toContain("'TODO: Fix bug'");
+  });
+});
+
+// ── Cross-cutting concerns ─────────────────────────────────
+
+describe('primitive tools cross-cutting', () => {
+  it('each built expression has a unique ID', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      const expr = buildRectangle({ x: 0, y: 0, width: 100, height: 100 });
+      ids.add(expr.id);
+    }
+    expect(ids.size).toBe(10);
+  });
+
+  it('all expressions have MCP author info', () => {
+    const expressions = [
+      buildRectangle({ x: 0, y: 0, width: 100, height: 100 }),
+      buildEllipse({ x: 0, y: 0, width: 100, height: 100 }),
+      buildLine({ points: [[0, 0], [100, 100]] }),
+      buildArrow({ points: [[0, 0], [100, 100]] }),
+      buildText({ x: 0, y: 0, text: 'test' }),
+      buildStickyNote({ x: 0, y: 0, text: 'test' }),
+    ];
+
+    for (const expr of expressions) {
+      expect(expr.meta.author).toEqual({
+        type: 'agent',
+        id: 'mcp-server',
+        name: 'InfiniCanvas MCP',
+        provider: 'mcp',
+      });
+    }
+  });
+
+  it('all expressions have timestamps', () => {
+    const before = Date.now();
+    const expr = buildRectangle({ x: 0, y: 0, width: 100, height: 100 });
+    const after = Date.now();
+
+    expect(expr.meta.createdAt).toBeGreaterThanOrEqual(before);
+    expect(expr.meta.createdAt).toBeLessThanOrEqual(after);
+    expect(expr.meta.updatedAt).toBe(expr.meta.createdAt);
+  });
+});

--- a/packages/mcp-server/src/defaults.ts
+++ b/packages/mcp-server/src/defaults.ts
@@ -1,0 +1,67 @@
+/**
+ * Default styles, colors, and layout constants for the MCP server.
+ *
+ * Provides sensible defaults so AI agents don't need to specify every
+ * visual property — they can focus on intent and structure.
+ *
+ * @module
+ */
+
+import type { ExpressionStyle } from '@infinicanvas/protocol';
+
+/** Default visual style for canvas expressions. */
+export const DEFAULT_STYLE: ExpressionStyle = {
+  strokeColor: '#1e1e1e',
+  backgroundColor: 'transparent',
+  fillStyle: 'hachure',
+  strokeWidth: 2,
+  roughness: 1,
+  opacity: 1,
+};
+
+/** Pastel color palette for sticky notes. */
+export const STICKY_NOTE_COLORS = [
+  '#FFEB3B', // Yellow
+  '#FF9800', // Orange
+  '#E91E63', // Pink
+  '#9C27B0', // Purple
+  '#3F51B5', // Indigo
+  '#03A9F4', // Light Blue
+  '#4CAF50', // Green
+  '#8BC34A', // Light Green
+] as const;
+
+/** Pick a random pastel color from the palette. */
+export function randomStickyColor(): string {
+  const index = Math.floor(Math.random() * STICKY_NOTE_COLORS.length);
+  return STICKY_NOTE_COLORS[index]!;
+}
+
+/** Default text properties. */
+export const DEFAULT_TEXT = {
+  fontSize: 16,
+  fontFamily: 'sans-serif',
+  textAlign: 'left' as const,
+};
+
+/** Grid spacing for auto-layout of composite child elements. */
+export const LAYOUT = {
+  /** Horizontal gap between grid cells. */
+  cellGapX: 200,
+  /** Vertical gap between grid cells. */
+  cellGapY: 150,
+  /** Default node width. */
+  nodeWidth: 160,
+  /** Default node height. */
+  nodeHeight: 80,
+  /** Padding around composite diagrams. */
+  padding: 40,
+} as const;
+
+/** MCP server author info — identifies operations as coming from the MCP tool server. */
+export const MCP_AUTHOR = {
+  type: 'agent' as const,
+  id: 'mcp-server',
+  name: 'InfiniCanvas MCP',
+  provider: 'mcp',
+};

--- a/packages/mcp-server/src/gatewayClient.ts
+++ b/packages/mcp-server/src/gatewayClient.ts
@@ -1,0 +1,322 @@
+/**
+ * Gateway WebSocket client for the MCP server.
+ *
+ * Connects to the InfiniCanvas gateway to send operations and receive
+ * canvas state. Used by all tool implementations to push expressions
+ * onto the shared canvas.
+ *
+ * @module
+ */
+
+import WebSocket from 'ws';
+import { nanoid } from 'nanoid';
+import type {
+  VisualExpression,
+  ProtocolOperation,
+  AuthorInfo,
+  CreatePayload,
+  DeletePayload,
+  MorphPayload,
+  StylePayload,
+  ExpressionKind,
+  ExpressionData,
+} from '@infinicanvas/protocol';
+import { MCP_AUTHOR } from './defaults.js';
+
+/** Messages the gateway sends back to us. */
+interface SessionCreatedMessage {
+  type: 'session-created';
+  sessionId: string;
+}
+
+interface StateSyncMessage {
+  type: 'state-sync';
+  sessionId: string;
+  expressions: VisualExpression[];
+  expressionOrder: string[];
+}
+
+interface OperationBroadcast {
+  type: 'operation';
+  operation: ProtocolOperation;
+}
+
+interface ErrorMessage {
+  type: 'error';
+  code: string;
+  message: string;
+}
+
+type ServerMessage =
+  | SessionCreatedMessage
+  | StateSyncMessage
+  | OperationBroadcast
+  | ErrorMessage;
+
+/** Options for creating a gateway client. */
+export interface GatewayClientOptions {
+  /** Gateway WebSocket URL (default: ws://localhost:8080). */
+  url?: string;
+  /** API key for gateway authentication. */
+  apiKey?: string;
+  /** Existing session ID to join (creates new session if omitted). */
+  sessionId?: string;
+}
+
+/**
+ * Gateway client interface — the port through which tools interact
+ * with the collaborative canvas.
+ */
+export interface IGatewayClient {
+  /** Connect to the gateway and create or join a session. */
+  connect(): Promise<void>;
+  /** Disconnect from the gateway. */
+  disconnect(): void;
+  /** Whether the client is currently connected. */
+  isConnected(): boolean;
+  /** Current session ID (null if not connected). */
+  getSessionId(): string | null;
+  /** Send a create operation for a visual expression. */
+  sendCreate(expression: VisualExpression): Promise<void>;
+  /** Send a delete operation for one or more expression IDs. */
+  sendDelete(expressionIds: string[]): Promise<void>;
+  /** Send a morph operation to change an expression's kind. */
+  sendMorph(expressionId: string, fromKind: ExpressionKind, toKind: ExpressionKind, newData: ExpressionData): Promise<void>;
+  /** Send a style operation to change expression visual properties. */
+  sendStyle(expressionIds: string[], style: Partial<import('@infinicanvas/protocol').ExpressionStyle>): Promise<void>;
+  /** Get the current canvas state (expressions). */
+  getState(): VisualExpression[];
+}
+
+/**
+ * WebSocket client that connects to the InfiniCanvas gateway.
+ *
+ * Maintains a live connection and synchronizes canvas state. All tool
+ * implementations use this client to push operations.
+ */
+export class GatewayClient implements IGatewayClient {
+  private ws: WebSocket | null = null;
+  private sessionId: string | null = null;
+  private expressions: VisualExpression[] = [];
+  private readonly url: string;
+  private readonly apiKey: string;
+  private readonly initialSessionId: string | undefined;
+  private readonly author: AuthorInfo;
+
+  constructor(options: GatewayClientOptions = {}) {
+    this.url = options.url ?? process.env['INFINICANVAS_GATEWAY_URL'] ?? 'ws://localhost:8080';
+    this.apiKey = options.apiKey ?? process.env['INFINICANVAS_API_KEY'] ?? '';
+    this.initialSessionId = options.sessionId ?? process.env['INFINICANVAS_SESSION_ID'] ?? undefined;
+    this.author = MCP_AUTHOR;
+  }
+
+  async connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.ws = new WebSocket(this.url);
+
+      const onError = (err: Error) => {
+        this.ws?.removeListener('error', onError);
+        reject(new Error(`Gateway connection failed: ${err.message}`));
+      };
+
+      this.ws.on('error', onError);
+
+      this.ws.on('open', () => {
+        this.ws?.removeListener('error', onError);
+        this.setupMessageHandler(resolve, reject);
+
+        if (this.initialSessionId) {
+          this.send({
+            type: 'join',
+            sessionId: this.initialSessionId,
+            auth: { apiKey: this.apiKey },
+          });
+        } else {
+          this.send({
+            type: 'create-session',
+            auth: { apiKey: this.apiKey },
+          });
+        }
+      });
+    });
+  }
+
+  disconnect(): void {
+    if (this.ws) {
+      this.ws.close(1000, 'MCP server disconnect');
+      this.ws = null;
+    }
+    this.sessionId = null;
+    this.expressions = [];
+  }
+
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  async sendCreate(expression: VisualExpression): Promise<void> {
+    const payload: CreatePayload = {
+      type: 'create',
+      expressionId: expression.id,
+      kind: expression.kind,
+      position: expression.position,
+      size: expression.size,
+      data: expression.data,
+    };
+
+    await this.sendOperation('create', payload);
+
+    // Update local state
+    this.expressions.push(expression);
+  }
+
+  async sendDelete(expressionIds: string[]): Promise<void> {
+    const payload: DeletePayload = {
+      type: 'delete',
+      expressionIds,
+    };
+
+    await this.sendOperation('delete', payload);
+
+    // Update local state
+    this.expressions = this.expressions.filter(
+      (e) => !expressionIds.includes(e.id),
+    );
+  }
+
+  async sendMorph(
+    expressionId: string,
+    fromKind: ExpressionKind,
+    toKind: ExpressionKind,
+    newData: ExpressionData,
+  ): Promise<void> {
+    const payload: MorphPayload = {
+      type: 'morph',
+      expressionId,
+      fromKind,
+      toKind,
+      newData,
+    };
+
+    await this.sendOperation('morph', payload);
+  }
+
+  async sendStyle(
+    expressionIds: string[],
+    style: Partial<import('@infinicanvas/protocol').ExpressionStyle>,
+  ): Promise<void> {
+    const payload: StylePayload = {
+      type: 'style',
+      expressionIds,
+      style,
+    };
+
+    await this.sendOperation('style', payload);
+  }
+
+  getState(): VisualExpression[] {
+    return [...this.expressions];
+  }
+
+  // ── Private helpers ──────────────────────────────────────
+
+  private setupMessageHandler(
+    onReady: () => void,
+    onFail: (err: Error) => void,
+  ): void {
+    let settled = false;
+
+    this.ws?.on('message', (raw: WebSocket.RawData) => {
+      const msg = JSON.parse(raw.toString()) as ServerMessage;
+
+      switch (msg.type) {
+        case 'session-created':
+          this.sessionId = msg.sessionId;
+          if (!settled) {
+            settled = true;
+            onReady();
+          }
+          break;
+
+        case 'state-sync':
+          this.sessionId = msg.sessionId;
+          this.expressions = msg.expressions;
+          if (!settled) {
+            settled = true;
+            onReady();
+          }
+          break;
+
+        case 'operation':
+          this.applyRemoteOperation(msg.operation);
+          break;
+
+        case 'error':
+          if (!settled) {
+            settled = true;
+            onFail(new Error(`Gateway error [${msg.code}]: ${msg.message}`));
+          }
+          break;
+      }
+    });
+  }
+
+  private applyRemoteOperation(op: ProtocolOperation): void {
+    if (op.payload.type === 'create') {
+      const createPayload = op.payload;
+      const exists = this.expressions.some((e) => e.id === createPayload.expressionId);
+      if (!exists) {
+        // This was from another client — we'd need the full expression
+        // For now, we just track what we sent ourselves
+      }
+    } else if (op.payload.type === 'delete') {
+      const deletePayload = op.payload;
+      this.expressions = this.expressions.filter(
+        (e) => !deletePayload.expressionIds.includes(e.id),
+      );
+    }
+  }
+
+  private async sendOperation(
+    type: ProtocolOperation['type'],
+    payload: ProtocolOperation['payload'],
+  ): Promise<void> {
+    if (!this.isConnected()) {
+      throw new Error('Not connected to gateway');
+    }
+
+    const operation: ProtocolOperation = {
+      id: nanoid(),
+      type,
+      author: this.author,
+      timestamp: Date.now(),
+      payload,
+    };
+
+    this.send({ type: 'operation', operation });
+  }
+
+  private send(message: unknown): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(message));
+    }
+  }
+}
+
+/**
+ * Create a gateway client instance.
+ *
+ * Uses environment variables for configuration if not provided:
+ * - INFINICANVAS_GATEWAY_URL (default: ws://localhost:8080)
+ * - INFINICANVAS_API_KEY
+ * - INFINICANVAS_SESSION_ID (optional — creates new session if omitted)
+ */
+export function createGatewayClient(
+  options?: GatewayClientOptions,
+): IGatewayClient {
+  return new GatewayClient(options);
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,56 @@
+/**
+ * InfiniCanvas MCP Server — public API.
+ *
+ * Re-exports the server factory, gateway client, defaults,
+ * and tool implementations for programmatic usage.
+ *
+ * @module
+ */
+
+// ── Server ─────────────────────────────────────────────────
+export { createMcpServer } from './server.js';
+
+// ── Gateway client ─────────────────────────────────────────
+export { createGatewayClient, GatewayClient } from './gatewayClient.js';
+export type { IGatewayClient, GatewayClientOptions } from './gatewayClient.js';
+
+// ── Defaults ───────────────────────────────────────────────
+export {
+  DEFAULT_STYLE,
+  DEFAULT_TEXT,
+  LAYOUT,
+  MCP_AUTHOR,
+  STICKY_NOTE_COLORS,
+  randomStickyColor,
+} from './defaults.js';
+
+// ── Primitive tools ────────────────────────────────────────
+export {
+  buildRectangle,
+  buildEllipse,
+  buildLine,
+  buildArrow,
+  buildText,
+  buildStickyNote,
+} from './tools/primitiveTools.js';
+
+// ── Composite tools ────────────────────────────────────────
+export {
+  buildFlowchart,
+  buildSequenceDiagram,
+  buildMindMap,
+  buildReasoningChain,
+  buildWireframe,
+  buildRoadmap,
+  buildKanban,
+} from './tools/compositeTools.js';
+
+// ── Annotation tools ───────────────────────────────────────
+export {
+  buildAnnotation,
+  buildHighlight,
+  buildComment,
+} from './tools/annotationTools.js';
+
+// ── Management tools ───────────────────────────────────────
+export { formatCanvasState } from './tools/managementTools.js';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,0 +1,458 @@
+/**
+ * InfiniCanvas MCP Server — canvas tools for AI agents.
+ *
+ * Registers MCP tools that allow any AI model (Copilot CLI, GPT, Claude)
+ * to draw diagrams, annotate, and manage visual expressions on the canvas
+ * via standard Model Context Protocol tool calling.
+ *
+ * Architecture:
+ * ```
+ * AI Model (any model with tool calling)
+ *   ↓ MCP tool calls (stdio transport)
+ * MCP Server (this module)
+ *   ↓ WebSocket
+ * Gateway Server (packages/gateway)
+ *   ↓ broadcast
+ * Browser Canvas (packages/app)
+ * ```
+ *
+ * @module
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { createGatewayClient, type IGatewayClient } from './gatewayClient.js';
+
+// ── Tool executors ─────────────────────────────────────────
+import {
+  executeDrawRectangle,
+  executeDrawEllipse,
+  executeDrawLine,
+  executeDrawArrow,
+  executeDrawText,
+  executeAddStickyNote,
+} from './tools/primitiveTools.js';
+import {
+  executeDrawFlowchart,
+  executeDrawSequenceDiagram,
+  executeDrawMindMap,
+  executeDrawReasoningChain,
+  executeDrawWireframe,
+  executeDrawRoadmap,
+  executeDrawKanban,
+} from './tools/compositeTools.js';
+import {
+  executeAnnotate,
+  executeHighlight,
+  executeAddComment,
+} from './tools/annotationTools.js';
+import {
+  executeGetState,
+  executeClear,
+  executeMorph,
+} from './tools/managementTools.js';
+
+// ── Zod schemas for tool parameters ────────────────────────
+
+const pointArraySchema = z.array(z.tuple([z.number(), z.number()]));
+const fillStyleSchema = z.enum(['solid', 'hachure', 'cross-hatch', 'none']);
+const flowNodeShapeSchema = z.enum(['rect', 'diamond', 'ellipse', 'parallelogram', 'cylinder']);
+const messageTypeSchema = z.enum(['sync', 'async', 'reply']);
+const wireframeComponentTypeSchema = z.enum(['button', 'input', 'text', 'image', 'container', 'nav', 'list']);
+const roadmapStatusSchema = z.enum(['planned', 'in-progress', 'done']);
+const roadmapOrientationSchema = z.enum(['horizontal', 'vertical']);
+const calloutPositionSchema = z.enum(['top', 'right', 'bottom', 'left']);
+const flowDirectionSchema = z.enum(['TB', 'LR', 'BT', 'RL']);
+
+// ── Server creation ────────────────────────────────────────
+
+/**
+ * Create and configure the MCP server with all canvas tools registered.
+ *
+ * The server uses stdio transport for Copilot CLI integration and
+ * connects to the gateway WebSocket server for canvas operations.
+ */
+export function createMcpServer(gatewayClient: IGatewayClient): McpServer {
+  const server = new McpServer({
+    name: 'infinicanvas',
+    version: '0.1.0',
+  });
+
+  // ── Primitive expression tools ─────────────────────────
+
+  server.tool(
+    'canvas_draw_rectangle',
+    'Draw a rectangle on the canvas. Use for boxes, containers, cards, or any rectangular element.',
+    {
+      x: z.number().describe('X position on the canvas'),
+      y: z.number().describe('Y position on the canvas'),
+      width: z.number().positive().describe('Width of the rectangle'),
+      height: z.number().positive().describe('Height of the rectangle'),
+      label: z.string().optional().describe('Text label inside the rectangle'),
+      strokeColor: z.string().optional().describe('Border color in hex (e.g. "#FF0000")'),
+      backgroundColor: z.string().optional().describe('Fill color in hex or "transparent"'),
+      fillStyle: fillStyleSchema.optional().describe('Fill rendering style'),
+    },
+    async (params) => {
+      const result = await executeDrawRectangle(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_draw_ellipse',
+    'Draw an ellipse (circle/oval) on the canvas. Use for start/end nodes, bubbles, or circular elements.',
+    {
+      x: z.number().describe('X position on the canvas'),
+      y: z.number().describe('Y position on the canvas'),
+      width: z.number().positive().describe('Width of the ellipse'),
+      height: z.number().positive().describe('Height of the ellipse'),
+      label: z.string().optional().describe('Text label inside the ellipse'),
+    },
+    async (params) => {
+      const result = await executeDrawEllipse(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_draw_line',
+    'Draw a line connecting multiple points. Use for connectors, separators, or freeform paths.',
+    {
+      points: pointArraySchema.min(2).describe('Array of [x, y] coordinate pairs (minimum 2 points)'),
+    },
+    async (params) => {
+      const result = await executeDrawLine(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_draw_arrow',
+    'Draw an arrow connecting multiple points. Use for directional connections, flow indicators, or pointers.',
+    {
+      points: pointArraySchema.min(2).describe('Array of [x, y] coordinate pairs (minimum 2 points)'),
+      label: z.string().optional().describe('Label text for the arrow'),
+    },
+    async (params) => {
+      const result = await executeDrawArrow(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_draw_text',
+    'Place text on the canvas. Use for labels, headings, descriptions, or any textual content.',
+    {
+      x: z.number().describe('X position on the canvas'),
+      y: z.number().describe('Y position on the canvas'),
+      text: z.string().min(1).describe('The text content to display'),
+      fontSize: z.number().positive().optional().describe('Font size in pixels (default: 16)'),
+      fontFamily: z.string().optional().describe('Font family name (default: "sans-serif")'),
+    },
+    async (params) => {
+      const result = await executeDrawText(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_add_sticky_note',
+    'Add a sticky note to the canvas. Use for quick notes, reminders, or informal annotations.',
+    {
+      x: z.number().describe('X position on the canvas'),
+      y: z.number().describe('Y position on the canvas'),
+      text: z.string().min(1).describe('Note text content'),
+      color: z.string().optional().describe('Background color in hex (default: random pastel)'),
+    },
+    async (params) => {
+      const result = await executeAddStickyNote(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  // ── Composite expression tools ─────────────────────────
+
+  server.tool(
+    'canvas_draw_flowchart',
+    'Draw a flowchart diagram. Use for process flows, decision trees, algorithms, or any step-by-step visualization.',
+    {
+      title: z.string().min(1).describe('Title of the flowchart'),
+      nodes: z.array(z.object({
+        id: z.string().describe('Unique node identifier'),
+        label: z.string().describe('Display text for the node'),
+        shape: flowNodeShapeSchema.optional().describe('Node shape (default: "rect")'),
+      })).min(1).describe('Flowchart nodes'),
+      edges: z.array(z.object({
+        from: z.string().describe('Source node ID'),
+        to: z.string().describe('Target node ID'),
+        label: z.string().optional().describe('Edge label text'),
+      })).describe('Connections between nodes'),
+      direction: flowDirectionSchema.optional().describe('Layout direction: TB (top-bottom), LR (left-right), BT, RL'),
+      x: z.number().optional().describe('X position on the canvas'),
+      y: z.number().optional().describe('Y position on the canvas'),
+    },
+    async (params) => {
+      const result = await executeDrawFlowchart(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_draw_sequence_diagram',
+    'Draw a sequence diagram showing interactions between participants over time. Use for API flows, protocol designs, or system interactions.',
+    {
+      title: z.string().min(1).describe('Title of the sequence diagram'),
+      participants: z.array(z.object({
+        id: z.string().describe('Unique participant identifier'),
+        name: z.string().describe('Display name for the participant'),
+      })).min(1).describe('Sequence diagram participants (actors/systems)'),
+      messages: z.array(z.object({
+        from: z.string().describe('Sender participant ID'),
+        to: z.string().describe('Receiver participant ID'),
+        label: z.string().describe('Message description'),
+        type: messageTypeSchema.optional().describe('Message type: sync, async, or reply'),
+      })).describe('Messages exchanged between participants'),
+      x: z.number().optional().describe('X position on the canvas'),
+      y: z.number().optional().describe('Y position on the canvas'),
+    },
+    async (params) => {
+      const result = await executeDrawSequenceDiagram(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  const mindMapBranchSchema: z.ZodType<{ id: string; label: string; children: unknown[] }> = z.object({
+    id: z.string().describe('Branch identifier'),
+    label: z.string().describe('Branch label text'),
+    children: z.lazy(() => z.array(mindMapBranchSchema)).describe('Sub-branches'),
+  });
+
+  server.tool(
+    'canvas_draw_mind_map',
+    'Draw a mind map radiating from a central topic. Use for brainstorming, concept exploration, or hierarchical idea organization.',
+    {
+      centralTopic: z.string().min(1).describe('Central topic of the mind map'),
+      branches: z.array(mindMapBranchSchema).min(1).describe('Main branches radiating from the center'),
+      x: z.number().optional().describe('X position on the canvas'),
+      y: z.number().optional().describe('Y position on the canvas'),
+    },
+    async (params) => {
+      const result = await executeDrawMindMap(gatewayClient, params as Parameters<typeof executeDrawMindMap>[1]);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_draw_reasoning_chain',
+    'Draw a visual reasoning chain showing step-by-step thinking. Use for explaining logic, problem-solving, or showing thought process.',
+    {
+      question: z.string().min(1).describe('The question or problem being reasoned about'),
+      steps: z.array(z.object({
+        title: z.string().describe('Step title or heading'),
+        content: z.string().describe('Step explanation or reasoning'),
+      })).min(1).describe('Reasoning steps from question to answer'),
+      finalAnswer: z.string().min(1).describe('The final conclusion or answer'),
+      x: z.number().optional().describe('X position on the canvas'),
+      y: z.number().optional().describe('Y position on the canvas'),
+    },
+    async (params) => {
+      const result = await executeDrawReasoningChain(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_draw_wireframe',
+    'Draw a UI wireframe with positioned components. Use for mockups, UI prototyping, or screen design.',
+    {
+      title: z.string().min(1).describe('Title of the wireframe/screen'),
+      screenSize: z.object({
+        width: z.number().positive().describe('Screen width in pixels'),
+        height: z.number().positive().describe('Screen height in pixels'),
+      }).describe('Target screen dimensions'),
+      components: z.array(z.object({
+        type: wireframeComponentTypeSchema.describe('UI component type'),
+        label: z.string().describe('Component label or placeholder text'),
+        x: z.number().describe('X position within the screen'),
+        y: z.number().describe('Y position within the screen'),
+        width: z.number().positive().describe('Component width'),
+        height: z.number().positive().describe('Component height'),
+      })).describe('UI components to place on the wireframe'),
+      x: z.number().optional().describe('X position on the canvas'),
+      y: z.number().optional().describe('Y position on the canvas'),
+    },
+    async (params) => {
+      const result = await executeDrawWireframe(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_draw_roadmap',
+    'Draw a project roadmap with phases and items. Use for project planning, release schedules, or milestone tracking.',
+    {
+      title: z.string().min(1).describe('Roadmap title'),
+      orientation: roadmapOrientationSchema.optional().describe('Layout orientation (default: "horizontal")'),
+      phases: z.array(z.object({
+        id: z.string().describe('Phase identifier'),
+        name: z.string().describe('Phase name'),
+        items: z.array(z.object({
+          id: z.string().describe('Item identifier'),
+          title: z.string().describe('Item title'),
+          status: roadmapStatusSchema.describe('Item status: planned, in-progress, or done'),
+        })).describe('Items within this phase'),
+      })).min(1).describe('Roadmap phases/milestones'),
+      x: z.number().optional().describe('X position on the canvas'),
+      y: z.number().optional().describe('Y position on the canvas'),
+    },
+    async (params) => {
+      const result = await executeDrawRoadmap(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_draw_kanban',
+    'Draw a kanban board with columns and cards. Use for task management, sprint boards, or workflow visualization.',
+    {
+      title: z.string().min(1).describe('Board title'),
+      columns: z.array(z.object({
+        id: z.string().describe('Column identifier'),
+        title: z.string().describe('Column heading'),
+        cards: z.array(z.object({
+          id: z.string().describe('Card identifier'),
+          title: z.string().describe('Card title'),
+          description: z.string().optional().describe('Card description'),
+        })).describe('Cards in this column'),
+      })).min(1).describe('Board columns'),
+      x: z.number().optional().describe('X position on the canvas'),
+      y: z.number().optional().describe('Y position on the canvas'),
+    },
+    async (params) => {
+      const result = await executeDrawKanban(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  // ── Annotation tools ───────────────────────────────────
+
+  server.tool(
+    'canvas_annotate',
+    'Add an annotation (callout) to an existing element. Use to add explanations, notes, or pointers to specific elements.',
+    {
+      targetId: z.string().min(1).describe('ID of the element to annotate'),
+      text: z.string().min(1).describe('Annotation text'),
+      position: calloutPositionSchema.optional().describe('Position relative to target (default: "right")'),
+    },
+    async (params) => {
+      const result = await executeAnnotate(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_highlight',
+    'Highlight one or more elements on the canvas. Use to draw attention to important elements or mark selections.',
+    {
+      elementIds: z.array(z.string()).min(1).describe('IDs of elements to highlight'),
+      color: z.string().optional().describe('Highlight color in hex (default: "#FFEB3B")'),
+    },
+    async (params) => {
+      const result = await executeHighlight(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_add_comment',
+    'Add a comment to an existing element. Use for code-review style comments or discussion threads.',
+    {
+      targetId: z.string().min(1).describe('ID of the element to comment on'),
+      text: z.string().min(1).describe('Comment text'),
+    },
+    async (params) => {
+      const result = await executeAddComment(gatewayClient, params);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  // ── Canvas management tools ────────────────────────────
+
+  server.tool(
+    'canvas_get_state',
+    'Get the current state of the canvas — lists all expressions with their IDs, kinds, positions, and labels. Use to inspect what is currently on the canvas before making changes.',
+    {},
+    async () => {
+      const result = await executeGetState(gatewayClient);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_clear',
+    'Clear all expressions from the canvas. Use to start with a blank canvas.',
+    {},
+    async () => {
+      const result = await executeClear(gatewayClient);
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  server.tool(
+    'canvas_morph',
+    'Morph an expression from one visual kind to another (e.g., rectangle → ellipse). Preserves the label if possible.',
+    {
+      elementId: z.string().min(1).describe('ID of the element to morph'),
+      toKind: z.string().min(1).describe('Target expression kind (e.g., "rectangle", "ellipse", "diamond", "text", "sticky-note")'),
+    },
+    async (params) => {
+      const result = await executeMorph(gatewayClient, {
+        elementId: params.elementId,
+        toKind: params.toKind as import('@infinicanvas/protocol').ExpressionKind,
+      });
+      return { content: [{ type: 'text' as const, text: result }] };
+    },
+  );
+
+  return server;
+}
+
+// ── Main entry point ───────────────────────────────────────
+
+/** Start the MCP server with stdio transport and gateway connection. */
+async function main(): Promise<void> {
+  const gatewayClient = createGatewayClient();
+
+  // Connect to gateway (optional — tools will fail gracefully if not connected)
+  try {
+    await gatewayClient.connect();
+  } catch {
+    // Gateway may not be running yet — tools will report connection errors
+    // The MCP server itself can still start and list tools
+    process.stderr.write(
+      'Warning: Could not connect to InfiniCanvas gateway. ' +
+      'Tools will attempt to reconnect. Set INFINICANVAS_GATEWAY_URL and INFINICANVAS_API_KEY.\n',
+    );
+  }
+
+  const server = createMcpServer(gatewayClient);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // Graceful shutdown
+  process.on('SIGINT', () => {
+    gatewayClient.disconnect();
+    process.exit(0);
+  });
+  process.on('SIGTERM', () => {
+    gatewayClient.disconnect();
+    process.exit(0);
+  });
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`MCP Server fatal error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/mcp-server/src/tools/annotationTools.ts
+++ b/packages/mcp-server/src/tools/annotationTools.ts
@@ -1,0 +1,151 @@
+/**
+ * Annotation tools for the MCP server.
+ *
+ * These tools add supplementary information to existing canvas expressions:
+ * comments, callouts, and highlights.
+ *
+ * @module
+ */
+
+import { nanoid } from 'nanoid';
+import type {
+  VisualExpression,
+  CommentData,
+  CalloutData,
+  HighlightData,
+} from '@infinicanvas/protocol';
+import { DEFAULT_STYLE, MCP_AUTHOR } from '../defaults.js';
+import type { IGatewayClient } from '../gatewayClient.js';
+
+// ── Shared expression builder ──────────────────────────────
+
+function buildExpression(
+  kind: VisualExpression['kind'],
+  position: { x: number; y: number },
+  size: { width: number; height: number },
+  data: VisualExpression['data'],
+): VisualExpression {
+  const now = Date.now();
+  return {
+    id: nanoid(),
+    kind,
+    position,
+    size,
+    angle: 0,
+    style: { ...DEFAULT_STYLE },
+    meta: {
+      author: MCP_AUTHOR,
+      createdAt: now,
+      updatedAt: now,
+      tags: [],
+      locked: false,
+    },
+    data,
+  };
+}
+
+// ── Tool parameter types ───────────────────────────────────
+
+export interface AnnotateParams {
+  targetId: string;
+  text: string;
+  position?: CalloutData['position'];
+}
+
+export interface HighlightParams {
+  elementIds: string[];
+  color?: string;
+}
+
+export interface AddCommentParams {
+  targetId: string;
+  text: string;
+}
+
+// ── Build functions ────────────────────────────────────────
+
+/** Build a callout annotation expression. */
+export function buildAnnotation(params: AnnotateParams): VisualExpression {
+  const data: CalloutData = {
+    kind: 'callout',
+    text: params.text,
+    targetExpressionId: params.targetId,
+    position: params.position ?? 'right',
+  };
+
+  // Position near the target — offset based on position direction
+  return buildExpression(
+    'callout',
+    { x: 0, y: 0 }, // Actual position depends on target — gateway resolves
+    { width: 200, height: 80 },
+    data,
+  );
+}
+
+/** Build a highlight annotation expression. */
+export function buildHighlight(params: HighlightParams): VisualExpression {
+  if (params.elementIds.length === 0) {
+    throw new Error('Highlight requires at least one element ID');
+  }
+
+  const data: HighlightData = {
+    kind: 'highlight',
+    targetExpressionIds: params.elementIds,
+    color: params.color ?? '#FFEB3B',
+  };
+
+  return buildExpression(
+    'highlight',
+    { x: 0, y: 0 },
+    { width: 100, height: 100 },
+    data,
+  );
+}
+
+/** Build a comment annotation expression. */
+export function buildComment(params: AddCommentParams): VisualExpression {
+  const data: CommentData = {
+    kind: 'comment',
+    text: params.text,
+    targetExpressionId: params.targetId,
+    resolved: false,
+  };
+
+  return buildExpression(
+    'comment',
+    { x: 0, y: 0 },
+    { width: 250, height: 100 },
+    data,
+  );
+}
+
+// ── Tool executors (send to gateway) ───────────────────────
+
+export async function executeAnnotate(
+  client: IGatewayClient,
+  params: AnnotateParams,
+): Promise<string> {
+  const expr = buildAnnotation(params);
+  await client.sendCreate(expr);
+  const preview = params.text.length > 40 ? params.text.slice(0, 40) + '…' : params.text;
+  return `Created annotation '${preview}' on element ${params.targetId} [id: ${expr.id}]`;
+}
+
+export async function executeHighlight(
+  client: IGatewayClient,
+  params: HighlightParams,
+): Promise<string> {
+  const expr = buildHighlight(params);
+  await client.sendCreate(expr);
+  return `Highlighted ${params.elementIds.length} elements with color ${params.color ?? '#FFEB3B'} [id: ${expr.id}]`;
+}
+
+export async function executeAddComment(
+  client: IGatewayClient,
+  params: AddCommentParams,
+): Promise<string> {
+  const expr = buildComment(params);
+  await client.sendCreate(expr);
+  const preview = params.text.length > 40 ? params.text.slice(0, 40) + '…' : params.text;
+  return `Added comment '${preview}' on element ${params.targetId} [id: ${expr.id}]`;
+}

--- a/packages/mcp-server/src/tools/compositeTools.ts
+++ b/packages/mcp-server/src/tools/compositeTools.ts
@@ -1,0 +1,436 @@
+/**
+ * Composite expression tools for the MCP server.
+ *
+ * These tools create structured, multi-element diagrams on the canvas:
+ * flowcharts, sequence diagrams, mind maps, reasoning chains,
+ * wireframes, roadmaps, and kanban boards.
+ *
+ * @module
+ */
+
+import { nanoid } from 'nanoid';
+import type {
+  VisualExpression,
+  ExpressionStyle,
+  FlowchartData,
+  FlowNode,
+  FlowEdge,
+  SequenceDiagramData,
+  Participant,
+  Message,
+  MindMapData,
+  MindMapBranch,
+  ReasoningChainData,
+  ReasoningStep,
+  WireframeData,
+  WireframeComponent,
+  RoadmapData,
+  RoadmapPhase,
+  RoadmapItem,
+  KanbanData,
+  KanbanColumn,
+} from '@infinicanvas/protocol';
+import { DEFAULT_STYLE, LAYOUT, MCP_AUTHOR } from '../defaults.js';
+import type { IGatewayClient } from '../gatewayClient.js';
+
+// ── Shared expression builder ──────────────────────────────
+
+function buildExpression(
+  kind: VisualExpression['kind'],
+  position: { x: number; y: number },
+  size: { width: number; height: number },
+  data: VisualExpression['data'],
+  styleOverrides?: Partial<ExpressionStyle>,
+): VisualExpression {
+  const now = Date.now();
+  return {
+    id: nanoid(),
+    kind,
+    position,
+    size,
+    angle: 0,
+    style: { ...DEFAULT_STYLE, ...styleOverrides },
+    meta: {
+      author: MCP_AUTHOR,
+      createdAt: now,
+      updatedAt: now,
+      tags: [],
+      locked: false,
+    },
+    data,
+  };
+}
+
+/** Estimate diagram size from node count using simple grid layout. */
+function estimateDiagramSize(
+  nodeCount: number,
+  direction: 'TB' | 'LR' | 'BT' | 'RL' = 'TB',
+): { width: number; height: number } {
+  const cols = direction === 'TB' || direction === 'BT'
+    ? Math.ceil(Math.sqrt(nodeCount))
+    : nodeCount;
+  const rows = direction === 'TB' || direction === 'BT'
+    ? Math.ceil(nodeCount / cols)
+    : 1;
+
+  return {
+    width: cols * LAYOUT.cellGapX + LAYOUT.padding * 2,
+    height: rows * LAYOUT.cellGapY + LAYOUT.padding * 2,
+  };
+}
+
+// ── Tool parameter types ───────────────────────────────────
+
+export interface DrawFlowchartParams {
+  title: string;
+  nodes: { id: string; label: string; shape?: FlowNode['shape'] }[];
+  edges: { from: string; to: string; label?: string }[];
+  direction?: 'TB' | 'LR' | 'BT' | 'RL';
+  x?: number;
+  y?: number;
+}
+
+export interface DrawSequenceDiagramParams {
+  title: string;
+  participants: { id: string; name: string }[];
+  messages: { from: string; to: string; label: string; type?: Message['type'] }[];
+  x?: number;
+  y?: number;
+}
+
+export interface DrawMindMapParams {
+  centralTopic: string;
+  branches: MindMapBranch[];
+  x?: number;
+  y?: number;
+}
+
+export interface DrawReasoningChainParams {
+  question: string;
+  steps: { title: string; content: string }[];
+  finalAnswer: string;
+  x?: number;
+  y?: number;
+}
+
+export interface DrawWireframeParams {
+  title: string;
+  screenSize: { width: number; height: number };
+  components: {
+    type: WireframeComponent['type'];
+    label: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }[];
+  x?: number;
+  y?: number;
+}
+
+export interface DrawRoadmapParams {
+  title: string;
+  orientation?: RoadmapData['orientation'];
+  phases: {
+    id: string;
+    name: string;
+    items: { id: string; title: string; status: RoadmapItem['status'] }[];
+  }[];
+  x?: number;
+  y?: number;
+}
+
+export interface DrawKanbanParams {
+  title: string;
+  columns: {
+    id: string;
+    title: string;
+    cards: { id: string; title: string; description?: string }[];
+  }[];
+  x?: number;
+  y?: number;
+}
+
+// ── Build functions ────────────────────────────────────────
+
+/** Build a flowchart visual expression. */
+export function buildFlowchart(params: DrawFlowchartParams): VisualExpression {
+  if (params.nodes.length === 0) {
+    throw new Error('Flowchart requires at least one node');
+  }
+
+  const direction = params.direction ?? 'TB';
+  const nodes: FlowNode[] = params.nodes.map((n) => ({
+    id: n.id,
+    label: n.label,
+    shape: n.shape ?? 'rect',
+  }));
+
+  const edges: FlowEdge[] = params.edges.map((e) => ({
+    from: e.from,
+    to: e.to,
+    label: e.label,
+  }));
+
+  const data: FlowchartData = {
+    kind: 'flowchart',
+    title: params.title,
+    nodes,
+    edges,
+    direction,
+  };
+
+  const size = estimateDiagramSize(nodes.length, direction);
+  const position = { x: params.x ?? 0, y: params.y ?? 0 };
+
+  return buildExpression('flowchart', position, size, data);
+}
+
+/** Build a sequence diagram visual expression. */
+export function buildSequenceDiagram(params: DrawSequenceDiagramParams): VisualExpression {
+  if (params.participants.length === 0) {
+    throw new Error('Sequence diagram requires at least one participant');
+  }
+
+  const participants: Participant[] = params.participants.map((p) => ({
+    id: p.id,
+    name: p.name,
+  }));
+
+  const messages: Message[] = params.messages.map((m) => ({
+    from: m.from,
+    to: m.to,
+    label: m.label,
+    type: m.type ?? 'sync',
+  }));
+
+  const data: SequenceDiagramData = {
+    kind: 'sequence-diagram',
+    title: params.title,
+    participants,
+    messages,
+  };
+
+  const width = participants.length * LAYOUT.cellGapX + LAYOUT.padding * 2;
+  const height = messages.length * LAYOUT.cellGapY + LAYOUT.padding * 2;
+  const position = { x: params.x ?? 0, y: params.y ?? 0 };
+
+  return buildExpression('sequence-diagram', position, { width, height }, data);
+}
+
+/** Count total nodes in a mind map branch tree. */
+function countBranches(branches: MindMapBranch[]): number {
+  let count = branches.length;
+  for (const b of branches) {
+    count += countBranches(b.children);
+  }
+  return count;
+}
+
+/** Build a mind map visual expression. */
+export function buildMindMap(params: DrawMindMapParams): VisualExpression {
+  if (params.branches.length === 0) {
+    throw new Error('Mind map requires at least one branch');
+  }
+
+  const data: MindMapData = {
+    kind: 'mind-map',
+    centralTopic: params.centralTopic,
+    branches: params.branches,
+  };
+
+  const totalNodes = countBranches(params.branches) + 1; // +1 for central topic
+  const size = estimateDiagramSize(totalNodes);
+  const position = { x: params.x ?? 0, y: params.y ?? 0 };
+
+  return buildExpression('mind-map', position, size, data);
+}
+
+/** Build a reasoning chain visual expression. */
+export function buildReasoningChain(params: DrawReasoningChainParams): VisualExpression {
+  if (params.steps.length === 0) {
+    throw new Error('Reasoning chain requires at least one step');
+  }
+
+  const steps: ReasoningStep[] = params.steps.map((s) => ({
+    title: s.title,
+    content: s.content,
+  }));
+
+  const data: ReasoningChainData = {
+    kind: 'reasoning-chain',
+    question: params.question,
+    steps,
+    finalAnswer: params.finalAnswer,
+  };
+
+  // Vertical layout: question → steps → answer
+  const height = (steps.length + 2) * LAYOUT.cellGapY + LAYOUT.padding * 2;
+  const width = LAYOUT.cellGapX * 2 + LAYOUT.padding * 2;
+  const position = { x: params.x ?? 0, y: params.y ?? 0 };
+
+  return buildExpression('reasoning-chain', position, { width, height }, data);
+}
+
+/** Build a wireframe visual expression. */
+export function buildWireframe(params: DrawWireframeParams): VisualExpression {
+  const components: WireframeComponent[] = params.components.map((c, i) => ({
+    id: `comp-${i}`,
+    type: c.type,
+    label: c.label,
+    x: c.x,
+    y: c.y,
+    width: c.width,
+    height: c.height,
+  }));
+
+  const data: WireframeData = {
+    kind: 'wireframe',
+    title: params.title,
+    screenSize: params.screenSize,
+    components,
+  };
+
+  const position = { x: params.x ?? 0, y: params.y ?? 0 };
+
+  return buildExpression(
+    'wireframe',
+    position,
+    { width: params.screenSize.width, height: params.screenSize.height },
+    data,
+  );
+}
+
+/** Build a roadmap visual expression. */
+export function buildRoadmap(params: DrawRoadmapParams): VisualExpression {
+  if (params.phases.length === 0) {
+    throw new Error('Roadmap requires at least one phase');
+  }
+
+  const orientation = params.orientation ?? 'horizontal';
+  const phases: RoadmapPhase[] = params.phases.map((p) => ({
+    id: p.id,
+    name: p.name,
+    items: p.items.map((item) => ({
+      id: item.id,
+      title: item.title,
+      status: item.status,
+    })),
+  }));
+
+  const data: RoadmapData = {
+    kind: 'roadmap',
+    title: params.title,
+    orientation,
+    phases,
+  };
+
+  const maxItems = Math.max(...phases.map((p) => p.items.length), 1);
+  const width = orientation === 'horizontal'
+    ? phases.length * LAYOUT.cellGapX + LAYOUT.padding * 2
+    : LAYOUT.cellGapX * 2 + LAYOUT.padding * 2;
+  const height = orientation === 'horizontal'
+    ? maxItems * LAYOUT.cellGapY + LAYOUT.padding * 2
+    : phases.length * LAYOUT.cellGapY + LAYOUT.padding * 2;
+
+  const position = { x: params.x ?? 0, y: params.y ?? 0 };
+
+  return buildExpression('roadmap', position, { width, height }, data);
+}
+
+/** Build a kanban board visual expression. */
+export function buildKanban(params: DrawKanbanParams): VisualExpression {
+  if (params.columns.length === 0) {
+    throw new Error('Kanban board requires at least one column');
+  }
+
+  const columns: KanbanColumn[] = params.columns.map((col) => ({
+    id: col.id,
+    title: col.title,
+    cards: col.cards.map((card) => ({
+      id: card.id,
+      title: card.title,
+      description: card.description,
+    })),
+  }));
+
+  const data: KanbanData = {
+    kind: 'kanban',
+    title: params.title,
+    columns,
+  };
+
+  const maxCards = Math.max(...columns.map((c) => c.cards.length), 1);
+  const width = columns.length * LAYOUT.cellGapX + LAYOUT.padding * 2;
+  const height = maxCards * LAYOUT.cellGapY + LAYOUT.padding * 2;
+  const position = { x: params.x ?? 0, y: params.y ?? 0 };
+
+  return buildExpression('kanban', position, { width, height }, data);
+}
+
+// ── Tool executors (send to gateway) ───────────────────────
+
+export async function executeDrawFlowchart(
+  client: IGatewayClient,
+  params: DrawFlowchartParams,
+): Promise<string> {
+  const expr = buildFlowchart(params);
+  await client.sendCreate(expr);
+  return `Created flowchart '${params.title}' with ${params.nodes.length} nodes and ${params.edges.length} edges [id: ${expr.id}]`;
+}
+
+export async function executeDrawSequenceDiagram(
+  client: IGatewayClient,
+  params: DrawSequenceDiagramParams,
+): Promise<string> {
+  const expr = buildSequenceDiagram(params);
+  await client.sendCreate(expr);
+  return `Created sequence diagram '${params.title}' with ${params.participants.length} participants and ${params.messages.length} messages [id: ${expr.id}]`;
+}
+
+export async function executeDrawMindMap(
+  client: IGatewayClient,
+  params: DrawMindMapParams,
+): Promise<string> {
+  const expr = buildMindMap(params);
+  await client.sendCreate(expr);
+  return `Created mind map '${params.centralTopic}' with ${params.branches.length} branches [id: ${expr.id}]`;
+}
+
+export async function executeDrawReasoningChain(
+  client: IGatewayClient,
+  params: DrawReasoningChainParams,
+): Promise<string> {
+  const expr = buildReasoningChain(params);
+  await client.sendCreate(expr);
+  return `Created reasoning chain '${params.question}' with ${params.steps.length} steps [id: ${expr.id}]`;
+}
+
+export async function executeDrawWireframe(
+  client: IGatewayClient,
+  params: DrawWireframeParams,
+): Promise<string> {
+  const expr = buildWireframe(params);
+  await client.sendCreate(expr);
+  return `Created wireframe '${params.title}' (${params.screenSize.width}×${params.screenSize.height}) with ${params.components.length} components [id: ${expr.id}]`;
+}
+
+export async function executeDrawRoadmap(
+  client: IGatewayClient,
+  params: DrawRoadmapParams,
+): Promise<string> {
+  const expr = buildRoadmap(params);
+  await client.sendCreate(expr);
+  const totalItems = params.phases.reduce((sum, p) => sum + p.items.length, 0);
+  return `Created roadmap '${params.title}' with ${params.phases.length} phases and ${totalItems} items [id: ${expr.id}]`;
+}
+
+export async function executeDrawKanban(
+  client: IGatewayClient,
+  params: DrawKanbanParams,
+): Promise<string> {
+  const expr = buildKanban(params);
+  await client.sendCreate(expr);
+  const totalCards = params.columns.reduce((sum, c) => sum + c.cards.length, 0);
+  return `Created kanban board '${params.title}' with ${params.columns.length} columns and ${totalCards} cards [id: ${expr.id}]`;
+}

--- a/packages/mcp-server/src/tools/managementTools.ts
+++ b/packages/mcp-server/src/tools/managementTools.ts
@@ -1,0 +1,161 @@
+/**
+ * Canvas management tools for the MCP server.
+ *
+ * These tools provide state inspection and mutation capabilities:
+ * get canvas state, clear all expressions, and morph expression kinds.
+ *
+ * @module
+ */
+
+import type { VisualExpression, ExpressionKind } from '@infinicanvas/protocol';
+import type { IGatewayClient } from '../gatewayClient.js';
+
+// ── Tool parameter types ───────────────────────────────────
+
+export interface MorphParams {
+  elementId: string;
+  toKind: ExpressionKind;
+}
+
+// ── Tool implementations ───────────────────────────────────
+
+/** Format canvas state into a readable summary. */
+export function formatCanvasState(expressions: VisualExpression[]): string {
+  if (expressions.length === 0) {
+    return 'Canvas is empty — no expressions on the canvas.';
+  }
+
+  const lines = [`Canvas has ${expressions.length} expression(s):\n`];
+
+  for (const expr of expressions) {
+    const label = getExpressionLabel(expr);
+    const labelStr = label ? ` — "${label}"` : '';
+    lines.push(
+      `  • [${expr.id}] ${expr.kind}${labelStr} at (${expr.position.x}, ${expr.position.y}) size ${expr.size.width}×${expr.size.height}`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+/** Extract a human-readable label from an expression's data. */
+function getExpressionLabel(expr: VisualExpression): string | undefined {
+  const data = expr.data;
+
+  switch (data.kind) {
+    case 'rectangle':
+    case 'ellipse':
+    case 'diamond':
+      return data.label;
+    case 'text':
+      return data.text.length > 50 ? data.text.slice(0, 50) + '…' : data.text;
+    case 'sticky-note':
+      return data.text.length > 50 ? data.text.slice(0, 50) + '…' : data.text;
+    case 'flowchart':
+    case 'wireframe':
+    case 'roadmap':
+    case 'kanban':
+      return data.title;
+    case 'sequence-diagram':
+      return data.title;
+    case 'mind-map':
+      return data.centralTopic;
+    case 'reasoning-chain':
+      return data.question.length > 50 ? data.question.slice(0, 50) + '…' : data.question;
+    case 'comment':
+    case 'callout':
+      return data.text.length > 50 ? data.text.slice(0, 50) + '…' : data.text;
+    case 'highlight':
+      return `${data.targetExpressionIds.length} elements`;
+    case 'marker':
+      return data.label;
+    default:
+      return undefined;
+  }
+}
+
+// ── Tool executors ─────────────────────────────────────────
+
+/** Get the current canvas state as a formatted summary. */
+export async function executeGetState(
+  client: IGatewayClient,
+): Promise<string> {
+  const expressions = client.getState();
+  return formatCanvasState(expressions);
+}
+
+/** Clear all expressions from the canvas. */
+export async function executeClear(
+  client: IGatewayClient,
+): Promise<string> {
+  const expressions = client.getState();
+
+  if (expressions.length === 0) {
+    return 'Canvas is already empty.';
+  }
+
+  const ids = expressions.map((e) => e.id);
+  await client.sendDelete(ids);
+  return `Cleared canvas — removed ${ids.length} expression(s).`;
+}
+
+/** Morph an expression to a different visual kind. */
+export async function executeMorph(
+  client: IGatewayClient,
+  params: MorphParams,
+): Promise<string> {
+  const expressions = client.getState();
+  const target = expressions.find((e) => e.id === params.elementId);
+
+  if (!target) {
+    throw new Error(`Expression '${params.elementId}' not found on canvas`);
+  }
+
+  if (target.kind === params.toKind) {
+    return `Expression '${params.elementId}' is already a ${params.toKind}.`;
+  }
+
+  // Create minimal data for the new kind
+  const newData = createMinimalData(params.toKind, target);
+
+  await client.sendMorph(
+    params.elementId,
+    target.kind,
+    params.toKind,
+    newData,
+  );
+
+  return `Morphed expression '${params.elementId}' from ${target.kind} to ${params.toKind}.`;
+}
+
+/** Create minimal valid data for a given expression kind, preserving label if possible. */
+function createMinimalData(
+  kind: ExpressionKind,
+  source: VisualExpression,
+): VisualExpression['data'] {
+  // Try to preserve the label from the source
+  const label = getExpressionLabel(source);
+
+  switch (kind) {
+    case 'rectangle':
+      return { kind: 'rectangle', label };
+    case 'ellipse':
+      return { kind: 'ellipse', label };
+    case 'diamond':
+      return { kind: 'diamond', label };
+    case 'text':
+      return {
+        kind: 'text',
+        text: label ?? '',
+        fontSize: 16,
+        fontFamily: 'sans-serif',
+        textAlign: 'left',
+      };
+    case 'sticky-note':
+      return { kind: 'sticky-note', text: label ?? '', color: '#FFEB3B' };
+    default:
+      // For complex kinds, we can't create meaningful minimal data
+      // Return a rectangle as a safe fallback
+      return { kind: 'rectangle', label };
+  }
+}

--- a/packages/mcp-server/src/tools/primitiveTools.ts
+++ b/packages/mcp-server/src/tools/primitiveTools.ts
@@ -1,0 +1,293 @@
+/**
+ * Primitive expression tools for the MCP server.
+ *
+ * These tools create basic visual elements on the canvas:
+ * rectangles, ellipses, lines, arrows, text, and sticky notes.
+ *
+ * @module
+ */
+
+import { nanoid } from 'nanoid';
+import type {
+  VisualExpression,
+  ExpressionStyle,
+  RectangleData,
+  EllipseData,
+  LineData,
+  ArrowData,
+  TextData,
+  StickyNoteData,
+} from '@infinicanvas/protocol';
+import { DEFAULT_STYLE, DEFAULT_TEXT, MCP_AUTHOR, randomStickyColor } from '../defaults.js';
+import type { IGatewayClient } from '../gatewayClient.js';
+
+// ── Helper to build a VisualExpression ─────────────────────
+
+function buildExpression(
+  kind: VisualExpression['kind'],
+  position: { x: number; y: number },
+  size: { width: number; height: number },
+  data: VisualExpression['data'],
+  styleOverrides?: Partial<ExpressionStyle>,
+): VisualExpression {
+  const now = Date.now();
+  return {
+    id: nanoid(),
+    kind,
+    position,
+    size,
+    angle: 0,
+    style: { ...DEFAULT_STYLE, ...styleOverrides },
+    meta: {
+      author: MCP_AUTHOR,
+      createdAt: now,
+      updatedAt: now,
+      tags: [],
+      locked: false,
+    },
+    data,
+  };
+}
+
+// ── Tool parameter types ───────────────────────────────────
+
+export interface DrawRectangleParams {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  label?: string;
+  strokeColor?: string;
+  backgroundColor?: string;
+  fillStyle?: ExpressionStyle['fillStyle'];
+}
+
+export interface DrawEllipseParams {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  label?: string;
+}
+
+export interface DrawLineParams {
+  points: [number, number][];
+}
+
+export interface DrawArrowParams {
+  points: [number, number][];
+  label?: string;
+}
+
+export interface DrawTextParams {
+  x: number;
+  y: number;
+  text: string;
+  fontSize?: number;
+  fontFamily?: string;
+}
+
+export interface AddStickyNoteParams {
+  x: number;
+  y: number;
+  text: string;
+  color?: string;
+}
+
+// ── Tool implementations ───────────────────────────────────
+
+/** Create a rectangle expression on the canvas. */
+export function buildRectangle(params: DrawRectangleParams): VisualExpression {
+  const data: RectangleData = {
+    kind: 'rectangle',
+    label: params.label,
+  };
+
+  const styleOverrides: Partial<ExpressionStyle> = {};
+  if (params.strokeColor) styleOverrides.strokeColor = params.strokeColor;
+  if (params.backgroundColor) styleOverrides.backgroundColor = params.backgroundColor;
+  if (params.fillStyle) styleOverrides.fillStyle = params.fillStyle;
+
+  return buildExpression(
+    'rectangle',
+    { x: params.x, y: params.y },
+    { width: params.width, height: params.height },
+    data,
+    styleOverrides,
+  );
+}
+
+/** Create an ellipse expression on the canvas. */
+export function buildEllipse(params: DrawEllipseParams): VisualExpression {
+  const data: EllipseData = {
+    kind: 'ellipse',
+    label: params.label,
+  };
+
+  return buildExpression(
+    'ellipse',
+    { x: params.x, y: params.y },
+    { width: params.width, height: params.height },
+    data,
+  );
+}
+
+/** Create a line expression on the canvas. */
+export function buildLine(params: DrawLineParams): VisualExpression {
+  if (params.points.length < 2) {
+    throw new Error('Line requires at least 2 points');
+  }
+
+  const data: LineData = {
+    kind: 'line',
+    points: params.points,
+  };
+
+  // Compute bounding box from points
+  const xs = params.points.map((p) => p[0]);
+  const ys = params.points.map((p) => p[1]);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+
+  return buildExpression(
+    'line',
+    { x: minX, y: minY },
+    { width: Math.max(maxX - minX, 1), height: Math.max(maxY - minY, 1) },
+    data,
+  );
+}
+
+/** Create an arrow expression on the canvas. */
+export function buildArrow(params: DrawArrowParams): VisualExpression {
+  if (params.points.length < 2) {
+    throw new Error('Arrow requires at least 2 points');
+  }
+
+  const data: ArrowData = {
+    kind: 'arrow',
+    points: params.points,
+    endArrowhead: true,
+  };
+
+  // Compute bounding box from points
+  const xs = params.points.map((p) => p[0]);
+  const ys = params.points.map((p) => p[1]);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+
+  return buildExpression(
+    'arrow',
+    { x: minX, y: minY },
+    { width: Math.max(maxX - minX, 1), height: Math.max(maxY - minY, 1) },
+    data,
+  );
+}
+
+/** Create a text expression on the canvas. */
+export function buildText(params: DrawTextParams): VisualExpression {
+  const data: TextData = {
+    kind: 'text',
+    text: params.text,
+    fontSize: params.fontSize ?? DEFAULT_TEXT.fontSize,
+    fontFamily: params.fontFamily ?? DEFAULT_TEXT.fontFamily,
+    textAlign: DEFAULT_TEXT.textAlign,
+  };
+
+  // Estimate text size based on content
+  const fontSize = params.fontSize ?? DEFAULT_TEXT.fontSize;
+  const estimatedWidth = Math.max(params.text.length * fontSize * 0.6, 100);
+  const estimatedHeight = fontSize * 1.5;
+
+  return buildExpression(
+    'text',
+    { x: params.x, y: params.y },
+    { width: estimatedWidth, height: estimatedHeight },
+    data,
+    { fontSize, fontFamily: params.fontFamily ?? DEFAULT_TEXT.fontFamily },
+  );
+}
+
+/** Create a sticky note expression on the canvas. */
+export function buildStickyNote(params: AddStickyNoteParams): VisualExpression {
+  const color = params.color ?? randomStickyColor();
+
+  const data: StickyNoteData = {
+    kind: 'sticky-note',
+    text: params.text,
+    color,
+  };
+
+  return buildExpression(
+    'sticky-note',
+    { x: params.x, y: params.y },
+    { width: 200, height: 200 },
+    data,
+    { backgroundColor: color, fillStyle: 'solid' },
+  );
+}
+
+// ── Tool executors (send to gateway) ───────────────────────
+
+/** Execute a primitive tool: build expression and send to gateway. */
+export async function executeDrawRectangle(
+  client: IGatewayClient,
+  params: DrawRectangleParams,
+): Promise<string> {
+  const expr = buildRectangle(params);
+  await client.sendCreate(expr);
+  const label = params.label ? ` '${params.label}'` : '';
+  return `Created rectangle${label} (${params.width}×${params.height}) at (${params.x}, ${params.y}) [id: ${expr.id}]`;
+}
+
+export async function executeDrawEllipse(
+  client: IGatewayClient,
+  params: DrawEllipseParams,
+): Promise<string> {
+  const expr = buildEllipse(params);
+  await client.sendCreate(expr);
+  const label = params.label ? ` '${params.label}'` : '';
+  return `Created ellipse${label} (${params.width}×${params.height}) at (${params.x}, ${params.y}) [id: ${expr.id}]`;
+}
+
+export async function executeDrawLine(
+  client: IGatewayClient,
+  params: DrawLineParams,
+): Promise<string> {
+  const expr = buildLine(params);
+  await client.sendCreate(expr);
+  return `Created line with ${params.points.length} points [id: ${expr.id}]`;
+}
+
+export async function executeDrawArrow(
+  client: IGatewayClient,
+  params: DrawArrowParams,
+): Promise<string> {
+  const expr = buildArrow(params);
+  await client.sendCreate(expr);
+  const label = params.label ? ` '${params.label}'` : '';
+  return `Created arrow${label} with ${params.points.length} points [id: ${expr.id}]`;
+}
+
+export async function executeDrawText(
+  client: IGatewayClient,
+  params: DrawTextParams,
+): Promise<string> {
+  const expr = buildText(params);
+  await client.sendCreate(expr);
+  const preview = params.text.length > 40 ? params.text.slice(0, 40) + '…' : params.text;
+  return `Created text '${preview}' at (${params.x}, ${params.y}) [id: ${expr.id}]`;
+}
+
+export async function executeAddStickyNote(
+  client: IGatewayClient,
+  params: AddStickyNoteParams,
+): Promise<string> {
+  const expr = buildStickyNote(params);
+  await client.sendCreate(expr);
+  const preview = params.text.length > 40 ? params.text.slice(0, 40) + '…' : params.text;
+  return `Created sticky note '${preview}' at (${params.x}, ${params.y}) [id: ${expr.id}]`;
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/__tests__/**", "dist"]
+}

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/__tests__/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## 🎯 The key integration piece

20 MCP tools exposing the canvas to any AI model:
- **Primitives:** rectangle, ellipse, line, arrow, text, sticky note
- **Composites:** flowchart, sequence diagram, mind map, reasoning chain, wireframe, roadmap, kanban
- **Annotations:** annotate, highlight, comment
- **Management:** get state, clear, morph

Uses stdio transport (MCP standard). Connects to gateway via WebSocket. Any AI with tool-calling can now draw on the canvas.

85 new tests, 528 total. Closes #31