### PR TITLE
feat(engine): 8 remaining composite renderers — Issue #17

### DIFF
--- a/packages/engine/src/__tests__/compositeRenderers.test.ts
+++ b/packages/engine/src/__tests__/compositeRenderers.test.ts
@@ -1,0 +1,746 @@
+/**
+ * Unit tests for the 8 remaining composite renderers.
+ *
+ * Covers: kanban, table, wireframe, roadmap, code-block, slide,
+ * collaboration-diagram, and decision-tree renderers.
+ *
+ * Each renderer is tested for:
+ * - Rendering with known data without errors (happy path)
+ * - Correct element count (fillText / draw calls)
+ * - Empty data gracefully handled (AC10)
+ * - Self-registration in composite registry (AC9)
+ *
+ * Ticket #17 — Remaining Composite Renderers
+ *
+ * @module
+ */
+
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import type {
+  VisualExpression,
+  ExpressionStyle,
+  KanbanData,
+  TableData,
+  WireframeData,
+  RoadmapData,
+  CodeBlockData,
+  SlideData,
+  CollaborationDiagramData,
+  DecisionTreeData,
+} from '@infinicanvas/protocol';
+import {
+  getCompositeRenderer,
+  clearCompositeRenderers,
+} from '../renderer/compositeRegistry.js';
+
+// ── Global stubs for browser APIs ────────────────────────────
+
+class Path2DStub {
+  moveTo = vi.fn();
+  lineTo = vi.fn();
+  closePath = vi.fn();
+}
+
+class ImageStub {
+  src = '';
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+}
+
+beforeAll(() => {
+  vi.stubGlobal('Path2D', Path2DStub);
+  vi.stubGlobal('Image', ImageStub);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  clearCompositeRenderers();
+});
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeStyle(overrides: Partial<ExpressionStyle> = {}): ExpressionStyle {
+  return {
+    strokeColor: '#000000',
+    backgroundColor: '#ffffff',
+    fillStyle: 'solid',
+    strokeWidth: 2,
+    roughness: 1,
+    opacity: 1,
+    ...overrides,
+  };
+}
+
+function makeExpression(
+  id: string,
+  kind: string,
+  data: Record<string, unknown>,
+  overrides: Partial<VisualExpression> = {},
+): VisualExpression {
+  return {
+    id,
+    kind: kind as VisualExpression['kind'],
+    position: { x: 100, y: 100 },
+    size: { width: 400, height: 300 },
+    angle: 0,
+    style: makeStyle(),
+    meta: {
+      author: { type: 'human', id: 'user-1', name: 'Test' },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      tags: [],
+      locked: false,
+    },
+    data: data as VisualExpression['data'],
+    ...overrides,
+  };
+}
+
+function createMockCtx() {
+  return {
+    save: vi.fn(),
+    restore: vi.fn(),
+    clearRect: vi.fn(),
+    setTransform: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    fillText: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    drawImage: vi.fn(),
+    rotate: vi.fn(),
+    translate: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    roundRect: vi.fn(),
+    measureText: vi.fn(() => ({ width: 50 })),
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'top' as CanvasTextBaseline,
+    globalAlpha: 1,
+    canvas: { width: 800, height: 600 },
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function createMockRoughCanvas() {
+  return {
+    rectangle: vi.fn(() => ({ shape: 'rectangle', options: {}, sets: [] })),
+    ellipse: vi.fn(() => ({ shape: 'ellipse', options: {}, sets: [] })),
+    polygon: vi.fn(() => ({ shape: 'polygon', options: {}, sets: [] })),
+    linearPath: vi.fn(() => ({ shape: 'linearPath', options: {}, sets: [] })),
+    line: vi.fn(() => ({ shape: 'line', options: {}, sets: [] })),
+    draw: vi.fn(),
+  };
+}
+
+// ── AC1: Kanban Renderer ─────────────────────────────────────
+
+describe('kanbanRenderer [AC1]', () => {
+  let renderKanban: typeof import('../renderer/composites/kanbanRenderer.js').renderKanban;
+
+  beforeAll(async () => {
+    const mod = await import('../renderer/composites/kanbanRenderer.js');
+    renderKanban = mod.renderKanban;
+  });
+
+
+  it('[HAPPY] renders kanban with columns and cards without error', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: KanbanData = {
+      kind: 'kanban',
+      title: 'Sprint Board',
+      columns: [
+        { id: 'c1', title: 'To Do', cards: [{ id: 'k1', title: 'Task A' }, { id: 'k2', title: 'Task B' }] },
+        { id: 'c2', title: 'In Progress', cards: [{ id: 'k3', title: 'Task C' }] },
+        { id: 'c3', title: 'Done', cards: [] },
+      ],
+    };
+    const expr = makeExpression('kb-1', 'kanban', data as unknown as Record<string, unknown>);
+
+    expect(() => renderKanban(ctx, expr, rc as any)).not.toThrow();
+
+    // Should render title + 3 column headers + 3 card titles
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Sprint Board');
+    expect(textCalls).toContain('To Do');
+    expect(textCalls).toContain('In Progress');
+    expect(textCalls).toContain('Done');
+    expect(textCalls).toContain('Task A');
+    expect(textCalls).toContain('Task B');
+    expect(textCalls).toContain('Task C');
+
+    // 3 cards = 3 card rectangles drawn via Rough.js
+    expect(rc.rectangle.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('[EMPTY] renders empty kanban (no columns) without crash [AC10]', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: KanbanData = { kind: 'kanban', title: 'Empty Board', columns: [] };
+    const expr = makeExpression('kb-empty', 'kanban', data as unknown as Record<string, unknown>);
+
+    expect(() => renderKanban(ctx, expr, rc as any)).not.toThrow();
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Empty Board');
+  });
+
+  it('[REGISTRATION] self-registers as "kanban" in composite registry [AC9]', () => {
+    // Module side-effect registers on first import (in beforeAll).
+    // Verify the function is callable from the registry.
+    const renderer = getCompositeRenderer('kanban');
+    expect(renderer).not.toBeNull();
+    expect(typeof renderer).toBe('function');
+  });
+});
+
+// ── AC2: Table Renderer ──────────────────────────────────────
+
+describe('tableRenderer [AC2]', () => {
+  let renderTable: typeof import('../renderer/composites/tableRenderer.js').renderTable;
+
+  beforeAll(async () => {
+    const mod = await import('../renderer/composites/tableRenderer.js');
+    renderTable = mod.renderTable;
+  });
+
+
+  it('[HAPPY] renders table with headers and rows', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: TableData = {
+      kind: 'table',
+      headers: ['Name', 'Age', 'City'],
+      rows: [
+        ['Alice', '30', 'NYC'],
+        ['Bob', '25', 'LA'],
+      ],
+    };
+    const expr = makeExpression('tbl-1', 'table', data as unknown as Record<string, unknown>);
+
+    expect(() => renderTable(ctx, expr, rc as any)).not.toThrow();
+
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Name');
+    expect(textCalls).toContain('Age');
+    expect(textCalls).toContain('City');
+    expect(textCalls).toContain('Alice');
+    expect(textCalls).toContain('Bob');
+
+    // Grid lines drawn via Rough.js
+    expect(rc.line.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('[EMPTY] renders table with no rows without crash [AC10]', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: TableData = { kind: 'table', headers: [], rows: [] };
+    const expr = makeExpression('tbl-empty', 'table', data as unknown as Record<string, unknown>);
+
+    expect(() => renderTable(ctx, expr, rc as any)).not.toThrow();
+  });
+
+  it('[REGISTRATION] self-registers as "table" [AC9]', () => {
+    const renderer = getCompositeRenderer('table');
+    expect(renderer).not.toBeNull();
+    expect(typeof renderer).toBe('function');
+  });
+});
+
+// ── AC3: Wireframe Renderer ──────────────────────────────────
+
+describe('wireframeRenderer [AC3]', () => {
+  let renderWireframe: typeof import('../renderer/composites/wireframeRenderer.js').renderWireframe;
+
+  beforeAll(async () => {
+    const mod = await import('../renderer/composites/wireframeRenderer.js');
+    renderWireframe = mod.renderWireframe;
+  });
+
+
+  it('[HAPPY] renders wireframe with components showing type labels', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: WireframeData = {
+      kind: 'wireframe',
+      title: 'Login Page',
+      screenSize: { width: 375, height: 667 },
+      components: [
+        { id: 'w1', type: 'input', label: 'Email', x: 20, y: 50, width: 200, height: 30 },
+        { id: 'w2', type: 'button', label: 'Submit', x: 20, y: 100, width: 100, height: 40 },
+        { id: 'w3', type: 'text', label: 'Welcome', x: 20, y: 10, width: 200, height: 20 },
+      ],
+    };
+    const expr = makeExpression('wf-1', 'wireframe', data as unknown as Record<string, unknown>);
+
+    expect(() => renderWireframe(ctx, expr, rc as any)).not.toThrow();
+
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Login Page');
+    // Component type labels like "[input]", "[button]"
+    expect(textCalls.some((t: string) => t.includes('[input]'))).toBe(true);
+    expect(textCalls.some((t: string) => t.includes('[button]'))).toBe(true);
+
+    // 3 component rectangles
+    expect(rc.rectangle.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('[EMPTY] renders wireframe with no components [AC10]', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: WireframeData = {
+      kind: 'wireframe',
+      title: 'Empty Screen',
+      screenSize: { width: 375, height: 667 },
+      components: [],
+    };
+    const expr = makeExpression('wf-empty', 'wireframe', data as unknown as Record<string, unknown>);
+
+    expect(() => renderWireframe(ctx, expr, rc as any)).not.toThrow();
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Empty Screen');
+  });
+
+  it('[REGISTRATION] self-registers as "wireframe" [AC9]', () => {
+    const renderer = getCompositeRenderer('wireframe');
+    expect(renderer).not.toBeNull();
+    expect(typeof renderer).toBe('function');
+  });
+});
+
+// ── AC4: Roadmap Renderer ────────────────────────────────────
+
+describe('roadmapRenderer [AC4]', () => {
+  let renderRoadmap: typeof import('../renderer/composites/roadmapRenderer.js').renderRoadmap;
+
+  beforeAll(async () => {
+    const mod = await import('../renderer/composites/roadmapRenderer.js');
+    renderRoadmap = mod.renderRoadmap;
+  });
+
+
+  it('[HAPPY] renders roadmap with phases and color-coded items', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: RoadmapData = {
+      kind: 'roadmap',
+      title: 'Q1 Plan',
+      orientation: 'horizontal',
+      phases: [
+        {
+          id: 'p1', name: 'Phase 1', items: [
+            { id: 'i1', title: 'Design', status: 'done' },
+            { id: 'i2', title: 'Prototype', status: 'in-progress' },
+          ],
+        },
+        {
+          id: 'p2', name: 'Phase 2', items: [
+            { id: 'i3', title: 'Build', status: 'planned' },
+          ],
+        },
+      ],
+    };
+    const expr = makeExpression('rm-1', 'roadmap', data as unknown as Record<string, unknown>);
+
+    expect(() => renderRoadmap(ctx, expr, rc as any)).not.toThrow();
+
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Q1 Plan');
+    expect(textCalls).toContain('Phase 1');
+    expect(textCalls).toContain('Phase 2');
+    expect(textCalls).toContain('Design');
+    expect(textCalls).toContain('Prototype');
+    expect(textCalls).toContain('Build');
+
+    // Item chips rendered as rounded rectangles
+    expect(rc.rectangle.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('[HAPPY] renders vertical roadmap without error', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: RoadmapData = {
+      kind: 'roadmap',
+      title: 'Vertical Plan',
+      orientation: 'vertical',
+      phases: [
+        { id: 'p1', name: 'Start', items: [{ id: 'i1', title: 'Init', status: 'done' }] },
+      ],
+    };
+    const expr = makeExpression('rm-v', 'roadmap', data as unknown as Record<string, unknown>);
+
+    expect(() => renderRoadmap(ctx, expr, rc as any)).not.toThrow();
+  });
+
+  it('[EMPTY] renders roadmap with no phases [AC10]', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: RoadmapData = { kind: 'roadmap', title: 'Empty Plan', orientation: 'horizontal', phases: [] };
+    const expr = makeExpression('rm-empty', 'roadmap', data as unknown as Record<string, unknown>);
+
+    expect(() => renderRoadmap(ctx, expr, rc as any)).not.toThrow();
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Empty Plan');
+  });
+
+  it('[REGISTRATION] self-registers as "roadmap" [AC9]', () => {
+    const renderer = getCompositeRenderer('roadmap');
+    expect(renderer).not.toBeNull();
+    expect(typeof renderer).toBe('function');
+  });
+});
+
+// ── AC5: Code Block Renderer ─────────────────────────────────
+
+describe('codeBlockRenderer [AC5]', () => {
+  let renderCodeBlock: typeof import('../renderer/composites/codeBlockRenderer.js').renderCodeBlock;
+
+  beforeAll(async () => {
+    const mod = await import('../renderer/composites/codeBlockRenderer.js');
+    renderCodeBlock = mod.renderCodeBlock;
+  });
+
+
+  it('[HAPPY] renders code block with dark background and language label', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: CodeBlockData = {
+      kind: 'code-block',
+      language: 'typescript',
+      code: 'const x = 42;\nconsole.log(x);',
+    };
+    const expr = makeExpression('cb-1', 'code-block', data as unknown as Record<string, unknown>);
+
+    expect(() => renderCodeBlock(ctx, expr, rc as any)).not.toThrow();
+
+    // Dark background rendered
+    expect(ctx.fillRect).toHaveBeenCalled();
+
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    // Language label
+    expect(textCalls).toContain('typescript');
+    // Code lines rendered
+    expect(textCalls.some((t: string) => t.includes('const x = 42;'))).toBe(true);
+  });
+
+  it('[EMPTY] renders code block with empty code string [AC10]', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: CodeBlockData = { kind: 'code-block', language: '', code: '' };
+    const expr = makeExpression('cb-empty', 'code-block', data as unknown as Record<string, unknown>);
+
+    expect(() => renderCodeBlock(ctx, expr, rc as any)).not.toThrow();
+  });
+
+  it('[REGISTRATION] self-registers as "code-block" [AC9]', () => {
+    const renderer = getCompositeRenderer('code-block');
+    expect(renderer).not.toBeNull();
+    expect(typeof renderer).toBe('function');
+  });
+});
+
+// ── AC6: Slide Renderer ──────────────────────────────────────
+
+describe('slideRenderer [AC6]', () => {
+  let renderSlide: typeof import('../renderer/composites/slideRenderer.js').renderSlide;
+
+  beforeAll(async () => {
+    const mod = await import('../renderer/composites/slideRenderer.js');
+    renderSlide = mod.renderSlide;
+  });
+
+
+  it('[HAPPY] renders "title" layout with centered large text', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: SlideData = { kind: 'slide', title: 'Welcome', bullets: [], layout: 'title' };
+    const expr = makeExpression('sl-t', 'slide', data as unknown as Record<string, unknown>);
+
+    expect(() => renderSlide(ctx, expr, rc as any)).not.toThrow();
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Welcome');
+  });
+
+  it('[HAPPY] renders "bullets" layout with title and list items', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: SlideData = {
+      kind: 'slide',
+      title: 'Agenda',
+      bullets: ['Intro', 'Demo', 'Q&A'],
+      layout: 'bullets',
+    };
+    const expr = makeExpression('sl-b', 'slide', data as unknown as Record<string, unknown>);
+
+    expect(() => renderSlide(ctx, expr, rc as any)).not.toThrow();
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Agenda');
+    // Bullets rendered with bullet character prefix
+    expect(textCalls.some((t: string) => t.includes('Intro'))).toBe(true);
+    expect(textCalls.some((t: string) => t.includes('Demo'))).toBe(true);
+    expect(textCalls.some((t: string) => t.includes('Q&A'))).toBe(true);
+  });
+
+  it('[HAPPY] renders "split" layout with title and two columns', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: SlideData = {
+      kind: 'slide',
+      title: 'Comparison',
+      bullets: ['Left A', 'Left B', 'Right A', 'Right B'],
+      layout: 'split',
+    };
+    const expr = makeExpression('sl-s', 'slide', data as unknown as Record<string, unknown>);
+
+    expect(() => renderSlide(ctx, expr, rc as any)).not.toThrow();
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Comparison');
+  });
+
+  it('[EMPTY] renders slide with no bullets [AC10]', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: SlideData = { kind: 'slide', title: 'Empty Slide', bullets: [], layout: 'bullets' };
+    const expr = makeExpression('sl-empty', 'slide', data as unknown as Record<string, unknown>);
+
+    expect(() => renderSlide(ctx, expr, rc as any)).not.toThrow();
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Empty Slide');
+  });
+
+  it('[REGISTRATION] self-registers as "slide" [AC9]', () => {
+    const renderer = getCompositeRenderer('slide');
+    expect(renderer).not.toBeNull();
+    expect(typeof renderer).toBe('function');
+  });
+});
+
+// ── AC7: Collaboration Diagram Renderer ──────────────────────
+
+describe('collaborationDiagramRenderer [AC7]', () => {
+  let renderCollaborationDiagram: typeof import('../renderer/composites/collaborationDiagramRenderer.js').renderCollaborationDiagram;
+
+  beforeAll(async () => {
+    const mod = await import('../renderer/composites/collaborationDiagramRenderer.js');
+    renderCollaborationDiagram = mod.renderCollaborationDiagram;
+  });
+
+
+  it('[HAPPY] renders objects as rounded rectangles with links', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: CollaborationDiagramData = {
+      kind: 'collaboration-diagram',
+      title: 'Auth Flow',
+      objects: [
+        { id: 'o1', name: 'Client', type: 'actor' },
+        { id: 'o2', name: 'Server', type: 'system' },
+        { id: 'o3', name: 'DB', type: 'database' },
+      ],
+      links: [
+        { from: 'o1', to: 'o2', label: 'login()', direction: 'unidirectional' },
+        { from: 'o2', to: 'o3', label: 'query', direction: 'bidirectional' },
+      ],
+    };
+    const expr = makeExpression('cd-1', 'collaboration-diagram', data as unknown as Record<string, unknown>);
+
+    expect(() => renderCollaborationDiagram(ctx, expr, rc as any)).not.toThrow();
+
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Auth Flow');
+    expect(textCalls).toContain('Client');
+    expect(textCalls).toContain('Server');
+    expect(textCalls).toContain('DB');
+    expect(textCalls).toContain('login()');
+    expect(textCalls).toContain('query');
+
+    // 3 objects = 3 rounded rectangles
+    expect(rc.rectangle.mock.calls.length).toBeGreaterThanOrEqual(3);
+    // 2 links = lines drawn
+    expect(rc.line.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('[HAPPY] bidirectional links have arrowheads on both ends', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: CollaborationDiagramData = {
+      kind: 'collaboration-diagram',
+      title: 'Bi-test',
+      objects: [
+        { id: 'a', name: 'A', type: 'service' },
+        { id: 'b', name: 'B', type: 'service' },
+      ],
+      links: [
+        { from: 'a', to: 'b', label: 'sync', direction: 'bidirectional' },
+      ],
+    };
+    const expr = makeExpression('cd-bi', 'collaboration-diagram', data as unknown as Record<string, unknown>);
+
+    renderCollaborationDiagram(ctx, expr, rc as any);
+
+    // Bidirectional draws arrowheads on both ends (ctx.fill called for arrowheads)
+    expect(ctx.beginPath.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('[EMPTY] renders with no objects or links [AC10]', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: CollaborationDiagramData = {
+      kind: 'collaboration-diagram',
+      title: 'Empty Collab',
+      objects: [],
+      links: [],
+    };
+    const expr = makeExpression('cd-empty', 'collaboration-diagram', data as unknown as Record<string, unknown>);
+
+    expect(() => renderCollaborationDiagram(ctx, expr, rc as any)).not.toThrow();
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Empty Collab');
+  });
+
+  it('[REGISTRATION] self-registers as "collaboration-diagram" [AC9]', () => {
+    const renderer = getCompositeRenderer('collaboration-diagram');
+    expect(renderer).not.toBeNull();
+    expect(typeof renderer).toBe('function');
+  });
+});
+
+// ── AC8: Decision Tree Renderer ──────────────────────────────
+
+describe('decisionTreeRenderer [AC8]', () => {
+  let renderDecisionTree: typeof import('../renderer/composites/decisionTreeRenderer.js').renderDecisionTree;
+
+  beforeAll(async () => {
+    const mod = await import('../renderer/composites/decisionTreeRenderer.js');
+    renderDecisionTree = mod.renderDecisionTree;
+  });
+
+
+  it('[HAPPY] renders root question and branching options', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: DecisionTreeData = {
+      kind: 'decision-tree',
+      question: 'Use TypeScript?',
+      options: [
+        {
+          label: 'Yes',
+          outcome: 'Type safety',
+          children: [],
+        },
+        {
+          label: 'No',
+          children: [
+            { label: 'JavaScript', outcome: 'Fast start', children: [] },
+            { label: 'CoffeeScript', outcome: 'Niche', children: [] },
+          ],
+        },
+      ],
+    };
+    const expr = makeExpression('dt-1', 'decision-tree', data as unknown as Record<string, unknown>);
+
+    expect(() => renderDecisionTree(ctx, expr, rc as any)).not.toThrow();
+
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Use TypeScript?');
+    expect(textCalls).toContain('Yes');
+    expect(textCalls).toContain('No');
+    expect(textCalls.some((t: string) => t.includes('Type safety'))).toBe(true);
+  });
+
+  it('[HAPPY] respects max 4 levels depth', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    // Create a 6-level deep tree — renderer should stop at level 4
+    const deepOption = (depth: number): any => ({
+      label: `Level ${depth}`,
+      outcome: depth >= 6 ? 'Deep' : undefined,
+      children: depth < 6 ? [deepOption(depth + 1)] : [],
+    });
+
+    const data: DecisionTreeData = {
+      kind: 'decision-tree',
+      question: 'Deep Q?',
+      options: [deepOption(1)],
+    };
+    const expr = makeExpression('dt-deep', 'decision-tree', data as unknown as Record<string, unknown>);
+
+    expect(() => renderDecisionTree(ctx, expr, rc as any)).not.toThrow();
+
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Deep Q?');
+    expect(textCalls).toContain('Level 1');
+    // Level 4 should be rendered (max depth)
+    expect(textCalls).toContain('Level 4');
+    // Level 5+ should NOT be rendered (beyond max depth)
+    expect(textCalls).not.toContain('Level 5');
+  });
+
+  it('[EMPTY] renders decision tree with no options [AC10]', () => {
+    const ctx = createMockCtx();
+    const rc = createMockRoughCanvas();
+
+    const data: DecisionTreeData = { kind: 'decision-tree', question: 'Empty?', options: [] };
+    const expr = makeExpression('dt-empty', 'decision-tree', data as unknown as Record<string, unknown>);
+
+    expect(() => renderDecisionTree(ctx, expr, rc as any)).not.toThrow();
+    const textCalls = ctx.fillText.mock.calls.map((c: any[]) => c[0]);
+    expect(textCalls).toContain('Empty?');
+  });
+
+  it('[REGISTRATION] self-registers as "decision-tree" [AC9]', () => {
+    const renderer = getCompositeRenderer('decision-tree');
+    expect(renderer).not.toBeNull();
+    expect(typeof renderer).toBe('function');
+  });
+});
+
+// ── AC9: All renderers registered in composite registry ──────
+
+describe('composite registry completeness [AC9]', () => {
+  it('all 8 new renderers are registered after import', () => {
+    // All modules were imported in beforeAll blocks above,
+    // triggering their self-registration side effects.
+    const expectedKinds = [
+      'kanban',
+      'table',
+      'wireframe',
+      'roadmap',
+      'code-block',
+      'slide',
+      'collaboration-diagram',
+      'decision-tree',
+    ];
+
+    for (const kind of expectedKinds) {
+      expect(getCompositeRenderer(kind)).not.toBeNull();
+    }
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -65,6 +65,14 @@ export {
   clearLayoutCache as clearReasoningLayoutCache,
   computeReasoningLayout,
 } from './renderer/composites/reasoningChainRenderer.js';
+export { renderKanban } from './renderer/composites/kanbanRenderer.js';
+export { renderTable } from './renderer/composites/tableRenderer.js';
+export { renderWireframe } from './renderer/composites/wireframeRenderer.js';
+export { renderRoadmap } from './renderer/composites/roadmapRenderer.js';
+export { renderCodeBlock } from './renderer/composites/codeBlockRenderer.js';
+export { renderSlide } from './renderer/composites/slideRenderer.js';
+export { renderCollaborationDiagram } from './renderer/composites/collaborationDiagramRenderer.js';
+export { renderDecisionTree } from './renderer/composites/decisionTreeRenderer.js';
 
 // ── Interaction ────────────────────────────────────────────
 export {

--- a/packages/engine/src/renderer/composites/codeBlockRenderer.ts
+++ b/packages/engine/src/renderer/composites/codeBlockRenderer.ts
@@ -1,0 +1,110 @@
+/**
+ * Code block composite renderer.
+ *
+ * Renders code with a dark background (#1e1e1e), language label in
+ * the top-right corner, and white monospace text. No syntax
+ * highlighting is applied.
+ *
+ * @module
+ */
+
+import type { VisualExpression, CodeBlockData } from '@infinicanvas/protocol';
+import type { RoughCanvas } from 'roughjs/bin/canvas.js';
+import { registerCompositeRenderer } from '../compositeRegistry.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Dark background color. */
+const BG_COLOR = '#1e1e1e';
+
+/** Code text color. */
+const TEXT_COLOR = '#d4d4d4';
+
+/** Language label color. */
+const LABEL_COLOR = '#888888';
+
+/** Padding inside the code block. */
+const PADDING = 16;
+
+/** Line height for code text. */
+const LINE_HEIGHT = 20;
+
+/** Font size for code. */
+const CODE_FONT_SIZE = 13;
+
+/** Font size for language label. */
+const LABEL_FONT_SIZE = 11;
+
+/** Font family for monospace code. */
+const CODE_FONT_FAMILY = 'monospace';
+
+/** Corner radius for the background. */
+const CORNER_RADIUS = 6;
+
+// ── Main renderer ────────────────────────────────────────────
+
+/**
+ * Render a code block expression. [AC5]
+ *
+ * @param ctx - The 2D canvas context.
+ * @param expr - The code block VisualExpression.
+ * @param rc - The Rough.js canvas (unused — code block uses native rendering).
+ */
+export function renderCodeBlock(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  _rc: RoughCanvas,
+): void {
+  const data = expr.data as CodeBlockData;
+  const { x: originX, y: originY } = expr.position;
+  const { width, height } = expr.size;
+
+  ctx.save();
+
+  // ── Dark background ────────────────────────────────────────
+  ctx.fillStyle = BG_COLOR;
+  ctx.beginPath();
+  if (ctx.roundRect) {
+    ctx.roundRect(originX, originY, width, height, CORNER_RADIUS);
+  } else {
+    ctx.rect(originX, originY, width, height);
+  }
+  ctx.fill();
+
+  // Clipping is handled by fillRect for the background
+  ctx.fillRect(originX, originY, width, height);
+
+  // ── Language label (top-right) ─────────────────────────────
+  if (data.language) {
+    ctx.font = `${LABEL_FONT_SIZE}px ${CODE_FONT_FAMILY}`;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    ctx.fillStyle = LABEL_COLOR;
+    ctx.fillText(data.language, originX + width - PADDING, originY + PADDING / 2);
+  }
+
+  // ── Code text ──────────────────────────────────────────────
+  if (!data.code) {
+    ctx.restore();
+    return;
+  }
+
+  const lines = data.code.split('\n');
+  ctx.font = `${CODE_FONT_SIZE}px ${CODE_FONT_FAMILY}`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  ctx.fillStyle = TEXT_COLOR;
+
+  const codeTop = originY + PADDING + (data.language ? LINE_HEIGHT : 0);
+  const maxLines = Math.floor((height - PADDING * 2) / LINE_HEIGHT);
+
+  for (let i = 0; i < Math.min(lines.length, maxLines); i++) {
+    ctx.fillText(lines[i]!, originX + PADDING, codeTop + i * LINE_HEIGHT);
+  }
+
+  ctx.restore();
+}
+
+// ── Self-registration ────────────────────────────────────────
+
+registerCompositeRenderer('code-block', renderCodeBlock);

--- a/packages/engine/src/renderer/composites/collaborationDiagramRenderer.ts
+++ b/packages/engine/src/renderer/composites/collaborationDiagramRenderer.ts
@@ -1,0 +1,178 @@
+/**
+ * Collaboration diagram composite renderer.
+ *
+ * Renders objects as labeled rounded rectangles arranged in a circle.
+ * Links are drawn as lines between objects with labels at midpoint.
+ * Bidirectional links have arrowheads on both ends; unidirectional
+ * links have an arrowhead only at the target end.
+ *
+ * @module
+ */
+
+import type { VisualExpression, CollaborationDiagramData, CollabObject } from '@infinicanvas/protocol';
+import type { RoughCanvas } from 'roughjs/bin/canvas.js';
+import { mapStyleToRoughOptions } from '../styleMapper.js';
+import { renderArrowhead } from '../primitiveRenderer.js';
+import { registerCompositeRenderer } from '../compositeRegistry.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Padding around the diagram. */
+const PADDING = 20;
+
+/** Height reserved for the title. */
+const TITLE_HEIGHT = 28;
+
+/** Object rectangle width. */
+const OBJECT_WIDTH = 100;
+
+/** Object rectangle height. */
+const OBJECT_HEIGHT = 40;
+
+/** Default font family. */
+const FONT_FAMILY = 'sans-serif';
+
+/** Title font size. */
+const TITLE_FONT_SIZE = 16;
+
+/** Object label font size. */
+const OBJECT_FONT_SIZE = 12;
+
+/** Link label font size. */
+const LINK_LABEL_FONT_SIZE = 11;
+
+/** Arrowhead size. */
+const ARROWHEAD_SIZE = 8;
+
+// ── Layout helpers ───────────────────────────────────────────
+
+interface PositionedObject {
+  id: string;
+  name: string;
+  cx: number;
+  cy: number;
+}
+
+/**
+ * Arrange objects in a circular layout within the given bounds.
+ */
+function layoutObjects(
+  objects: CollabObject[],
+  centerX: number,
+  centerY: number,
+  radiusX: number,
+  radiusY: number,
+): PositionedObject[] {
+  if (objects.length === 0) return [];
+  if (objects.length === 1) {
+    return [{ id: objects[0]!.id, name: objects[0]!.name, cx: centerX, cy: centerY }];
+  }
+
+  return objects.map((obj, i) => {
+    const angle = (2 * Math.PI * i) / objects.length - Math.PI / 2;
+    return {
+      id: obj.id,
+      name: obj.name,
+      cx: centerX + radiusX * Math.cos(angle),
+      cy: centerY + radiusY * Math.sin(angle),
+    };
+  });
+}
+
+// ── Main renderer ────────────────────────────────────────────
+
+/**
+ * Render a collaboration diagram expression. [AC7]
+ *
+ * @param ctx - The 2D canvas context.
+ * @param expr - The collaboration diagram VisualExpression.
+ * @param rc - The Rough.js canvas for sketchy rendering.
+ */
+export function renderCollaborationDiagram(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  rc: RoughCanvas,
+): void {
+  const data = expr.data as CollaborationDiagramData;
+  const { x: originX, y: originY } = expr.position;
+  const { width, height } = expr.size;
+  const roughOptions = mapStyleToRoughOptions(expr.style);
+
+  ctx.save();
+
+  // ── Title ──────────────────────────────────────────────────
+  ctx.font = `bold ${TITLE_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = expr.style.strokeColor;
+  ctx.fillText(data.title, originX + width / 2, originY + PADDING + TITLE_HEIGHT / 2);
+
+  // ── Empty diagram ──────────────────────────────────────────
+  if (data.objects.length === 0) {
+    ctx.restore();
+    return;
+  }
+
+  // ── Layout objects in circular arrangement ─────────────────
+  const contentTop = originY + PADDING + TITLE_HEIGHT;
+  const contentHeight = height - PADDING * 2 - TITLE_HEIGHT;
+  const centerX = originX + width / 2;
+  const centerY = contentTop + contentHeight / 2;
+  const radiusX = (width - PADDING * 2 - OBJECT_WIDTH) / 2;
+  const radiusY = (contentHeight - OBJECT_HEIGHT) / 2;
+
+  const positioned = layoutObjects(data.objects, centerX, centerY, radiusX, radiusY);
+  const posMap = new Map(positioned.map(p => [p.id, p]));
+
+  // ── Render links ───────────────────────────────────────────
+  for (const link of data.links) {
+    const fromObj = posMap.get(link.from);
+    const toObj = posMap.get(link.to);
+    if (!fromObj || !toObj) continue;
+
+    // Draw line
+    const lineDrawable = rc.line(fromObj.cx, fromObj.cy, toObj.cx, toObj.cy, roughOptions);
+    rc.draw(lineDrawable);
+
+    // Arrowhead at target
+    const angle = Math.atan2(toObj.cy - fromObj.cy, toObj.cx - fromObj.cx);
+    ctx.fillStyle = (roughOptions.stroke as string) ?? '#000000';
+    renderArrowhead(ctx, toObj.cx, toObj.cy, angle, ARROWHEAD_SIZE);
+
+    // Bidirectional: arrowhead at source too
+    if (link.direction === 'bidirectional') {
+      const reverseAngle = angle + Math.PI;
+      renderArrowhead(ctx, fromObj.cx, fromObj.cy, reverseAngle, ARROWHEAD_SIZE);
+    }
+
+    // Link label at midpoint
+    const midX = (fromObj.cx + toObj.cx) / 2;
+    const midY = (fromObj.cy + toObj.cy) / 2;
+    ctx.font = `${LINK_LABEL_FONT_SIZE}px ${FONT_FAMILY}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    ctx.fillStyle = (roughOptions.stroke as string) ?? '#000000';
+    ctx.fillText(link.label, midX, midY - 4);
+  }
+
+  // ── Render objects (on top of links) ───────────────────────
+  for (const obj of positioned) {
+    const rx = obj.cx - OBJECT_WIDTH / 2;
+    const ry = obj.cy - OBJECT_HEIGHT / 2;
+
+    const drawable = rc.rectangle(rx, ry, OBJECT_WIDTH, OBJECT_HEIGHT, roughOptions);
+    rc.draw(drawable);
+
+    ctx.font = `${OBJECT_FONT_SIZE}px ${FONT_FAMILY}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = (roughOptions.stroke as string) ?? '#000000';
+    ctx.fillText(obj.name, obj.cx, obj.cy);
+  }
+
+  ctx.restore();
+}
+
+// ── Self-registration ────────────────────────────────────────
+
+registerCompositeRenderer('collaboration-diagram', renderCollaborationDiagram);

--- a/packages/engine/src/renderer/composites/decisionTreeRenderer.ts
+++ b/packages/engine/src/renderer/composites/decisionTreeRenderer.ts
@@ -1,0 +1,241 @@
+/**
+ * Decision tree composite renderer.
+ *
+ * Renders a root question at the top with options branching downward.
+ * Supports a maximum of 4 levels of recursive depth. Outcomes are
+ * displayed as leaf text nodes.
+ *
+ * @module
+ */
+
+import type { VisualExpression, DecisionTreeData, DecisionOption } from '@infinicanvas/protocol';
+import type { RoughCanvas } from 'roughjs/bin/canvas.js';
+import type { Options } from 'roughjs/bin/core.js';
+import { mapStyleToRoughOptions } from '../styleMapper.js';
+import { registerCompositeRenderer } from '../compositeRegistry.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Padding around the decision tree. */
+const PADDING = 20;
+
+/** Maximum recursive depth for rendering. */
+const MAX_DEPTH = 4;
+
+/** Height of the root question box. */
+const QUESTION_HEIGHT = 40;
+
+/** Width of option nodes. */
+const OPTION_WIDTH = 120;
+
+/** Height of option nodes. */
+const OPTION_HEIGHT = 32;
+
+/** Vertical gap between levels. */
+const LEVEL_GAP = 50;
+
+/** Horizontal gap between sibling options. */
+const SIBLING_GAP = 16;
+
+/** Default font family. */
+const FONT_FAMILY = 'sans-serif';
+
+/** Question font size. */
+const QUESTION_FONT_SIZE = 14;
+
+/** Option label font size. */
+const OPTION_FONT_SIZE = 12;
+
+/** Outcome text font size. */
+const OUTCOME_FONT_SIZE = 10;
+
+/** Outcome text vertical offset below option. */
+const OUTCOME_OFFSET = 14;
+
+// ── Layout computation ───────────────────────────────────────
+
+interface LayoutNode {
+  label: string;
+  outcome?: string;
+  children: LayoutNode[];
+  x: number;
+  y: number;
+  width: number;
+}
+
+/**
+ * Compute the total width needed for a subtree.
+ */
+function computeSubtreeWidth(option: DecisionOption, depth: number): number {
+  if (depth >= MAX_DEPTH || option.children.length === 0) {
+    return OPTION_WIDTH;
+  }
+
+  const childrenWidth = option.children.reduce(
+    (sum, child) => sum + computeSubtreeWidth(child, depth + 1),
+    0,
+  );
+  const gaps = Math.max(0, option.children.length - 1) * SIBLING_GAP;
+
+  return Math.max(OPTION_WIDTH, childrenWidth + gaps);
+}
+
+/**
+ * Layout a subtree recursively, assigning x/y positions.
+ */
+function layoutSubtree(
+  option: DecisionOption,
+  centerX: number,
+  topY: number,
+  depth: number,
+): LayoutNode {
+  const node: LayoutNode = {
+    label: option.label,
+    outcome: option.outcome,
+    children: [],
+    x: centerX,
+    y: topY,
+    width: OPTION_WIDTH,
+  };
+
+  if (depth >= MAX_DEPTH || option.children.length === 0) {
+    return node;
+  }
+
+  const childY = topY + OPTION_HEIGHT + LEVEL_GAP;
+  const totalWidth = computeSubtreeWidth(option, depth);
+  let currentX = centerX - totalWidth / 2;
+
+  for (const child of option.children) {
+    const childWidth = computeSubtreeWidth(child, depth + 1);
+    const childCenterX = currentX + childWidth / 2;
+    const childNode = layoutSubtree(child, childCenterX, childY, depth + 1);
+    node.children.push(childNode);
+    currentX += childWidth + SIBLING_GAP;
+  }
+
+  return node;
+}
+
+// ── Main renderer ────────────────────────────────────────────
+
+/**
+ * Render a decision tree expression. [AC8]
+ *
+ * @param ctx - The 2D canvas context.
+ * @param expr - The decision tree VisualExpression.
+ * @param rc - The Rough.js canvas for sketchy rendering.
+ */
+export function renderDecisionTree(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  rc: RoughCanvas,
+): void {
+  const data = expr.data as DecisionTreeData;
+  const { x: originX, y: originY } = expr.position;
+  const { width } = expr.size;
+  const roughOptions = mapStyleToRoughOptions(expr.style);
+
+  ctx.save();
+
+  // ── Root question ──────────────────────────────────────────
+  const questionCenterX = originX + width / 2;
+  const questionY = originY + PADDING;
+
+  ctx.font = `bold ${QUESTION_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = expr.style.strokeColor;
+  ctx.fillText(data.question, questionCenterX, questionY + QUESTION_HEIGHT / 2);
+
+  // ── Empty tree ─────────────────────────────────────────────
+  if (data.options.length === 0) {
+    ctx.restore();
+    return;
+  }
+
+  // ── Layout options ─────────────────────────────────────────
+  const optionsTopY = questionY + QUESTION_HEIGHT + LEVEL_GAP;
+
+  // Compute total width of all top-level options
+  const totalWidth = data.options.reduce(
+    (sum, opt) => sum + computeSubtreeWidth(opt, 1),
+    0,
+  ) + Math.max(0, data.options.length - 1) * SIBLING_GAP;
+
+  let currentX = questionCenterX - totalWidth / 2;
+  const layoutNodes: LayoutNode[] = [];
+
+  for (const option of data.options) {
+    const optWidth = computeSubtreeWidth(option, 1);
+    const optCenterX = currentX + optWidth / 2;
+    layoutNodes.push(layoutSubtree(option, optCenterX, optionsTopY, 1));
+    currentX += optWidth + SIBLING_GAP;
+  }
+
+  // ── Render tree ────────────────────────────────────────────
+  for (const node of layoutNodes) {
+    // Draw connector from question to top-level option
+    drawConnector(ctx, rc, questionCenterX, questionY + QUESTION_HEIGHT, node.x, node.y, roughOptions);
+    renderNode(ctx, rc, node, roughOptions);
+  }
+
+  ctx.restore();
+}
+
+/**
+ * Render a single option node and its children recursively.
+ */
+function renderNode(
+  ctx: CanvasRenderingContext2D,
+  rc: RoughCanvas,
+  node: LayoutNode,
+  roughOptions: Options,
+): void {
+  // Draw option box
+  const rx = node.x - OPTION_WIDTH / 2;
+  const drawable = rc.rectangle(rx, node.y, OPTION_WIDTH, OPTION_HEIGHT, roughOptions);
+  rc.draw(drawable);
+
+  // Option label
+  ctx.font = `${OPTION_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = (roughOptions.stroke as string) ?? '#000000';
+  ctx.fillText(node.label, node.x, node.y + OPTION_HEIGHT / 2);
+
+  // Outcome text below leaf nodes
+  if (node.outcome && node.children.length === 0) {
+    ctx.font = `italic ${OUTCOME_FONT_SIZE}px ${FONT_FAMILY}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillStyle = '#666666';
+    ctx.fillText(node.outcome, node.x, node.y + OPTION_HEIGHT + OUTCOME_OFFSET / 2);
+  }
+
+  // Render children
+  for (const child of node.children) {
+    drawConnector(ctx, rc, node.x, node.y + OPTION_HEIGHT, child.x, child.y, roughOptions);
+    renderNode(ctx, rc, child, roughOptions);
+  }
+}
+
+/**
+ * Draw a vertical connector line between parent bottom and child top.
+ */
+function drawConnector(
+  _ctx: CanvasRenderingContext2D,
+  rc: RoughCanvas,
+  fromX: number,
+  fromY: number,
+  toX: number,
+  toY: number,
+  roughOptions: Options,
+): void {
+  const lineDrawable = rc.line(fromX, fromY, toX, toY, roughOptions);
+  rc.draw(lineDrawable);
+}
+
+// ── Self-registration ────────────────────────────────────────
+
+registerCompositeRenderer('decision-tree', renderDecisionTree);

--- a/packages/engine/src/renderer/composites/kanbanRenderer.ts
+++ b/packages/engine/src/renderer/composites/kanbanRenderer.ts
@@ -1,0 +1,130 @@
+/**
+ * Kanban board composite renderer.
+ *
+ * Renders columns as vertical sections with title headers and cards
+ * as stacked Rough.js rectangles with title text. Column width is
+ * computed as expression width / columns.length.
+ *
+ * @module
+ */
+
+import type { VisualExpression, KanbanData } from '@infinicanvas/protocol';
+import type { RoughCanvas } from 'roughjs/bin/canvas.js';
+import { mapStyleToRoughOptions } from '../styleMapper.js';
+import { registerCompositeRenderer } from '../compositeRegistry.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Padding inside the kanban board. */
+const PADDING = 16;
+
+/** Height reserved for the board title. */
+const TITLE_HEIGHT = 30;
+
+/** Height reserved for each column header. */
+const COLUMN_HEADER_HEIGHT = 28;
+
+/** Height of each card rectangle. */
+const CARD_HEIGHT = 36;
+
+/** Vertical gap between cards. */
+const CARD_GAP = 8;
+
+/** Horizontal gap between columns. */
+const COLUMN_GAP = 8;
+
+/** Default font family. */
+const FONT_FAMILY = 'sans-serif';
+
+/** Title font size. */
+const TITLE_FONT_SIZE = 16;
+
+/** Column header font size. */
+const HEADER_FONT_SIZE = 13;
+
+/** Card font size. */
+const CARD_FONT_SIZE = 12;
+
+/** Card inner padding. */
+const CARD_PADDING = 6;
+
+// ── Main renderer ────────────────────────────────────────────
+
+/**
+ * Render a kanban board expression. [AC1]
+ *
+ * @param ctx - The 2D canvas context.
+ * @param expr - The kanban VisualExpression.
+ * @param rc - The Rough.js canvas for sketchy rendering.
+ */
+export function renderKanban(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  rc: RoughCanvas,
+): void {
+  const data = expr.data as KanbanData;
+  const { x: originX, y: originY } = expr.position;
+  const { width, height } = expr.size;
+  const roughOptions = mapStyleToRoughOptions(expr.style);
+
+  ctx.save();
+
+  // ── Title ──────────────────────────────────────────────────
+  ctx.font = `bold ${TITLE_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = expr.style.strokeColor;
+  ctx.fillText(data.title, originX + width / 2, originY + PADDING + TITLE_HEIGHT / 2);
+
+  // ── Empty board ────────────────────────────────────────────
+  if (data.columns.length === 0) {
+    ctx.restore();
+    return;
+  }
+
+  // ── Column layout ──────────────────────────────────────────
+  const contentTop = originY + PADDING + TITLE_HEIGHT;
+  const totalGap = COLUMN_GAP * (data.columns.length - 1);
+  const usableWidth = width - PADDING * 2 - totalGap;
+  const colWidth = usableWidth / data.columns.length;
+
+  for (let ci = 0; ci < data.columns.length; ci++) {
+    const col = data.columns[ci]!;
+    const colX = originX + PADDING + ci * (colWidth + COLUMN_GAP);
+
+    // Column header
+    ctx.font = `bold ${HEADER_FONT_SIZE}px ${FONT_FAMILY}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = expr.style.strokeColor;
+    ctx.fillText(col.title, colX + colWidth / 2, contentTop + COLUMN_HEADER_HEIGHT / 2);
+
+    // Column separator line
+    if (ci > 0) {
+      const sepX = colX - COLUMN_GAP / 2;
+      const sepDrawable = rc.line(sepX, contentTop, sepX, originY + height - PADDING, roughOptions);
+      rc.draw(sepDrawable);
+    }
+
+    // Cards
+    let cardY = contentTop + COLUMN_HEADER_HEIGHT + CARD_GAP;
+    for (const card of col.cards) {
+      const drawable = rc.rectangle(colX, cardY, colWidth, CARD_HEIGHT, roughOptions);
+      rc.draw(drawable);
+
+      ctx.font = `${CARD_FONT_SIZE}px ${FONT_FAMILY}`;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = expr.style.strokeColor;
+      ctx.fillText(card.title, colX + CARD_PADDING, cardY + CARD_HEIGHT / 2);
+
+      cardY += CARD_HEIGHT + CARD_GAP;
+    }
+  }
+
+  ctx.restore();
+}
+
+// ── Self-registration ────────────────────────────────────────
+
+registerCompositeRenderer('kanban', renderKanban);

--- a/packages/engine/src/renderer/composites/roadmapRenderer.ts
+++ b/packages/engine/src/renderer/composites/roadmapRenderer.ts
@@ -1,0 +1,211 @@
+/**
+ * Roadmap composite renderer.
+ *
+ * Renders phases as sections (horizontal or vertical per orientation)
+ * with items as chips, color-coded by status:
+ * - planned = gray
+ * - in-progress = blue
+ * - done = green
+ *
+ * @module
+ */
+
+import type { VisualExpression, RoadmapData, RoadmapItem } from '@infinicanvas/protocol';
+import type { RoughCanvas } from 'roughjs/bin/canvas.js';
+import type { Options } from 'roughjs/bin/core.js';
+import { mapStyleToRoughOptions } from '../styleMapper.js';
+import { registerCompositeRenderer } from '../compositeRegistry.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Padding around the roadmap. */
+const PADDING = 16;
+
+/** Height reserved for the title. */
+const TITLE_HEIGHT = 30;
+
+/** Height of a phase name label. */
+const PHASE_HEADER_HEIGHT = 24;
+
+/** Item chip height. */
+const CHIP_HEIGHT = 26;
+
+/** Gap between items. */
+const CHIP_GAP = 6;
+
+/** Item chip horizontal padding. */
+const CHIP_PADDING = 8;
+
+/** Gap between phases. */
+const PHASE_GAP = 12;
+
+/** Default font family. */
+const FONT_FAMILY = 'sans-serif';
+
+/** Title font size. */
+const TITLE_FONT_SIZE = 16;
+
+/** Phase header font size. */
+const PHASE_FONT_SIZE = 13;
+
+/** Chip font size. */
+const CHIP_FONT_SIZE = 11;
+
+// ── Status colors ────────────────────────────────────────────
+
+/** Map status to fill color for chips. */
+const STATUS_COLORS: Record<RoadmapItem['status'], string> = {
+  'planned': '#cccccc',
+  'in-progress': '#4a90d9',
+  'done': '#4caf50',
+};
+
+// ── Main renderer ────────────────────────────────────────────
+
+/**
+ * Render a roadmap expression. [AC4]
+ *
+ * @param ctx - The 2D canvas context.
+ * @param expr - The roadmap VisualExpression.
+ * @param rc - The Rough.js canvas for sketchy rendering.
+ */
+export function renderRoadmap(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  rc: RoughCanvas,
+): void {
+  const data = expr.data as RoadmapData;
+  const { x: originX, y: originY } = expr.position;
+  const { width } = expr.size;
+  const roughOptions = mapStyleToRoughOptions(expr.style);
+
+  ctx.save();
+
+  // ── Title ──────────────────────────────────────────────────
+  ctx.font = `bold ${TITLE_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = expr.style.strokeColor;
+  ctx.fillText(data.title, originX + width / 2, originY + PADDING + TITLE_HEIGHT / 2);
+
+  // ── Empty roadmap ──────────────────────────────────────────
+  if (data.phases.length === 0) {
+    ctx.restore();
+    return;
+  }
+
+  const isHorizontal = data.orientation === 'horizontal';
+
+  if (isHorizontal) {
+    renderHorizontal(ctx, rc, data, originX, originY, width, roughOptions);
+  } else {
+    renderVertical(ctx, rc, data, originX, originY, width, roughOptions);
+  }
+
+  ctx.restore();
+}
+
+/**
+ * Render phases as horizontal sections (left to right).
+ */
+function renderHorizontal(
+  ctx: CanvasRenderingContext2D,
+  rc: RoughCanvas,
+  data: RoadmapData,
+  originX: number,
+  originY: number,
+  totalWidth: number,
+  roughOptions: Options,
+): void {
+  const contentTop = originY + PADDING + TITLE_HEIGHT;
+  const totalGap = PHASE_GAP * (data.phases.length - 1);
+  const usableWidth = totalWidth - PADDING * 2 - totalGap;
+  const phaseWidth = usableWidth / data.phases.length;
+
+  for (let pi = 0; pi < data.phases.length; pi++) {
+    const phase = data.phases[pi]!;
+    const phaseX = originX + PADDING + pi * (phaseWidth + PHASE_GAP);
+
+    // Phase header
+    ctx.font = `bold ${PHASE_FONT_SIZE}px ${FONT_FAMILY}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = roughOptions.stroke as string ?? '#000000';
+    ctx.fillText(phase.name, phaseX + phaseWidth / 2, contentTop + PHASE_HEADER_HEIGHT / 2);
+
+    // Items as chips
+    let chipY = contentTop + PHASE_HEADER_HEIGHT + CHIP_GAP;
+    for (const item of phase.items) {
+      renderChip(ctx, rc, item, phaseX, chipY, phaseWidth, roughOptions);
+      chipY += CHIP_HEIGHT + CHIP_GAP;
+    }
+  }
+}
+
+/**
+ * Render phases as vertical sections (top to bottom).
+ */
+function renderVertical(
+  ctx: CanvasRenderingContext2D,
+  rc: RoughCanvas,
+  data: RoadmapData,
+  originX: number,
+  originY: number,
+  totalWidth: number,
+  roughOptions: Options,
+): void {
+  const contentWidth = totalWidth - PADDING * 2;
+  let currentY = originY + PADDING + TITLE_HEIGHT;
+
+  for (const phase of data.phases) {
+    // Phase header
+    ctx.font = `bold ${PHASE_FONT_SIZE}px ${FONT_FAMILY}`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = roughOptions.stroke as string ?? '#000000';
+    ctx.fillText(phase.name, originX + PADDING, currentY + PHASE_HEADER_HEIGHT / 2);
+
+    currentY += PHASE_HEADER_HEIGHT + CHIP_GAP;
+
+    // Items as chips
+    for (const item of phase.items) {
+      renderChip(ctx, rc, item, originX + PADDING, currentY, contentWidth, roughOptions);
+      currentY += CHIP_HEIGHT + CHIP_GAP;
+    }
+
+    currentY += PHASE_GAP;
+  }
+}
+
+/**
+ * Render a single item chip with status-based coloring.
+ */
+function renderChip(
+  ctx: CanvasRenderingContext2D,
+  rc: RoughCanvas,
+  item: RoadmapItem,
+  x: number,
+  y: number,
+  maxWidth: number,
+  roughOptions: Options,
+): void {
+  const chipColor = STATUS_COLORS[item.status];
+  const chipOptions: Options = {
+    ...roughOptions,
+    fill: chipColor,
+    fillStyle: 'solid',
+  };
+
+  const drawable = rc.rectangle(x, y, maxWidth, CHIP_HEIGHT, chipOptions);
+  rc.draw(drawable);
+
+  ctx.font = `${CHIP_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = item.status === 'planned' ? '#333333' : '#ffffff';
+  ctx.fillText(item.title, x + CHIP_PADDING, y + CHIP_HEIGHT / 2);
+}
+
+// ── Self-registration ────────────────────────────────────────
+
+registerCompositeRenderer('roadmap', renderRoadmap);

--- a/packages/engine/src/renderer/composites/slideRenderer.ts
+++ b/packages/engine/src/renderer/composites/slideRenderer.ts
@@ -1,0 +1,184 @@
+/**
+ * Slide composite renderer.
+ *
+ * Supports three layouts:
+ * - title: centered large text
+ * - bullets: title + bulleted list
+ * - split: title + two columns of bullets
+ *
+ * @module
+ */
+
+import type { VisualExpression, SlideData } from '@infinicanvas/protocol';
+import type { RoughCanvas } from 'roughjs/bin/canvas.js';
+import { mapStyleToRoughOptions } from '../styleMapper.js';
+import { registerCompositeRenderer } from '../compositeRegistry.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Padding inside the slide. */
+const PADDING = 24;
+
+/** Default font family. */
+const FONT_FAMILY = 'sans-serif';
+
+/** Title font size for "title" layout (large centered). */
+const TITLE_LARGE_FONT_SIZE = 28;
+
+/** Title font size for "bullets" / "split" layouts. */
+const TITLE_FONT_SIZE = 20;
+
+/** Bullet text font size. */
+const BULLET_FONT_SIZE = 14;
+
+/** Line height for bullet items. */
+const BULLET_LINE_HEIGHT = 28;
+
+/** Bullet character. */
+const BULLET_CHAR = '• ';
+
+/** Space between title and content area. */
+const TITLE_GAP = 16;
+
+// ── Main renderer ────────────────────────────────────────────
+
+/**
+ * Render a slide expression. [AC6]
+ *
+ * @param ctx - The 2D canvas context.
+ * @param expr - The slide VisualExpression.
+ * @param rc - The Rough.js canvas for sketchy rendering.
+ */
+export function renderSlide(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  rc: RoughCanvas,
+): void {
+  const data = expr.data as SlideData;
+  const { x: originX, y: originY } = expr.position;
+  const { width, height } = expr.size;
+  const roughOptions = mapStyleToRoughOptions(expr.style);
+
+  ctx.save();
+
+  // ── Slide border ───────────────────────────────────────────
+  const borderDrawable = rc.rectangle(originX, originY, width, height, roughOptions);
+  rc.draw(borderDrawable);
+
+  switch (data.layout) {
+    case 'title':
+      renderTitleLayout(ctx, data, originX, originY, width, height);
+      break;
+    case 'bullets':
+      renderBulletsLayout(ctx, data, originX, originY, width, height);
+      break;
+    case 'split':
+      renderSplitLayout(ctx, rc, data, originX, originY, width, height, roughOptions);
+      break;
+    default:
+      renderBulletsLayout(ctx, data, originX, originY, width, height);
+      break;
+  }
+
+  ctx.restore();
+}
+
+/**
+ * "title" layout — large centered title text.
+ */
+function renderTitleLayout(
+  ctx: CanvasRenderingContext2D,
+  data: SlideData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): void {
+  ctx.font = `bold ${TITLE_LARGE_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = '#000000';
+  ctx.fillText(data.title, x + w / 2, y + h / 2);
+}
+
+/**
+ * "bullets" layout — title at top + bulleted list.
+ */
+function renderBulletsLayout(
+  ctx: CanvasRenderingContext2D,
+  data: SlideData,
+  x: number,
+  y: number,
+  _w: number,
+  _h: number,
+): void {
+  // Title
+  ctx.font = `bold ${TITLE_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  ctx.fillStyle = '#000000';
+  ctx.fillText(data.title, x + PADDING, y + PADDING);
+
+  // Bullets
+  ctx.font = `${BULLET_FONT_SIZE}px ${FONT_FAMILY}`;
+  let bulletY = y + PADDING + TITLE_FONT_SIZE + TITLE_GAP;
+
+  for (const bullet of data.bullets) {
+    ctx.fillText(`${BULLET_CHAR}${bullet}`, x + PADDING + 8, bulletY);
+    bulletY += BULLET_LINE_HEIGHT;
+  }
+}
+
+/**
+ * "split" layout — title at top + two columns of bullets.
+ */
+function renderSplitLayout(
+  ctx: CanvasRenderingContext2D,
+  rc: RoughCanvas,
+  data: SlideData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  roughOptions: ReturnType<typeof mapStyleToRoughOptions>,
+): void {
+  // Title
+  ctx.font = `bold ${TITLE_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillStyle = '#000000';
+  ctx.fillText(data.title, x + w / 2, y + PADDING);
+
+  // Vertical divider
+  const midX = x + w / 2;
+  const divTop = y + PADDING + TITLE_FONT_SIZE + TITLE_GAP;
+  const divLine = rc.line(midX, divTop, midX, y + h - PADDING, roughOptions);
+  rc.draw(divLine);
+
+  // Split bullets into left/right halves
+  const midIdx = Math.ceil(data.bullets.length / 2);
+  const leftBullets = data.bullets.slice(0, midIdx);
+  const rightBullets = data.bullets.slice(midIdx);
+
+  ctx.font = `${BULLET_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+
+  // Left column
+  let bulletY = divTop;
+  for (const bullet of leftBullets) {
+    ctx.fillText(`${BULLET_CHAR}${bullet}`, x + PADDING, bulletY);
+    bulletY += BULLET_LINE_HEIGHT;
+  }
+
+  // Right column
+  bulletY = divTop;
+  for (const bullet of rightBullets) {
+    ctx.fillText(`${BULLET_CHAR}${bullet}`, midX + PADDING, bulletY);
+    bulletY += BULLET_LINE_HEIGHT;
+  }
+}
+
+// ── Self-registration ────────────────────────────────────────
+
+registerCompositeRenderer('slide', renderSlide);

--- a/packages/engine/src/renderer/composites/tableRenderer.ts
+++ b/packages/engine/src/renderer/composites/tableRenderer.ts
@@ -1,0 +1,121 @@
+/**
+ * Table composite renderer.
+ *
+ * Renders a grid with bold header row, data rows, and Rough.js lines
+ * separating cells. Uses equal column widths and 30px row height.
+ *
+ * @module
+ */
+
+import type { VisualExpression, TableData } from '@infinicanvas/protocol';
+import type { RoughCanvas } from 'roughjs/bin/canvas.js';
+import { mapStyleToRoughOptions } from '../styleMapper.js';
+import { registerCompositeRenderer } from '../compositeRegistry.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Padding around the table. */
+const PADDING = 12;
+
+/** Height of each row. */
+const ROW_HEIGHT = 30;
+
+/** Default font family. */
+const FONT_FAMILY = 'sans-serif';
+
+/** Header font size. */
+const HEADER_FONT_SIZE = 13;
+
+/** Cell font size. */
+const CELL_FONT_SIZE = 12;
+
+/** Cell horizontal padding. */
+const CELL_PADDING = 8;
+
+// ── Main renderer ────────────────────────────────────────────
+
+/**
+ * Render a table expression. [AC2]
+ *
+ * @param ctx - The 2D canvas context.
+ * @param expr - The table VisualExpression.
+ * @param rc - The Rough.js canvas for sketchy rendering.
+ */
+export function renderTable(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  rc: RoughCanvas,
+): void {
+  const data = expr.data as TableData;
+  const { x: originX, y: originY } = expr.position;
+  const { width } = expr.size;
+  const roughOptions = mapStyleToRoughOptions(expr.style);
+
+  ctx.save();
+
+  // ── Empty table ────────────────────────────────────────────
+  if (data.headers.length === 0 && data.rows.length === 0) {
+    ctx.restore();
+    return;
+  }
+
+  const colCount = Math.max(data.headers.length, ...data.rows.map(r => r.length), 1);
+  const tableWidth = width - PADDING * 2;
+  const colWidth = tableWidth / colCount;
+  const tableX = originX + PADDING;
+  let currentY = originY + PADDING;
+
+  // ── Header row ─────────────────────────────────────────────
+  if (data.headers.length > 0) {
+    // Header background line (bottom of header row)
+    const headerBottomY = currentY + ROW_HEIGHT;
+    const headerLine = rc.line(tableX, headerBottomY, tableX + tableWidth, headerBottomY, roughOptions);
+    rc.draw(headerLine);
+
+    ctx.font = `bold ${HEADER_FONT_SIZE}px ${FONT_FAMILY}`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = expr.style.strokeColor;
+
+    for (let ci = 0; ci < data.headers.length; ci++) {
+      const cellX = tableX + ci * colWidth;
+      ctx.fillText(data.headers[ci]!, cellX + CELL_PADDING, currentY + ROW_HEIGHT / 2);
+    }
+    currentY += ROW_HEIGHT;
+  }
+
+  // ── Data rows ──────────────────────────────────────────────
+  ctx.font = `${CELL_FONT_SIZE}px ${FONT_FAMILY}`;
+
+  for (const row of data.rows) {
+    for (let ci = 0; ci < row.length; ci++) {
+      const cellX = tableX + ci * colWidth;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = expr.style.strokeColor;
+      ctx.fillText(row[ci]!, cellX + CELL_PADDING, currentY + ROW_HEIGHT / 2);
+    }
+
+    currentY += ROW_HEIGHT;
+
+    // Row separator line
+    const rowLine = rc.line(tableX, currentY, tableX + tableWidth, currentY, roughOptions);
+    rc.draw(rowLine);
+  }
+
+  // ── Vertical column separators ─────────────────────────────
+  const tableTop = originY + PADDING;
+  const tableBottom = currentY;
+
+  for (let ci = 1; ci < colCount; ci++) {
+    const sepX = tableX + ci * colWidth;
+    const colLine = rc.line(sepX, tableTop, sepX, tableBottom, roughOptions);
+    rc.draw(colLine);
+  }
+
+  ctx.restore();
+}
+
+// ── Self-registration ────────────────────────────────────────
+
+registerCompositeRenderer('table', renderTable);

--- a/packages/engine/src/renderer/composites/wireframeRenderer.ts
+++ b/packages/engine/src/renderer/composites/wireframeRenderer.ts
@@ -1,0 +1,103 @@
+/**
+ * Wireframe composite renderer.
+ *
+ * Renders UI components as labeled Rough.js rectangles at specified
+ * x, y, w, h positions within expression bounds. Component type is
+ * shown as "[button]", "[input]", etc.
+ *
+ * @module
+ */
+
+import type { VisualExpression, WireframeData } from '@infinicanvas/protocol';
+import type { RoughCanvas } from 'roughjs/bin/canvas.js';
+import { mapStyleToRoughOptions } from '../styleMapper.js';
+import { registerCompositeRenderer } from '../compositeRegistry.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Padding around the wireframe. */
+const PADDING = 12;
+
+/** Height reserved for the title. */
+const TITLE_HEIGHT = 28;
+
+/** Default font family. */
+const FONT_FAMILY = 'sans-serif';
+
+/** Title font size. */
+const TITLE_FONT_SIZE = 16;
+
+/** Component label font size. */
+const LABEL_FONT_SIZE = 11;
+
+/** Component type badge font size. */
+const TYPE_FONT_SIZE = 10;
+
+// ── Main renderer ────────────────────────────────────────────
+
+/**
+ * Render a wireframe expression. [AC3]
+ *
+ * @param ctx - The 2D canvas context.
+ * @param expr - The wireframe VisualExpression.
+ * @param rc - The Rough.js canvas for sketchy rendering.
+ */
+export function renderWireframe(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  rc: RoughCanvas,
+): void {
+  const data = expr.data as WireframeData;
+  const { x: originX, y: originY } = expr.position;
+  const { width } = expr.size;
+  const roughOptions = mapStyleToRoughOptions(expr.style);
+
+  ctx.save();
+
+  // ── Title ──────────────────────────────────────────────────
+  ctx.font = `bold ${TITLE_FONT_SIZE}px ${FONT_FAMILY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = expr.style.strokeColor;
+  ctx.fillText(data.title, originX + width / 2, originY + PADDING + TITLE_HEIGHT / 2);
+
+  // ── Empty wireframe ────────────────────────────────────────
+  if (data.components.length === 0) {
+    ctx.restore();
+    return;
+  }
+
+  // ── Render components ──────────────────────────────────────
+  const contentOffsetX = originX + PADDING;
+  const contentOffsetY = originY + PADDING + TITLE_HEIGHT;
+
+  for (const comp of data.components) {
+    const cx = contentOffsetX + comp.x;
+    const cy = contentOffsetY + comp.y;
+
+    // Component rectangle
+    const drawable = rc.rectangle(cx, cy, comp.width, comp.height, roughOptions);
+    rc.draw(drawable);
+
+    // Type badge (top-left inside rectangle)
+    const typeLabel = `[${comp.type}]`;
+    ctx.font = `${TYPE_FONT_SIZE}px ${FONT_FAMILY}`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillStyle = '#888888';
+    ctx.fillText(typeLabel, cx + 4, cy + 3);
+
+    // Component label (centered)
+    ctx.font = `${LABEL_FONT_SIZE}px ${FONT_FAMILY}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = expr.style.strokeColor;
+    ctx.fillText(comp.label, cx + comp.width / 2, cy + comp.height / 2);
+  }
+
+  ctx.restore();
+}
+
+// ── Self-registration ────────────────────────────────────────
+
+registerCompositeRenderer('wireframe', renderWireframe);


### PR DESCRIPTION
Kanban, table, wireframe, roadmap, code-block, slide, collaboration diagram, decision tree. All registered, handle empty data gracefully. 30 tests. Closes #17