### PR TITLE
feat(engine,app): Drawing tools & toolbar — Issue #6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3065,6 +3065,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -4488,6 +4497,7 @@
       "dependencies": {
         "@infinicanvas/engine": "*",
         "@infinicanvas/protocol": "*",
+        "lucide-react": "^0.577.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@infinicanvas/engine": "*",
     "@infinicanvas/protocol": "*",
+    "lucide-react": "^0.577.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2,18 +2,21 @@
  * Root application component.
  *
  * Renders the Canvas component from @infinicanvas/engine
- * with the AgentSidebar overlay for connected AI agents.
+ * with the Toolbar for drawing tools and AgentSidebar overlay
+ * for connected AI agents.
  *
  * @module
  */
 
 import { Canvas } from '@infinicanvas/engine';
+import { Toolbar } from './components/toolbar/Toolbar.js';
 import { AgentSidebar } from './components/sidebar/AgentSidebar.js';
 
 export function App() {
   return (
     <>
       <Canvas />
+      <Toolbar />
       <AgentSidebar />
     </>
   );

--- a/packages/app/src/__tests__/Toolbar.test.tsx
+++ b/packages/app/src/__tests__/Toolbar.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for Toolbar component.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Verifies toolbar renders, tool buttons work, and active tool
+ * is visually highlighted.
+ *
+ * @vitest-environment jsdom
+ * @module
+ */
+
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Toolbar } from '../components/toolbar/Toolbar.js';
+import { useCanvasStore } from '@infinicanvas/engine';
+
+// ── Test helpers ───────────────────────────────────────────
+
+function resetStore() {
+  useCanvasStore.setState({
+    activeTool: 'select',
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────
+
+describe('Toolbar', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders all 8 tool buttons [AC3]', () => {
+    const { container } = render(<Toolbar />);
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(8);
+  });
+
+  it('renders with role="toolbar" for accessibility', () => {
+    const { container } = render(<Toolbar />);
+    const toolbar = container.querySelector('[role="toolbar"]');
+    expect(toolbar).not.toBeNull();
+  });
+
+  it('highlights the active tool (Select by default) [AC3]', () => {
+    const { container } = render(<Toolbar />);
+    const selectButton = container.querySelector('[data-tool="select"]');
+    expect(selectButton).not.toBeNull();
+    expect(selectButton!.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('sets activeTool in store when clicking a tool [AC3]', () => {
+    const { container } = render(<Toolbar />);
+
+    const rectButton = container.querySelector('[data-tool="rectangle"]');
+    expect(rectButton).not.toBeNull();
+
+    fireEvent.click(rectButton!);
+
+    expect(useCanvasStore.getState().activeTool).toBe('rectangle');
+  });
+
+  it('updates active highlighting when tool changes [AC3]', () => {
+    const { container, rerender } = render(<Toolbar />);
+
+    fireEvent.click(container.querySelector('[data-tool="ellipse"]')!);
+
+    // Re-render to pick up state change
+    rerender(<Toolbar />);
+
+    const ellipseBtn = container.querySelector('[data-tool="ellipse"]');
+    const selectBtn = container.querySelector('[data-tool="select"]');
+
+    expect(ellipseBtn!.getAttribute('aria-pressed')).toBe('true');
+    expect(selectBtn!.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('renders all expected tool types', () => {
+    const { container } = render(<Toolbar />);
+
+    const toolTypes = ['select', 'rectangle', 'ellipse', 'diamond', 'line', 'arrow', 'freehand', 'text'];
+    for (const type of toolTypes) {
+      const btn = container.querySelector(`[data-tool="${type}"]`);
+      expect(btn, `Button for tool "${type}" should exist`).not.toBeNull();
+    }
+  });
+
+  it('each button has an accessible label', () => {
+    const { container } = render(<Toolbar />);
+    const buttons = container.querySelectorAll('button');
+
+    for (const button of buttons) {
+      const label = button.getAttribute('aria-label');
+      expect(label, 'Each button should have an aria-label').toBeTruthy();
+    }
+  });
+});

--- a/packages/app/src/components/toolbar/Toolbar.tsx
+++ b/packages/app/src/components/toolbar/Toolbar.tsx
@@ -1,0 +1,110 @@
+/**
+ * Toolbar — vertical tool selection bar on the left side of the canvas.
+ *
+ * Renders icon buttons for each drawing tool. Clicking a tool sets
+ * `activeTool` in the canvas store. The active tool is visually
+ * highlighted with a blue background.
+ *
+ * Uses lucide-react for icons.
+ *
+ * @module
+ */
+
+import { useCanvasStore } from '@infinicanvas/engine';
+import type { ToolType } from '@infinicanvas/engine';
+import {
+  MousePointer2,
+  Square,
+  Circle,
+  Diamond,
+  Minus,
+  ArrowRight,
+  Pencil,
+  Type,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+/** Tool definition for rendering toolbar buttons. */
+interface ToolDefinition {
+  type: ToolType;
+  icon: LucideIcon;
+  label: string;
+}
+
+/** Ordered list of tools displayed in the toolbar. */
+const TOOLS: ToolDefinition[] = [
+  { type: 'select', icon: MousePointer2, label: 'Select (V)' },
+  { type: 'rectangle', icon: Square, label: 'Rectangle (R)' },
+  { type: 'ellipse', icon: Circle, label: 'Ellipse (O)' },
+  { type: 'diamond', icon: Diamond, label: 'Diamond (D)' },
+  { type: 'line', icon: Minus, label: 'Line (L)' },
+  { type: 'arrow', icon: ArrowRight, label: 'Arrow (A)' },
+  { type: 'freehand', icon: Pencil, label: 'Pen (P)' },
+  { type: 'text', icon: Type, label: 'Text (T)' },
+];
+
+/** Toolbar button size in pixels. */
+const BUTTON_SIZE = 36;
+
+/** Icon size in pixels. */
+const ICON_SIZE = 18;
+
+/** Toolbar component — renders a vertical bar on the left side. */
+export function Toolbar() {
+  const activeTool = useCanvasStore((s) => s.activeTool);
+  const setActiveTool = useCanvasStore((s) => s.setActiveTool);
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Drawing tools"
+      style={{
+        position: 'fixed',
+        left: 12,
+        top: '50%',
+        transform: 'translateY(-50%)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        padding: 6,
+        backgroundColor: '#ffffff',
+        borderRadius: 10,
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.12)',
+        border: '1px solid #e0e0e0',
+        zIndex: 20,
+      }}
+    >
+      {TOOLS.map((tool) => {
+        const isActive = activeTool === tool.type;
+        const Icon = tool.icon;
+
+        return (
+          <button
+            key={tool.type}
+            type="button"
+            title={tool.label}
+            aria-label={tool.label}
+            aria-pressed={isActive}
+            data-tool={tool.type}
+            onClick={() => setActiveTool(tool.type)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: BUTTON_SIZE,
+              height: BUTTON_SIZE,
+              border: 'none',
+              borderRadius: 6,
+              cursor: 'pointer',
+              backgroundColor: isActive ? '#4A90D9' : 'transparent',
+              color: isActive ? '#ffffff' : '#333333',
+              transition: 'background-color 0.15s, color 0.15s',
+            }}
+          >
+            <Icon size={ICON_SIZE} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/engine/src/__tests__/drawingTools.test.ts
+++ b/packages/engine/src/__tests__/drawingTools.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Unit tests for drawing tool handlers.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Each test corresponds to acceptance criteria from Issue #6.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useCanvasStore } from '../store/canvasStore.js';
+import { RectangleTool } from '../tools/RectangleTool.js';
+import { EllipseTool } from '../tools/EllipseTool.js';
+import { DiamondTool } from '../tools/DiamondTool.js';
+import { LineTool } from '../tools/LineTool.js';
+import { ArrowTool } from '../tools/ArrowTool.js';
+import { FreehandTool } from '../tools/FreehandTool.js';
+import { TextTool } from '../tools/TextTool.js';
+import type { ToolHandler, DrawPreview } from '../tools/BaseTool.js';
+
+// ── Test helpers ───────────────────────────────────────────
+
+/** Stub PointerEvent for testing (jsdom doesn't fully support it). */
+function stubPointerEvent(overrides: Partial<PointerEvent> = {}): PointerEvent {
+  return { pressure: 0.5, ...overrides } as PointerEvent;
+}
+
+/** Reset store to clean state before each test. */
+function resetStore() {
+  useCanvasStore.setState({
+    expressions: {},
+    expressionOrder: [],
+    selectedIds: new Set<string>(),
+    activeTool: 'select',
+    camera: { x: 0, y: 0, zoom: 1 },
+    operationLog: [],
+    canUndo: false,
+    canRedo: false,
+  });
+  useCanvasStore.getState().clearHistory();
+}
+
+/** Simulate a full draw gesture: pointerdown → pointermove → pointerup */
+function simulateDraw(
+  tool: ToolHandler,
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+  ev?: Partial<PointerEvent>,
+) {
+  tool.onPointerDown(start.x, start.y, stubPointerEvent(ev));
+  tool.onPointerMove(end.x, end.y, stubPointerEvent(ev));
+  tool.onPointerUp(end.x, end.y, stubPointerEvent(ev));
+}
+
+/** Get the number of expressions in the store. */
+function expressionCount(): number {
+  return Object.keys(useCanvasStore.getState().expressions).length;
+}
+
+/** Get the first expression from the store. */
+function firstExpression() {
+  const exprs = useCanvasStore.getState().expressions;
+  const id = useCanvasStore.getState().expressionOrder[0];
+  return id ? exprs[id] : undefined;
+}
+
+// ── RectangleTool ────────────────────────────────────────────
+
+describe('RectangleTool', () => {
+  let tool: RectangleTool;
+
+  beforeEach(() => {
+    resetStore();
+    tool = new RectangleTool();
+  });
+
+  it('creates a rectangle expression on valid draw (>10×10) [AC1]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 200, y: 200 });
+
+    expect(expressionCount()).toBe(1);
+    const expr = firstExpression()!;
+    expect(expr.kind).toBe('rectangle');
+    expect(expr.data.kind).toBe('rectangle');
+    expect(expr.position.x).toBe(100);
+    expect(expr.position.y).toBe(100);
+    expect(expr.size.width).toBe(100);
+    expect(expr.size.height).toBe(100);
+  });
+
+  it('does not create expression when draw is too small (<10×10) [AC2]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 105, y: 105 });
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('shows dashed preview during drag [AC4]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    expect(tool.getPreview()).toBeNull();
+
+    tool.onPointerMove(200, 200, stubPointerEvent());
+    const preview = tool.getPreview();
+    expect(preview).not.toBeNull();
+    expect(preview!.kind).toBe('rectangle');
+    expect(preview!.x).toBe(100);
+    expect(preview!.y).toBe(100);
+    expect(preview!.width).toBe(100);
+    expect(preview!.height).toBe(100);
+  });
+
+  it('handles negative drag direction (bottom-right to top-left)', () => {
+    simulateDraw(tool, { x: 200, y: 200 }, { x: 100, y: 100 });
+
+    expect(expressionCount()).toBe(1);
+    const expr = firstExpression()!;
+    expect(expr.position.x).toBe(100);
+    expect(expr.position.y).toBe(100);
+    expect(expr.size.width).toBe(100);
+    expect(expr.size.height).toBe(100);
+  });
+
+  it('auto-switches to Select tool after creation [AC10]', () => {
+    useCanvasStore.getState().setActiveTool('rectangle');
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 200, y: 200 });
+    expect(useCanvasStore.getState().activeTool).toBe('select');
+  });
+
+  it('cancel clears preview and does not create expression [AC12]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(200, 200, stubPointerEvent());
+    expect(tool.getPreview()).not.toBeNull();
+
+    tool.onCancel();
+    expect(tool.getPreview()).toBeNull();
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('sets human author on created expression [AC11]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 200, y: 200 });
+    const expr = firstExpression()!;
+    expect(expr.meta.author.type).toBe('human');
+    expect(expr.meta.author.id).toBe('local-user');
+  });
+
+  it('uses DEFAULT_EXPRESSION_STYLE [AC11]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 200, y: 200 });
+    const expr = firstExpression()!;
+    expect(expr.style.strokeColor).toBe('#1e1e1e');
+    expect(expr.style.fillStyle).toBe('hachure');
+    expect(expr.style.opacity).toBe(1);
+  });
+
+  it('selects the newly created expression', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 200, y: 200 });
+    const expr = firstExpression()!;
+    const { selectedIds } = useCanvasStore.getState();
+    expect(selectedIds.has(expr.id)).toBe(true);
+  });
+});
+
+// ── EllipseTool ──────────────────────────────────────────────
+
+describe('EllipseTool', () => {
+  let tool: EllipseTool;
+
+  beforeEach(() => {
+    resetStore();
+    tool = new EllipseTool();
+  });
+
+  it('creates an ellipse expression on valid draw [AC1]', () => {
+    simulateDraw(tool, { x: 50, y: 50 }, { x: 200, y: 150 });
+
+    expect(expressionCount()).toBe(1);
+    const expr = firstExpression()!;
+    expect(expr.kind).toBe('ellipse');
+    expect(expr.data.kind).toBe('ellipse');
+  });
+
+  it('does not create expression when draw is too small [AC2]', () => {
+    simulateDraw(tool, { x: 50, y: 50 }, { x: 55, y: 55 });
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('shows preview with kind ellipse during drag [AC4]', () => {
+    tool.onPointerDown(50, 50, stubPointerEvent());
+    tool.onPointerMove(200, 150, stubPointerEvent());
+
+    const preview = tool.getPreview();
+    expect(preview).not.toBeNull();
+    expect(preview!.kind).toBe('ellipse');
+  });
+
+  it('auto-switches to Select after creation [AC10]', () => {
+    useCanvasStore.getState().setActiveTool('ellipse');
+    simulateDraw(tool, { x: 50, y: 50 }, { x: 200, y: 150 });
+    expect(useCanvasStore.getState().activeTool).toBe('select');
+  });
+});
+
+// ── DiamondTool ──────────────────────────────────────────────
+
+describe('DiamondTool', () => {
+  let tool: DiamondTool;
+
+  beforeEach(() => {
+    resetStore();
+    tool = new DiamondTool();
+  });
+
+  it('creates a diamond expression on valid draw [AC1]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 250, y: 250 });
+
+    expect(expressionCount()).toBe(1);
+    const expr = firstExpression()!;
+    expect(expr.kind).toBe('diamond');
+    expect(expr.data.kind).toBe('diamond');
+  });
+
+  it('does not create expression when draw is too small [AC2]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 108, y: 108 });
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('shows preview with kind diamond during drag [AC4]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(250, 250, stubPointerEvent());
+
+    const preview = tool.getPreview();
+    expect(preview).not.toBeNull();
+    expect(preview!.kind).toBe('diamond');
+  });
+
+  it('auto-switches to Select after creation [AC10]', () => {
+    useCanvasStore.getState().setActiveTool('diamond');
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 250, y: 250 });
+    expect(useCanvasStore.getState().activeTool).toBe('select');
+  });
+});
+
+// ── LineTool ─────────────────────────────────────────────────
+
+describe('LineTool', () => {
+  let tool: LineTool;
+
+  beforeEach(() => {
+    resetStore();
+    tool = new LineTool();
+  });
+
+  it('creates a line expression on valid draw (length >5px) [AC5]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 200, y: 200 });
+
+    expect(expressionCount()).toBe(1);
+    const expr = firstExpression()!;
+    expect(expr.kind).toBe('line');
+    expect(expr.data.kind).toBe('line');
+    if (expr.data.kind === 'line') {
+      expect(expr.data.points.length).toBeGreaterThanOrEqual(2);
+      expect(expr.data.points[0]).toEqual([100, 100]);
+      expect(expr.data.points[expr.data.points.length - 1]).toEqual([200, 200]);
+    }
+  });
+
+  it('does not create line when too short (<5px) [AC5]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 103, y: 103 });
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('shows line preview during drag [AC4]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(200, 200, stubPointerEvent());
+
+    const preview = tool.getPreview();
+    expect(preview).not.toBeNull();
+    expect(preview!.kind).toBe('line');
+    expect(preview!.points).toBeDefined();
+    expect(preview!.points!.length).toBe(2);
+  });
+
+  it('auto-switches to Select after creation [AC10]', () => {
+    useCanvasStore.getState().setActiveTool('line');
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 200, y: 200 });
+    expect(useCanvasStore.getState().activeTool).toBe('select');
+  });
+
+  it('computes bounding box from line points', () => {
+    simulateDraw(tool, { x: 100, y: 50 }, { x: 300, y: 250 });
+
+    const expr = firstExpression()!;
+    expect(expr.position.x).toBe(100);
+    expect(expr.position.y).toBe(50);
+    expect(expr.size.width).toBe(200);
+    expect(expr.size.height).toBe(200);
+  });
+});
+
+// ── ArrowTool ────────────────────────────────────────────────
+
+describe('ArrowTool', () => {
+  let tool: ArrowTool;
+
+  beforeEach(() => {
+    resetStore();
+    tool = new ArrowTool();
+  });
+
+  it('creates an arrow expression with endArrowhead: true [AC6]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 300, y: 200 });
+
+    expect(expressionCount()).toBe(1);
+    const expr = firstExpression()!;
+    expect(expr.kind).toBe('arrow');
+    expect(expr.data.kind).toBe('arrow');
+    if (expr.data.kind === 'arrow') {
+      expect(expr.data.endArrowhead).toBe(true);
+      expect(expr.data.points.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('does not create arrow when too short (<5px) [AC6]', () => {
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 102, y: 102 });
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('shows arrow preview during drag [AC4]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(300, 200, stubPointerEvent());
+
+    const preview = tool.getPreview();
+    expect(preview).not.toBeNull();
+    expect(preview!.kind).toBe('arrow');
+  });
+
+  it('auto-switches to Select after creation [AC10]', () => {
+    useCanvasStore.getState().setActiveTool('arrow');
+    simulateDraw(tool, { x: 100, y: 100 }, { x: 300, y: 200 });
+    expect(useCanvasStore.getState().activeTool).toBe('select');
+  });
+});
+
+// ── FreehandTool ─────────────────────────────────────────────
+
+describe('FreehandTool', () => {
+  let tool: FreehandTool;
+
+  beforeEach(() => {
+    resetStore();
+    tool = new FreehandTool();
+  });
+
+  it('creates a freehand expression capturing pressure points [AC7]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent({ pressure: 0.5 }));
+    tool.onPointerMove(120, 130, stubPointerEvent({ pressure: 0.6 }));
+    tool.onPointerMove(140, 160, stubPointerEvent({ pressure: 0.7 }));
+    tool.onPointerUp(160, 190, stubPointerEvent({ pressure: 0.8 }));
+
+    expect(expressionCount()).toBe(1);
+    const expr = firstExpression()!;
+    expect(expr.kind).toBe('freehand');
+    expect(expr.data.kind).toBe('freehand');
+    if (expr.data.kind === 'freehand') {
+      expect(expr.data.points.length).toBeGreaterThanOrEqual(2);
+      // Points should include pressure as 3rd element
+      expect(expr.data.points[0]!.length).toBe(3);
+    }
+  });
+
+  it('does not create freehand with fewer than 2 points [AC7]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerUp(100, 100, stubPointerEvent());
+
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('does NOT auto-switch to Select (stays in freehand) [AC10]', () => {
+    useCanvasStore.getState().setActiveTool('freehand');
+
+    tool.onPointerDown(100, 100, stubPointerEvent({ pressure: 0.5 }));
+    tool.onPointerMove(120, 130, stubPointerEvent({ pressure: 0.6 }));
+    tool.onPointerMove(140, 160, stubPointerEvent({ pressure: 0.7 }));
+    tool.onPointerUp(160, 190, stubPointerEvent({ pressure: 0.8 }));
+
+    expect(useCanvasStore.getState().activeTool).toBe('freehand');
+  });
+
+  it('shows freehand preview during draw [AC4]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent({ pressure: 0.5 }));
+    tool.onPointerMove(120, 130, stubPointerEvent({ pressure: 0.6 }));
+
+    const preview = tool.getPreview();
+    expect(preview).not.toBeNull();
+    expect(preview!.kind).toBe('freehand');
+    expect(preview!.points).toBeDefined();
+    expect(preview!.points!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('computes bounding box from freehand points', () => {
+    tool.onPointerDown(100, 200, stubPointerEvent({ pressure: 0.5 }));
+    tool.onPointerMove(150, 100, stubPointerEvent({ pressure: 0.6 }));
+    tool.onPointerMove(200, 300, stubPointerEvent({ pressure: 0.7 }));
+    tool.onPointerUp(250, 250, stubPointerEvent({ pressure: 0.8 }));
+
+    const expr = firstExpression()!;
+    expect(expr.position.x).toBe(100);
+    expect(expr.position.y).toBe(100);
+    expect(expr.size.width).toBe(150);
+    expect(expr.size.height).toBe(200);
+  });
+});
+
+// ── TextTool ─────────────────────────────────────────────────
+
+describe('TextTool', () => {
+  let tool: TextTool;
+
+  beforeEach(() => {
+    resetStore();
+    tool = new TextTool();
+  });
+
+  it('creates a text expression when commitText is called [AC8]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerUp(100, 100, stubPointerEvent());
+
+    // Simulate text input commitment
+    tool.commitText('Hello World');
+
+    expect(expressionCount()).toBe(1);
+    const expr = firstExpression()!;
+    expect(expr.kind).toBe('text');
+    expect(expr.data.kind).toBe('text');
+    if (expr.data.kind === 'text') {
+      expect(expr.data.text).toBe('Hello World');
+      expect(expr.data.fontSize).toBe(16);
+      expect(expr.data.fontFamily).toBe('sans-serif');
+      expect(expr.data.textAlign).toBe('left');
+    }
+  });
+
+  it('does not create text expression when text is empty [AC8]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerUp(100, 100, stubPointerEvent());
+    tool.commitText('');
+
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('auto-switches to Select after text creation [AC10]', () => {
+    useCanvasStore.getState().setActiveTool('text');
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerUp(100, 100, stubPointerEvent());
+    tool.commitText('Hello');
+
+    expect(useCanvasStore.getState().activeTool).toBe('select');
+  });
+
+  it('cancel clears text input position [AC12]', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerUp(100, 100, stubPointerEvent());
+    expect(tool.getInputPosition()).not.toBeNull();
+
+    tool.onCancel();
+    expect(tool.getInputPosition()).toBeNull();
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('returns input position after click [AC8]', () => {
+    tool.onPointerDown(150, 250, stubPointerEvent());
+    tool.onPointerUp(150, 250, stubPointerEvent());
+
+    const pos = tool.getInputPosition();
+    expect(pos).not.toBeNull();
+    expect(pos!.x).toBe(150);
+    expect(pos!.y).toBe(250);
+  });
+});
+
+// ── Cross-cutting concerns ───────────────────────────────────
+
+describe('Tool cancel via ESC', () => {
+  it('cancels rectangle draw on ESC [AC12]', () => {
+    resetStore();
+    const tool = new RectangleTool();
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(200, 200, stubPointerEvent());
+
+    tool.onCancel();
+
+    expect(tool.getPreview()).toBeNull();
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('cancels line draw on ESC [AC12]', () => {
+    resetStore();
+    const tool = new LineTool();
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(200, 200, stubPointerEvent());
+
+    tool.onCancel();
+
+    expect(tool.getPreview()).toBeNull();
+    expect(expressionCount()).toBe(0);
+  });
+
+  it('cancels freehand draw on ESC [AC12]', () => {
+    resetStore();
+    const tool = new FreehandTool();
+    tool.onPointerDown(100, 100, stubPointerEvent({ pressure: 0.5 }));
+    tool.onPointerMove(150, 150, stubPointerEvent({ pressure: 0.6 }));
+
+    tool.onCancel();
+
+    expect(tool.getPreview()).toBeNull();
+    expect(expressionCount()).toBe(0);
+  });
+});

--- a/packages/engine/src/components/Canvas.tsx
+++ b/packages/engine/src/components/Canvas.tsx
@@ -16,8 +16,10 @@ import { ErrorBoundary } from './ErrorBoundary.js';
 import { useCanvasInteraction } from '../hooks/useCanvasInteraction.js';
 import { useSelectionInteraction } from '../hooks/useSelectionInteraction.js';
 import { useManipulationInteraction } from '../hooks/useManipulationInteraction.js';
+import { useDrawingInteraction } from '../hooks/useDrawingInteraction.js';
 import { useUndoRedoShortcuts } from '../hooks/useUndoRedoShortcuts.js';
 import { useCanvasStore } from '../store/canvasStore.js';
+import { worldToScreen } from '../camera.js';
 import { createRenderLoop } from '../renderer/renderLoop.js';
 import type { RenderLoop } from '../renderer/renderLoop.js';
 
@@ -32,11 +34,24 @@ function CanvasInner() {
   const containerRef = useRef<HTMLDivElement>(null);
   const renderLoopRef = useRef<RenderLoop | null>(null);
   const { canvasRef, cursor: canvasCursor } = useCanvasInteraction();
-  const { renderMarquee } = useSelectionInteraction(canvasRef);
+  useSelectionInteraction(canvasRef);
   const { cursor: manipulationCursor } = useManipulationInteraction(canvasRef);
+  const { getDrawPreview, textTool } = useDrawingInteraction(canvasRef);
 
-  // Manipulation cursor takes priority over canvas default
-  const cursor = manipulationCursor !== 'default' ? manipulationCursor : canvasCursor;
+  // Track active tool for cursor and text overlay
+  const activeTool = useCanvasStore((s) => s.activeTool);
+  const camera = useCanvasStore((s) => s.camera);
+
+  // Check text tool input position on each render
+  const textInputPos = textTool.getInputPosition();
+
+  // Manipulation cursor takes priority, then drawing crosshair, then canvas default
+  let cursor = canvasCursor;
+  if (manipulationCursor !== 'default') {
+    cursor = manipulationCursor;
+  } else if (activeTool !== 'select') {
+    cursor = 'crosshair';
+  }
 
   // Register global undo/redo keyboard shortcuts [AC1, AC2]
   useUndoRedoShortcuts();
@@ -92,7 +107,10 @@ function CanvasInner() {
     const selectionProvider = {
       getSelectedIds: () => useCanvasStore.getState().selectedIds,
     };
-    const loop = createRenderLoop(ctx, getCamera, width, height, roughCanvas, expressionProvider, selectionProvider);
+    const drawPreviewProvider = {
+      getDrawPreview,
+    };
+    const loop = createRenderLoop(ctx, getCamera, width, height, roughCanvas, expressionProvider, selectionProvider, drawPreviewProvider);
 
     renderLoopRef.current = loop;
     loop.start();
@@ -141,6 +159,7 @@ function CanvasInner() {
         overflow: 'hidden',
         margin: 0,
         padding: 0,
+        position: 'relative',
       }}
     >
       <canvas
@@ -151,6 +170,20 @@ function CanvasInner() {
           cursor,
         }}
       />
+      {/* Text input overlay for text tool */}
+      {textInputPos && (
+        <TextInputOverlay
+          worldX={textInputPos.x}
+          worldY={textInputPos.y}
+          camera={camera}
+          onCommit={(text) => {
+            textTool.commitText(text);
+          }}
+          onCancel={() => {
+            textTool.onCancel();
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -161,5 +194,64 @@ export function Canvas() {
     <ErrorBoundary>
       <CanvasInner />
     </ErrorBoundary>
+  );
+}
+
+// ── Text Input Overlay ─────────────────────────────────────
+
+interface TextInputOverlayProps {
+  worldX: number;
+  worldY: number;
+  camera: { x: number; y: number; zoom: number };
+  onCommit: (text: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Textarea overlay positioned at a world coordinate for the text tool.
+ *
+ * Enter commits the text, ESC cancels. Auto-focuses on mount.
+ */
+function TextInputOverlay({ worldX, worldY, camera, onCommit, onCancel }: TextInputOverlayProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Convert world position to screen position
+  const screenPos = worldToScreen(worldX, worldY, camera);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      onCommit(textareaRef.current?.value ?? '');
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onCancel();
+    }
+  };
+
+  return (
+    <textarea
+      ref={textareaRef}
+      onKeyDown={handleKeyDown}
+      style={{
+        position: 'absolute',
+        left: `${screenPos.x}px`,
+        top: `${screenPos.y}px`,
+        minWidth: '200px',
+        minHeight: '40px',
+        padding: '4px 8px',
+        border: '2px solid #4A90D9',
+        borderRadius: '4px',
+        outline: 'none',
+        fontSize: '16px',
+        fontFamily: 'sans-serif',
+        background: 'white',
+        resize: 'both',
+        zIndex: 10,
+      }}
+    />
   );
 }

--- a/packages/engine/src/hooks/useDrawingInteraction.ts
+++ b/packages/engine/src/hooks/useDrawingInteraction.ts
@@ -1,0 +1,176 @@
+/**
+ * Drawing interaction hook — wires tool handlers into canvas pointer events.
+ *
+ * When the active tool is not 'select', this hook intercepts pointer events,
+ * converts screen coordinates to world space, and dispatches to the active
+ * tool handler. Also handles ESC key to cancel drawing operations.
+ *
+ * @module
+ */
+
+import { useRef, useEffect, useCallback, useMemo } from 'react';
+import { useCanvasStore } from '../store/canvasStore.js';
+import { screenToWorld } from '../camera.js';
+import { RectangleTool } from '../tools/RectangleTool.js';
+import { EllipseTool } from '../tools/EllipseTool.js';
+import { DiamondTool } from '../tools/DiamondTool.js';
+import { LineTool } from '../tools/LineTool.js';
+import { ArrowTool } from '../tools/ArrowTool.js';
+import { FreehandTool } from '../tools/FreehandTool.js';
+import { TextTool } from '../tools/TextTool.js';
+import type { ToolHandler, DrawPreview } from '../tools/BaseTool.js';
+
+export interface DrawingInteraction {
+  /** Current draw preview for the render loop, or null. */
+  getDrawPreview(): DrawPreview | null;
+  /** Text tool instance for overlay input positioning. */
+  textTool: TextTool;
+}
+
+/**
+ * Hook for drawing tool interactions on the canvas.
+ *
+ * Creates tool handler instances and routes pointer events to the
+ * active tool when in drawing mode (activeTool !== 'select').
+ */
+export function useDrawingInteraction(
+  canvasRef: React.RefObject<HTMLCanvasElement>,
+): DrawingInteraction {
+  // Create stable tool handler instances
+  const toolHandlers = useMemo(() => {
+    const textTool = new TextTool();
+    return {
+      rectangle: new RectangleTool(),
+      ellipse: new EllipseTool(),
+      diamond: new DiamondTool(),
+      line: new LineTool(),
+      arrow: new ArrowTool(),
+      freehand: new FreehandTool(),
+      text: textTool,
+    } as Record<string, ToolHandler>;
+  }, []);
+
+  const textTool = useMemo(() => toolHandlers.text as TextTool, [toolHandlers]);
+
+  /** Get the handler for the currently active tool. */
+  const getActiveHandler = useCallback((): ToolHandler | null => {
+    const { activeTool } = useCanvasStore.getState();
+    if (activeTool === 'select') return null;
+    return toolHandlers[activeTool] ?? null;
+  }, [toolHandlers]);
+
+  // Track which handler was active during the current drag to prevent
+  // handler switching mid-draw
+  const activeDrawHandlerRef = useRef<ToolHandler | null>(null);
+
+  // ── Pointer handlers ───────────────────────────────────────
+
+  const handlePointerDown = useCallback(
+    (e: PointerEvent) => {
+      const handler = getActiveHandler();
+      if (!handler) return;
+
+      // Only react to primary button (left click)
+      if (e.button !== 0) return;
+
+      const { camera } = useCanvasStore.getState();
+      const world = screenToWorld(e.offsetX, e.offsetY, camera);
+
+      // Capture pointer to receive events even when cursor leaves canvas
+      const target = e.currentTarget as Element;
+      target.setPointerCapture(e.pointerId);
+
+      activeDrawHandlerRef.current = handler;
+      handler.onPointerDown(world.x, world.y, e);
+    },
+    [getActiveHandler],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent) => {
+      const handler = activeDrawHandlerRef.current;
+      if (!handler) return;
+
+      const { camera } = useCanvasStore.getState();
+      const world = screenToWorld(e.offsetX, e.offsetY, camera);
+
+      handler.onPointerMove(world.x, world.y, e);
+    },
+    [],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: PointerEvent) => {
+      const handler = activeDrawHandlerRef.current;
+      if (!handler) return;
+
+      const { camera } = useCanvasStore.getState();
+      const world = screenToWorld(e.offsetX, e.offsetY, camera);
+
+      handler.onPointerUp(world.x, world.y, e);
+      activeDrawHandlerRef.current = null;
+
+      // Release pointer capture
+      const target = e.currentTarget as Element;
+      target.releasePointerCapture(e.pointerId);
+    },
+    [],
+  );
+
+  // ── ESC key handler ────────────────────────────────────────
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        // Cancel any active draw operation
+        const handler = activeDrawHandlerRef.current;
+        if (handler) {
+          handler.onCancel();
+          activeDrawHandlerRef.current = null;
+        }
+
+        // Also cancel text input if waiting
+        textTool.onCancel();
+
+        // Switch back to select tool
+        useCanvasStore.getState().setActiveTool('select');
+      }
+    },
+    [textTool],
+  );
+
+  // ── Effect: attach/detach event listeners ──────────────────
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    canvas.addEventListener('pointerdown', handlePointerDown);
+    canvas.addEventListener('pointermove', handlePointerMove);
+    canvas.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      canvas.removeEventListener('pointerdown', handlePointerDown);
+      canvas.removeEventListener('pointermove', handlePointerMove);
+      canvas.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [canvasRef, handlePointerDown, handlePointerMove, handlePointerUp, handleKeyDown]);
+
+  // ── Public API ─────────────────────────────────────────────
+
+  const getDrawPreview = useCallback((): DrawPreview | null => {
+    // Check the actively-dragging handler first
+    const handler = activeDrawHandlerRef.current;
+    if (handler) {
+      return handler.getPreview();
+    }
+
+    // Fallback: check current active tool handler
+    const activeHandler = getActiveHandler();
+    return activeHandler?.getPreview() ?? null;
+  }, [getActiveHandler]);
+
+  return { getDrawPreview, textTool };
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -27,7 +27,7 @@ export {
 // ── Renderers ──────────────────────────────────────────────
 export { renderGrid, getGridSpacing } from './renderer/gridRenderer.js';
 export { createRenderLoop } from './renderer/renderLoop.js';
-export type { RenderLoop, ExpressionProvider, SelectionProvider } from './renderer/renderLoop.js';
+export type { RenderLoop, ExpressionProvider, SelectionProvider, DrawPreviewProvider } from './renderer/renderLoop.js';
 export {
   renderExpressions,
   renderLabel,
@@ -42,6 +42,7 @@ export type { BoundingBox, WorldViewport } from './renderer/viewportCulling.js';
 export { createDrawableCache } from './renderer/drawableCache.js';
 export type { DrawableCache, RenderContext } from './renderer/drawableCache.js';
 export { renderSelection } from './renderer/selectionRenderer.js';
+export { renderDrawPreview } from './renderer/drawPreviewRenderer.js';
 export {
   registerCompositeRenderer,
   getCompositeRenderer,
@@ -98,6 +99,17 @@ export type {
   PointerTarget,
 } from './interaction/manipulationHelpers.js';
 
+// ── Drawing Tools ──────────────────────────────────────────
+export type { ToolHandler, DrawPreview, ToolHandlerRegistry } from './tools/BaseTool.js';
+export { createToolHandlerRegistry } from './tools/BaseTool.js';
+export { RectangleTool } from './tools/RectangleTool.js';
+export { EllipseTool } from './tools/EllipseTool.js';
+export { DiamondTool } from './tools/DiamondTool.js';
+export { LineTool } from './tools/LineTool.js';
+export { ArrowTool } from './tools/ArrowTool.js';
+export { FreehandTool } from './tools/FreehandTool.js';
+export { TextTool } from './tools/TextTool.js';
+
 // ── Persistence ────────────────────────────────────────────
 export { saveCanvasState, loadCanvasState, STORAGE_KEY } from './persistence/localStorage.js';
 export type { PersistedCanvasState } from './persistence/localStorage.js';
@@ -110,6 +122,8 @@ export { useSelectionInteraction } from './hooks/useSelectionInteraction.js';
 export type { SelectionInteraction, MarqueeRect } from './hooks/useSelectionInteraction.js';
 export { useManipulationInteraction } from './hooks/useManipulationInteraction.js';
 export type { ManipulationInteraction } from './hooks/useManipulationInteraction.js';
+export { useDrawingInteraction } from './hooks/useDrawingInteraction.js';
+export type { DrawingInteraction } from './hooks/useDrawingInteraction.js';
 export { subscribeAutoSave, DEBOUNCE_MS } from './hooks/useAutoSave.js';
 export { createGatewayConnection } from './hooks/useGatewayConnection.js';
 export type {

--- a/packages/engine/src/renderer/drawPreviewRenderer.ts
+++ b/packages/engine/src/renderer/drawPreviewRenderer.ts
@@ -1,0 +1,165 @@
+/**
+ * Draw preview renderer.
+ *
+ * Renders transient dashed outlines during active tool drag.
+ * These shapes are NOT committed to the store — they're rendered
+ * directly each frame from the tool handler's preview state.
+ *
+ * @module
+ */
+
+import type { DrawPreview } from '../tools/BaseTool.js';
+
+/** Dashed stroke color for draw previews. */
+const PREVIEW_STROKE_COLOR = '#4A90D9';
+
+/** Dash pattern for draw previews. */
+const PREVIEW_DASH_PATTERN = [6, 4];
+
+/** Stroke width for draw previews. */
+const PREVIEW_STROKE_WIDTH = 1.5;
+
+/** Preview fill color (very light blue). */
+const PREVIEW_FILL_COLOR = 'rgba(74, 144, 217, 0.08)';
+
+/**
+ * Render a draw preview on the canvas context.
+ *
+ * Called within the render loop after expressions are drawn,
+ * while the camera transform is still active (world coordinates).
+ */
+export function renderDrawPreview(
+  ctx: CanvasRenderingContext2D,
+  preview: DrawPreview,
+): void {
+  ctx.save();
+
+  ctx.strokeStyle = PREVIEW_STROKE_COLOR;
+  ctx.fillStyle = PREVIEW_FILL_COLOR;
+  ctx.lineWidth = PREVIEW_STROKE_WIDTH;
+  ctx.setLineDash(PREVIEW_DASH_PATTERN);
+
+  switch (preview.kind) {
+    case 'rectangle':
+      renderRectanglePreview(ctx, preview);
+      break;
+    case 'ellipse':
+      renderEllipsePreview(ctx, preview);
+      break;
+    case 'diamond':
+      renderDiamondPreview(ctx, preview);
+      break;
+    case 'line':
+      renderLinePreview(ctx, preview);
+      break;
+    case 'arrow':
+      renderArrowPreview(ctx, preview);
+      break;
+    case 'freehand':
+      renderFreehandPreview(ctx, preview);
+      break;
+  }
+
+  ctx.restore();
+}
+
+/** Render rectangle preview as dashed outline with light fill. */
+function renderRectanglePreview(ctx: CanvasRenderingContext2D, p: DrawPreview): void {
+  ctx.fillRect(p.x, p.y, p.width, p.height);
+  ctx.strokeRect(p.x, p.y, p.width, p.height);
+}
+
+/** Render ellipse preview as dashed outline with light fill. */
+function renderEllipsePreview(ctx: CanvasRenderingContext2D, p: DrawPreview): void {
+  const cx = p.x + p.width / 2;
+  const cy = p.y + p.height / 2;
+  const rx = p.width / 2;
+  const ry = p.height / 2;
+
+  ctx.beginPath();
+  ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+}
+
+/** Render diamond preview as dashed outline with light fill. */
+function renderDiamondPreview(ctx: CanvasRenderingContext2D, p: DrawPreview): void {
+  const cx = p.x + p.width / 2;
+  const cy = p.y + p.height / 2;
+
+  ctx.beginPath();
+  ctx.moveTo(cx, p.y);
+  ctx.lineTo(p.x + p.width, cy);
+  ctx.lineTo(cx, p.y + p.height);
+  ctx.lineTo(p.x, cy);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+}
+
+/** Render line preview as dashed line. */
+function renderLinePreview(ctx: CanvasRenderingContext2D, p: DrawPreview): void {
+  if (!p.points || p.points.length < 2) return;
+
+  ctx.beginPath();
+  const [first, ...rest] = p.points;
+  ctx.moveTo(first![0], first![1]);
+  for (const [px, py] of rest) {
+    ctx.lineTo(px, py);
+  }
+  ctx.stroke();
+}
+
+/** Render arrow preview as dashed line with arrowhead. */
+function renderArrowPreview(ctx: CanvasRenderingContext2D, p: DrawPreview): void {
+  if (!p.points || p.points.length < 2) return;
+
+  ctx.beginPath();
+  const [first, ...rest] = p.points;
+  ctx.moveTo(first![0], first![1]);
+  for (const [px, py] of rest) {
+    ctx.lineTo(px, py);
+  }
+  ctx.stroke();
+
+  // Draw arrowhead at the end
+  const last = p.points[p.points.length - 1]!;
+  const prev = p.points[p.points.length - 2]!;
+  const angle = Math.atan2(last[1] - prev[1], last[0] - prev[0]);
+  const size = 10;
+  const halfAngle = Math.PI / 6;
+
+  ctx.setLineDash([]);
+  ctx.fillStyle = PREVIEW_STROKE_COLOR;
+  ctx.beginPath();
+  ctx.moveTo(last[0], last[1]);
+  ctx.lineTo(
+    last[0] - size * Math.cos(angle - halfAngle),
+    last[1] - size * Math.sin(angle - halfAngle),
+  );
+  ctx.lineTo(
+    last[0] - size * Math.cos(angle + halfAngle),
+    last[1] - size * Math.sin(angle + halfAngle),
+  );
+  ctx.closePath();
+  ctx.fill();
+}
+
+/** Render freehand preview as dashed polyline. */
+function renderFreehandPreview(ctx: CanvasRenderingContext2D, p: DrawPreview): void {
+  if (!p.points || p.points.length < 2) return;
+
+  ctx.setLineDash([]);
+  ctx.strokeStyle = PREVIEW_STROKE_COLOR;
+  ctx.lineWidth = 2;
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+
+  ctx.beginPath();
+  const [first, ...rest] = p.points;
+  ctx.moveTo(first![0], first![1]);
+  for (const [px, py] of rest) {
+    ctx.lineTo(px, py);
+  }
+  ctx.stroke();
+}

--- a/packages/engine/src/renderer/renderLoop.ts
+++ b/packages/engine/src/renderer/renderLoop.ts
@@ -10,10 +10,12 @@
 import type { VisualExpression } from '@infinicanvas/protocol';
 import type { RoughCanvas } from 'roughjs/bin/canvas.js';
 import type { Camera } from '../types/index.js';
+import type { DrawPreview } from '../tools/BaseTool.js';
 import { applyTransform } from '../camera.js';
 import { renderGrid } from './gridRenderer.js';
 import { renderExpressions } from './primitiveRenderer.js';
 import { renderSelection } from './selectionRenderer.js';
+import { renderDrawPreview } from './drawPreviewRenderer.js';
 
 export interface RenderLoop {
   start(): void;
@@ -33,6 +35,12 @@ export interface ExpressionProvider {
 export interface SelectionProvider {
   /** Set of currently selected expression IDs. */
   getSelectedIds(): Set<string>;
+}
+
+/** Callback that returns the current draw preview for rendering. */
+export interface DrawPreviewProvider {
+  /** Current draw preview from the active tool, or null. */
+  getDrawPreview(): DrawPreview | null;
 }
 
 /**
@@ -55,6 +63,7 @@ export function createRenderLoop(
   roughCanvas?: RoughCanvas,
   expressionProvider?: ExpressionProvider,
   selectionProvider?: SelectionProvider,
+  drawPreviewProvider?: DrawPreviewProvider,
 ): RenderLoop {
   let width = initialWidth;
   let height = initialHeight;
@@ -97,6 +106,14 @@ export function createRenderLoop(
         expressionProvider.getExpressions(),
         camera,
       );
+    }
+
+    // 6. Render draw preview (transient dashed outline during tool drag)
+    if (drawPreviewProvider) {
+      const preview = drawPreviewProvider.getDrawPreview();
+      if (preview) {
+        renderDrawPreview(ctx, preview);
+      }
     }
 
     // Schedule next frame

--- a/packages/engine/src/tools/AreaShapeTool.ts
+++ b/packages/engine/src/tools/AreaShapeTool.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared helper for area-based drawing tools (rectangle, ellipse, diamond).
+ *
+ * Implements the common pattern: click+drag → dashed preview →
+ * on release if area > 10×10, create expression.
+ *
+ * @module
+ */
+
+import { nanoid } from 'nanoid';
+import { DEFAULT_EXPRESSION_STYLE } from '@infinicanvas/protocol';
+import type { VisualExpression, ExpressionData } from '@infinicanvas/protocol';
+import type { ToolHandler, DrawPreview } from './BaseTool.js';
+import { useCanvasStore } from '../store/canvasStore.js';
+
+/** Minimum dimension (width or height) to create a shape. */
+const MIN_DIMENSION = 10;
+
+/** Human author for locally-drawn expressions. */
+const LOCAL_AUTHOR = {
+  type: 'human' as const,
+  id: 'local-user',
+  name: 'You',
+};
+
+/** Shape kind for area-based tools. */
+export type AreaShapeKind = 'rectangle' | 'ellipse' | 'diamond';
+
+/**
+ * Base class for area-based drawing tools.
+ *
+ * Handles the common drag-to-create pattern with preview rendering.
+ * Subclasses only need to specify the shape kind.
+ */
+export class AreaShapeTool implements ToolHandler {
+  private readonly shapeKind: AreaShapeKind;
+  private isDrawing = false;
+  private startX = 0;
+  private startY = 0;
+  private currentX = 0;
+  private currentY = 0;
+
+  constructor(kind: AreaShapeKind) {
+    this.shapeKind = kind;
+  }
+
+  onPointerDown(worldX: number, worldY: number, _event: PointerEvent): void {
+    this.isDrawing = true;
+    this.startX = worldX;
+    this.startY = worldY;
+    this.currentX = worldX;
+    this.currentY = worldY;
+  }
+
+  onPointerMove(worldX: number, worldY: number, _event: PointerEvent): void {
+    if (!this.isDrawing) return;
+    this.currentX = worldX;
+    this.currentY = worldY;
+  }
+
+  onPointerUp(worldX: number, worldY: number, _event: PointerEvent): void {
+    if (!this.isDrawing) {
+      return;
+    }
+
+    this.currentX = worldX;
+    this.currentY = worldY;
+    this.isDrawing = false;
+
+    const { x, y, width, height } = this.computeBounds();
+
+    // Only create if dimensions exceed minimum threshold
+    if (width < MIN_DIMENSION || height < MIN_DIMENSION) {
+      this.reset();
+      return;
+    }
+
+    const now = Date.now();
+    const id = nanoid();
+
+    const data: ExpressionData = { kind: this.shapeKind };
+
+    const expression: VisualExpression = {
+      id,
+      kind: this.shapeKind,
+      position: { x, y },
+      size: { width, height },
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: LOCAL_AUTHOR,
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data,
+    };
+
+    const store = useCanvasStore.getState();
+    store.addExpression(expression);
+    store.setSelectedIds(new Set([id]));
+    store.setActiveTool('select');
+
+    this.reset();
+  }
+
+  onCancel(): void {
+    this.isDrawing = false;
+    this.reset();
+  }
+
+  getPreview(): DrawPreview | null {
+    if (!this.isDrawing) return null;
+
+    // Don't show preview until pointer has moved from start
+    if (this.currentX === this.startX && this.currentY === this.startY) {
+      return null;
+    }
+
+    const { x, y, width, height } = this.computeBounds();
+    return { kind: this.shapeKind, x, y, width, height };
+  }
+
+  /** Compute normalized bounds (handles negative drag). */
+  private computeBounds() {
+    const x = Math.min(this.startX, this.currentX);
+    const y = Math.min(this.startY, this.currentY);
+    const width = Math.abs(this.currentX - this.startX);
+    const height = Math.abs(this.currentY - this.startY);
+    return { x, y, width, height };
+  }
+
+  /** Reset internal state. */
+  private reset(): void {
+    this.startX = 0;
+    this.startY = 0;
+    this.currentX = 0;
+    this.currentY = 0;
+  }
+}

--- a/packages/engine/src/tools/ArrowTool.ts
+++ b/packages/engine/src/tools/ArrowTool.ts
@@ -1,0 +1,151 @@
+/**
+ * Arrow drawing tool.
+ *
+ * Same as LineTool but creates arrows with endArrowhead: true.
+ * Minimum distance: 5px. Auto-switches to Select after creation.
+ *
+ * @module
+ */
+
+import { nanoid } from 'nanoid';
+import { DEFAULT_EXPRESSION_STYLE } from '@infinicanvas/protocol';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import type { ToolHandler, DrawPreview } from './BaseTool.js';
+import { useCanvasStore } from '../store/canvasStore.js';
+
+/** Minimum arrow length in world units. */
+const MIN_ARROW_LENGTH = 5;
+
+/** Human author for locally-drawn expressions. */
+const LOCAL_AUTHOR = {
+  type: 'human' as const,
+  id: 'local-user',
+  name: 'You',
+};
+
+/** Tool handler for drawing arrows on the canvas. */
+export class ArrowTool implements ToolHandler {
+  private isDrawing = false;
+  private startX = 0;
+  private startY = 0;
+  private endX = 0;
+  private endY = 0;
+
+  onPointerDown(worldX: number, worldY: number, _event: PointerEvent): void {
+    this.isDrawing = true;
+    this.startX = worldX;
+    this.startY = worldY;
+    this.endX = worldX;
+    this.endY = worldY;
+  }
+
+  onPointerMove(worldX: number, worldY: number, _event: PointerEvent): void {
+    if (!this.isDrawing) return;
+    this.endX = worldX;
+    this.endY = worldY;
+  }
+
+  onPointerUp(worldX: number, worldY: number, _event: PointerEvent): void {
+    if (!this.isDrawing) return;
+
+    this.endX = worldX;
+    this.endY = worldY;
+    this.isDrawing = false;
+
+    const length = Math.hypot(this.endX - this.startX, this.endY - this.startY);
+    if (length < MIN_ARROW_LENGTH) {
+      this.reset();
+      return;
+    }
+
+    const points: [number, number][] = [
+      [this.startX, this.startY],
+      [this.endX, this.endY],
+    ];
+
+    const { position, size } = computeBoundingBox(points);
+    const now = Date.now();
+    const id = nanoid();
+
+    const expression: VisualExpression = {
+      id,
+      kind: 'arrow',
+      position,
+      size,
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: LOCAL_AUTHOR,
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: {
+        kind: 'arrow',
+        points,
+        startArrowhead: false,
+        endArrowhead: true,
+      },
+    };
+
+    const store = useCanvasStore.getState();
+    store.addExpression(expression);
+    store.setSelectedIds(new Set([id]));
+    store.setActiveTool('select');
+
+    this.reset();
+  }
+
+  onCancel(): void {
+    this.isDrawing = false;
+    this.reset();
+  }
+
+  getPreview(): DrawPreview | null {
+    if (!this.isDrawing) return null;
+    if (this.endX === this.startX && this.endY === this.startY) return null;
+
+    const points: [number, number][] = [
+      [this.startX, this.startY],
+      [this.endX, this.endY],
+    ];
+    const { position, size } = computeBoundingBox(points);
+
+    return {
+      kind: 'arrow',
+      x: position.x,
+      y: position.y,
+      width: size.width,
+      height: size.height,
+      points,
+    };
+  }
+
+  private reset(): void {
+    this.startX = 0;
+    this.startY = 0;
+    this.endX = 0;
+    this.endY = 0;
+  }
+}
+
+/** Compute axis-aligned bounding box from a set of points. */
+function computeBoundingBox(points: [number, number][]) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const [px, py] of points) {
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+    if (px > maxX) maxX = px;
+    if (py > maxY) maxY = py;
+  }
+
+  return {
+    position: { x: minX, y: minY },
+    size: { width: maxX - minX, height: maxY - minY },
+  };
+}

--- a/packages/engine/src/tools/BaseTool.ts
+++ b/packages/engine/src/tools/BaseTool.ts
@@ -1,0 +1,75 @@
+/**
+ * Tool handler interface and registry.
+ *
+ * Defines the contract all drawing tools must implement and provides
+ * a registry to dispatch pointer events to the active tool.
+ *
+ * Each tool handles pointer lifecycle (down/move/up) in world coordinates
+ * and can produce transient draw previews rendered by the render loop.
+ *
+ * @module
+ */
+
+import type { ToolType } from '../types/index.js';
+
+/**
+ * Transient draw preview state rendered during active tool drag.
+ *
+ * Displayed as a dashed outline in the render loop and NOT committed
+ * to the store until the tool completes (pointerup).
+ */
+export interface DrawPreview {
+  /** The kind of shape being previewed. */
+  kind: 'rectangle' | 'ellipse' | 'diamond' | 'line' | 'arrow' | 'freehand';
+  /** World-space x coordinate. */
+  x: number;
+  /** World-space y coordinate. */
+  y: number;
+  /** Preview width (for area shapes). */
+  width: number;
+  /** Preview height (for area shapes). */
+  height: number;
+  /** Points for line/arrow/freehand previews. */
+  points?: [number, number][];
+}
+
+/**
+ * Contract that all drawing tool handlers must implement.
+ *
+ * All coordinates are in world space (already converted via screenToWorld).
+ */
+export interface ToolHandler {
+  /** Called when the pointer is pressed down. */
+  onPointerDown(worldX: number, worldY: number, event: PointerEvent): void;
+  /** Called when the pointer moves (only during active drag). */
+  onPointerMove(worldX: number, worldY: number, event: PointerEvent): void;
+  /** Called when the pointer is released. */
+  onPointerUp(worldX: number, worldY: number, event: PointerEvent): void;
+  /** Cancel the current draw operation (e.g., ESC key). */
+  onCancel(): void;
+  /** Current transient preview to render, or null if not drawing. */
+  getPreview(): DrawPreview | null;
+}
+
+/** Registry mapping tool types to their handler instances. */
+export type ToolHandlerRegistry = Record<ToolType, ToolHandler | undefined>;
+
+/**
+ * Create an empty tool handler registry.
+ *
+ * The `select` tool has no ToolHandler — it uses the existing
+ * selection/manipulation interaction hooks. Only drawing tools
+ * need handlers.
+ */
+export function createToolHandlerRegistry(): ToolHandlerRegistry {
+  return {
+    select: undefined,
+    rectangle: undefined,
+    ellipse: undefined,
+    diamond: undefined,
+    line: undefined,
+    arrow: undefined,
+    freehand: undefined,
+    text: undefined,
+  };
+}

--- a/packages/engine/src/tools/DiamondTool.ts
+++ b/packages/engine/src/tools/DiamondTool.ts
@@ -1,0 +1,16 @@
+/**
+ * Diamond drawing tool.
+ *
+ * Click+drag → dashed preview → on release if >10×10, create diamond expression.
+ *
+ * @module
+ */
+
+import { AreaShapeTool } from './AreaShapeTool.js';
+
+/** Tool handler for drawing diamonds on the canvas. */
+export class DiamondTool extends AreaShapeTool {
+  constructor() {
+    super('diamond');
+  }
+}

--- a/packages/engine/src/tools/EllipseTool.ts
+++ b/packages/engine/src/tools/EllipseTool.ts
@@ -1,0 +1,16 @@
+/**
+ * Ellipse drawing tool.
+ *
+ * Click+drag → dashed preview → on release if >10×10, create ellipse expression.
+ *
+ * @module
+ */
+
+import { AreaShapeTool } from './AreaShapeTool.js';
+
+/** Tool handler for drawing ellipses on the canvas. */
+export class EllipseTool extends AreaShapeTool {
+  constructor() {
+    super('ellipse');
+  }
+}

--- a/packages/engine/src/tools/FreehandTool.ts
+++ b/packages/engine/src/tools/FreehandTool.ts
@@ -1,0 +1,126 @@
+/**
+ * Freehand drawing tool.
+ *
+ * Captures [x, y, pressure] points on pointermove → creates freehand
+ * expression. Minimum 2 points required. Stays in freehand mode after
+ * creation (no auto-switch to Select).
+ *
+ * @module
+ */
+
+import { nanoid } from 'nanoid';
+import { DEFAULT_EXPRESSION_STYLE } from '@infinicanvas/protocol';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import type { ToolHandler, DrawPreview } from './BaseTool.js';
+import { useCanvasStore } from '../store/canvasStore.js';
+
+/** Minimum number of points to create a freehand stroke. */
+const MIN_POINTS = 2;
+
+/** Human author for locally-drawn expressions. */
+const LOCAL_AUTHOR = {
+  type: 'human' as const,
+  id: 'local-user',
+  name: 'You',
+};
+
+/** Tool handler for freehand/pen drawing on the canvas. */
+export class FreehandTool implements ToolHandler {
+  private isDrawing = false;
+  private points: [number, number, number][] = [];
+
+  onPointerDown(worldX: number, worldY: number, event: PointerEvent): void {
+    this.isDrawing = true;
+    this.points = [[worldX, worldY, event.pressure ?? 0.5]];
+  }
+
+  onPointerMove(worldX: number, worldY: number, event: PointerEvent): void {
+    if (!this.isDrawing) return;
+    this.points.push([worldX, worldY, event.pressure ?? 0.5]);
+  }
+
+  onPointerUp(worldX: number, worldY: number, event: PointerEvent): void {
+    if (!this.isDrawing) return;
+
+    this.points.push([worldX, worldY, event.pressure ?? 0.5]);
+    this.isDrawing = false;
+
+    if (this.points.length < MIN_POINTS) {
+      this.reset();
+      return;
+    }
+
+    const { position, size } = computeBoundingBox(this.points);
+    const now = Date.now();
+    const id = nanoid();
+
+    const expression: VisualExpression = {
+      id,
+      kind: 'freehand',
+      position,
+      size,
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: LOCAL_AUTHOR,
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: { kind: 'freehand', points: [...this.points] },
+    };
+
+    const store = useCanvasStore.getState();
+    store.addExpression(expression);
+    store.setSelectedIds(new Set([id]));
+    // Freehand stays in freehand mode — do NOT switch to select
+
+    this.reset();
+  }
+
+  onCancel(): void {
+    this.isDrawing = false;
+    this.reset();
+  }
+
+  getPreview(): DrawPreview | null {
+    if (!this.isDrawing || this.points.length < 2) return null;
+
+    const { position, size } = computeBoundingBox(this.points);
+    const points2D: [number, number][] = this.points.map(([x, y]) => [x, y]);
+
+    return {
+      kind: 'freehand',
+      x: position.x,
+      y: position.y,
+      width: size.width,
+      height: size.height,
+      points: points2D,
+    };
+  }
+
+  private reset(): void {
+    this.points = [];
+  }
+}
+
+/** Compute axis-aligned bounding box from 3-element point arrays. */
+function computeBoundingBox(points: [number, number, number][]) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const [px, py] of points) {
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+    if (px > maxX) maxX = px;
+    if (py > maxY) maxY = py;
+  }
+
+  return {
+    position: { x: minX, y: minY },
+    size: { width: maxX - minX, height: maxY - minY },
+  };
+}

--- a/packages/engine/src/tools/LineTool.ts
+++ b/packages/engine/src/tools/LineTool.ts
@@ -1,0 +1,146 @@
+/**
+ * Line drawing tool.
+ *
+ * Click start → drag end → create line expression with points array.
+ * Minimum distance: 5px. Auto-switches to Select after creation.
+ *
+ * @module
+ */
+
+import { nanoid } from 'nanoid';
+import { DEFAULT_EXPRESSION_STYLE } from '@infinicanvas/protocol';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import type { ToolHandler, DrawPreview } from './BaseTool.js';
+import { useCanvasStore } from '../store/canvasStore.js';
+
+/** Minimum line length in world units. */
+const MIN_LINE_LENGTH = 5;
+
+/** Human author for locally-drawn expressions. */
+const LOCAL_AUTHOR = {
+  type: 'human' as const,
+  id: 'local-user',
+  name: 'You',
+};
+
+/** Tool handler for drawing straight lines on the canvas. */
+export class LineTool implements ToolHandler {
+  private isDrawing = false;
+  private startX = 0;
+  private startY = 0;
+  private endX = 0;
+  private endY = 0;
+
+  onPointerDown(worldX: number, worldY: number, _event: PointerEvent): void {
+    this.isDrawing = true;
+    this.startX = worldX;
+    this.startY = worldY;
+    this.endX = worldX;
+    this.endY = worldY;
+  }
+
+  onPointerMove(worldX: number, worldY: number, _event: PointerEvent): void {
+    if (!this.isDrawing) return;
+    this.endX = worldX;
+    this.endY = worldY;
+  }
+
+  onPointerUp(worldX: number, worldY: number, _event: PointerEvent): void {
+    if (!this.isDrawing) return;
+
+    this.endX = worldX;
+    this.endY = worldY;
+    this.isDrawing = false;
+
+    const length = Math.hypot(this.endX - this.startX, this.endY - this.startY);
+    if (length < MIN_LINE_LENGTH) {
+      this.reset();
+      return;
+    }
+
+    const points: [number, number][] = [
+      [this.startX, this.startY],
+      [this.endX, this.endY],
+    ];
+
+    const { position, size } = computeBoundingBox(points);
+    const now = Date.now();
+    const id = nanoid();
+
+    const expression: VisualExpression = {
+      id,
+      kind: 'line',
+      position,
+      size,
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: LOCAL_AUTHOR,
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: { kind: 'line', points },
+    };
+
+    const store = useCanvasStore.getState();
+    store.addExpression(expression);
+    store.setSelectedIds(new Set([id]));
+    store.setActiveTool('select');
+
+    this.reset();
+  }
+
+  onCancel(): void {
+    this.isDrawing = false;
+    this.reset();
+  }
+
+  getPreview(): DrawPreview | null {
+    if (!this.isDrawing) return null;
+    if (this.endX === this.startX && this.endY === this.startY) return null;
+
+    const points: [number, number][] = [
+      [this.startX, this.startY],
+      [this.endX, this.endY],
+    ];
+    const { position, size } = computeBoundingBox(points);
+
+    return {
+      kind: 'line',
+      x: position.x,
+      y: position.y,
+      width: size.width,
+      height: size.height,
+      points,
+    };
+  }
+
+  private reset(): void {
+    this.startX = 0;
+    this.startY = 0;
+    this.endX = 0;
+    this.endY = 0;
+  }
+}
+
+/** Compute axis-aligned bounding box from a set of points. */
+function computeBoundingBox(points: [number, number][]) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const [px, py] of points) {
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+    if (px > maxX) maxX = px;
+    if (py > maxY) maxY = py;
+  }
+
+  return {
+    position: { x: minX, y: minY },
+    size: { width: maxX - minX, height: maxY - minY },
+  };
+}

--- a/packages/engine/src/tools/RectangleTool.ts
+++ b/packages/engine/src/tools/RectangleTool.ts
@@ -1,0 +1,16 @@
+/**
+ * Rectangle drawing tool.
+ *
+ * Click+drag → dashed preview → on release if >10×10, create rectangle expression.
+ *
+ * @module
+ */
+
+import { AreaShapeTool } from './AreaShapeTool.js';
+
+/** Tool handler for drawing rectangles on the canvas. */
+export class RectangleTool extends AreaShapeTool {
+  constructor() {
+    super('rectangle');
+  }
+}

--- a/packages/engine/src/tools/TextTool.ts
+++ b/packages/engine/src/tools/TextTool.ts
@@ -1,0 +1,113 @@
+/**
+ * Text drawing tool.
+ *
+ * Click → position textarea overlay → Enter commits text, ESC cancels →
+ * creates text expression. Auto-switches to Select after creation.
+ *
+ * The tool itself manages the input position; the actual textarea
+ * rendering is handled by the Canvas component which reads getInputPosition().
+ *
+ * @module
+ */
+
+import { nanoid } from 'nanoid';
+import { DEFAULT_EXPRESSION_STYLE } from '@infinicanvas/protocol';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import type { ToolHandler, DrawPreview } from './BaseTool.js';
+import { useCanvasStore } from '../store/canvasStore.js';
+
+/** Default text properties. */
+const DEFAULT_FONT_SIZE = 16;
+const DEFAULT_FONT_FAMILY = 'sans-serif';
+const DEFAULT_TEXT_ALIGN = 'left' as const;
+
+/** Default text expression size. */
+const TEXT_WIDTH = 200;
+const TEXT_HEIGHT = 50;
+
+/** Human author for locally-drawn expressions. */
+const LOCAL_AUTHOR = {
+  type: 'human' as const,
+  id: 'local-user',
+  name: 'You',
+};
+
+/** Tool handler for creating text expressions on the canvas. */
+export class TextTool implements ToolHandler {
+  private inputPosition: { x: number; y: number } | null = null;
+
+  onPointerDown(_worldX: number, _worldY: number, _event: PointerEvent): void {
+    // If already waiting for input, commit/cancel first
+    if (this.inputPosition) {
+      this.onCancel();
+    }
+  }
+
+  onPointerMove(_worldX: number, _worldY: number, _event: PointerEvent): void {
+    // Text tool has no drag preview
+  }
+
+  onPointerUp(worldX: number, worldY: number, _event: PointerEvent): void {
+    // Set position for the text input overlay
+    this.inputPosition = { x: worldX, y: worldY };
+  }
+
+  onCancel(): void {
+    this.inputPosition = null;
+  }
+
+  getPreview(): DrawPreview | null {
+    // Text tool has no drag preview
+    return null;
+  }
+
+  /** Get the world position where text input should appear. */
+  getInputPosition(): { x: number; y: number } | null {
+    return this.inputPosition;
+  }
+
+  /**
+   * Commit the text content and create the expression.
+   *
+   * Called by the text input overlay when the user presses Enter.
+   */
+  commitText(text: string): void {
+    if (!this.inputPosition || !text.trim()) {
+      this.inputPosition = null;
+      return;
+    }
+
+    const now = Date.now();
+    const id = nanoid();
+
+    const expression: VisualExpression = {
+      id,
+      kind: 'text',
+      position: { x: this.inputPosition.x, y: this.inputPosition.y },
+      size: { width: TEXT_WIDTH, height: TEXT_HEIGHT },
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: LOCAL_AUTHOR,
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: {
+        kind: 'text',
+        text,
+        fontSize: DEFAULT_FONT_SIZE,
+        fontFamily: DEFAULT_FONT_FAMILY,
+        textAlign: DEFAULT_TEXT_ALIGN,
+      },
+    };
+
+    const store = useCanvasStore.getState();
+    store.addExpression(expression);
+    store.setSelectedIds(new Set([id]));
+    store.setActiveTool('select');
+
+    this.inputPosition = null;
+  }
+}

--- a/packages/engine/src/tools/index.ts
+++ b/packages/engine/src/tools/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Drawing tools — public module exports.
+ *
+ * @module
+ */
+
+export type { ToolHandler, DrawPreview, ToolHandlerRegistry } from './BaseTool.js';
+export { createToolHandlerRegistry } from './BaseTool.js';
+export { AreaShapeTool } from './AreaShapeTool.js';
+export { RectangleTool } from './RectangleTool.js';
+export { EllipseTool } from './EllipseTool.js';
+export { DiamondTool } from './DiamondTool.js';
+export { LineTool } from './LineTool.js';
+export { ArrowTool } from './ArrowTool.js';
+export { FreehandTool } from './FreehandTool.js';
+export { TextTool } from './TextTool.js';


### PR DESCRIPTION
8 tool handlers (rect, ellipse, diamond, line, arrow, freehand, text + select), toolbar UI with lucide icons, draw preview, auto-switch, cancel. 46 tests. Closes #6