### PR TITLE
fix(engine): Marquee visibility + middle-click/shift-scroll pan — #68 #70

### DIFF
--- a/packages/engine/src/__tests__/renderLoop.test.ts
+++ b/packages/engine/src/__tests__/renderLoop.test.ts
@@ -49,7 +49,12 @@ function createMockCtx() {
     beginPath: vi.fn(),
     arc: vi.fn(),
     fill: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    setLineDash: vi.fn(),
     fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
     canvas: { width: 800, height: 600 },
   } as unknown as CanvasRenderingContext2D;
 }
@@ -183,6 +188,122 @@ describe('createRenderLoop', () => {
       expect.any(Number),
       expect.any(Number),
     );
+    loop.stop();
+  });
+});
+
+// ── #68: Marquee rendering in render loop ────────────────────
+
+describe('createRenderLoop — marquee rendering (#68)', () => {
+  let raf: ReturnType<typeof createRafMock>;
+
+  beforeEach(() => {
+    raf = createRafMock();
+    vi.stubGlobal('requestAnimationFrame', raf.requestAnimationFrame);
+    vi.stubGlobal('cancelAnimationFrame', raf.cancelAnimationFrame);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('calls marqueeProvider.getMarquee() each frame', () => {
+    const ctx = createMockCtx();
+    const getCamera = (): Camera => ({ x: 0, y: 0, zoom: 1 });
+    const marqueeProvider = { getMarquee: vi.fn().mockReturnValue(null) };
+
+    const loop = createRenderLoop(
+      ctx, getCamera, 800, 600,
+      undefined, undefined, undefined, undefined,
+      1, marqueeProvider,
+    );
+
+    loop.start();
+    raf.tick();
+    expect(marqueeProvider.getMarquee).toHaveBeenCalledOnce();
+
+    raf.tick();
+    expect(marqueeProvider.getMarquee).toHaveBeenCalledTimes(2);
+    loop.stop();
+  });
+
+  it('renders marquee fill and stroke when marquee is non-null', () => {
+    const ctx = createMockCtx();
+    const getCamera = (): Camera => ({ x: 0, y: 0, zoom: 1 });
+    const marqueeProvider = {
+      getMarquee: vi.fn().mockReturnValue({ x: 10, y: 20, width: 100, height: 50 }),
+    };
+
+    const loop = createRenderLoop(
+      ctx, getCamera, 800, 600,
+      undefined, undefined, undefined, undefined,
+      1, marqueeProvider,
+    );
+
+    loop.start();
+    raf.tick();
+
+    // Should have drawn filled rect
+    expect(ctx.fillRect).toHaveBeenCalledWith(10, 20, 100, 50);
+    // Should have drawn stroked rect
+    expect(ctx.strokeRect).toHaveBeenCalledWith(10, 20, 100, 50);
+    // Should have set dashed line
+    expect(ctx.setLineDash).toHaveBeenCalledWith([6, 3]);
+    // Should have cleared dash pattern after
+    expect(ctx.setLineDash).toHaveBeenCalledWith([]);
+    loop.stop();
+  });
+
+  it('does not render marquee when getMarquee returns null', () => {
+    const ctx = createMockCtx();
+    const getCamera = (): Camera => ({ x: 0, y: 0, zoom: 1 });
+    const marqueeProvider = {
+      getMarquee: vi.fn().mockReturnValue(null),
+    };
+
+    const loop = createRenderLoop(
+      ctx, getCamera, 800, 600,
+      undefined, undefined, undefined, undefined,
+      1, marqueeProvider,
+    );
+
+    loop.start();
+    raf.tick();
+
+    // fillRect is called once for clearRect; marquee should NOT add another fillRect
+    // strokeRect should NOT be called at all (no grid/expressions = no world-space strokes)
+    expect(ctx.strokeRect).not.toHaveBeenCalled();
+    expect(ctx.setLineDash).not.toHaveBeenCalled();
+    loop.stop();
+  });
+
+  it('renders marquee in DPR-scaled screen coordinates', () => {
+    const ctx = createMockCtx();
+    const getCamera = (): Camera => ({ x: 0, y: 0, zoom: 1 });
+    const dpr = 2;
+    const marqueeProvider = {
+      getMarquee: vi.fn().mockReturnValue({ x: 5, y: 10, width: 200, height: 100 }),
+    };
+
+    const loop = createRenderLoop(
+      ctx, getCamera, 800, 600,
+      undefined, undefined, undefined, undefined,
+      dpr, marqueeProvider,
+    );
+
+    loop.start();
+    raf.tick();
+
+    // The setTransform call before marquee should use DPR-scaled identity
+    const setTransformCalls = (ctx.setTransform as ReturnType<typeof vi.fn>).mock.calls;
+    // Last setTransform before marquee drawing should be DPR identity: (2, 0, 0, 2, 0, 0)
+    // Find the call that sets DPR identity for marquee (should be after camera transform)
+    const dprIdentityCalls = setTransformCalls.filter(
+      (args: number[]) => args[0] === dpr && args[1] === 0 && args[2] === 0
+        && args[3] === dpr && args[4] === 0 && args[5] === 0,
+    );
+    // At least 2: one for clear, one for marquee
+    expect(dprIdentityCalls.length).toBeGreaterThanOrEqual(2);
     loop.stop();
   });
 });

--- a/packages/engine/src/__tests__/useCanvasInteraction.test.tsx
+++ b/packages/engine/src/__tests__/useCanvasInteraction.test.tsx
@@ -228,3 +228,192 @@ describe('useCanvasInteraction — zoom [AC2]', () => {
     expect(zoom).toBeLessThanOrEqual(5.0);
   });
 });
+
+// ── #70: Middle-click drag pan ──────────────────────────────
+
+describe('useCanvasInteraction — middle-click pan (#70)', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('sets cursor to grabbing on middle-click mousedown', () => {
+    const { getByTestId } = render(<TestCanvas />);
+    const canvas = getByTestId('canvas');
+
+    act(() => {
+      canvas.dispatchEvent(new MouseEvent('mousedown', {
+        button: 1, clientX: 100, clientY: 100, bubbles: true,
+      }));
+    });
+
+    expect(canvas.getAttribute('data-cursor')).toBe('grabbing');
+  });
+
+  it('pans camera on middle-click drag', () => {
+    useCanvasStore.setState({ camera: { x: 0, y: 0, zoom: 1 } });
+
+    const { getByTestId } = render(<TestCanvas />);
+    const canvas = getByTestId('canvas');
+
+    act(() => {
+      canvas.dispatchEvent(new MouseEvent('mousedown', {
+        button: 1, clientX: 100, clientY: 100, bubbles: true,
+      }));
+    });
+
+    act(() => {
+      canvas.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: 200, clientY: 150, bubbles: true,
+      }));
+    });
+
+    // Delta is (200-100, 150-100) = (100, 50)
+    // Divided by zoom 1: camera moves by (-100, -50)
+    const camera = useCanvasStore.getState().camera;
+    expect(camera.x).toBeCloseTo(-100, 5);
+    expect(camera.y).toBeCloseTo(-50, 5);
+  });
+
+  it('divides middle-click pan delta by zoom for consistent speed', () => {
+    useCanvasStore.setState({ camera: { x: 0, y: 0, zoom: 2 } });
+
+    const { getByTestId } = render(<TestCanvas />);
+    const canvas = getByTestId('canvas');
+
+    act(() => {
+      canvas.dispatchEvent(new MouseEvent('mousedown', {
+        button: 1, clientX: 100, clientY: 100, bubbles: true,
+      }));
+    });
+
+    act(() => {
+      canvas.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: 200, clientY: 150, bubbles: true,
+      }));
+    });
+
+    // Delta (100, 50) / zoom 2 = (-50, -25)
+    const camera = useCanvasStore.getState().camera;
+    expect(camera.x).toBeCloseTo(-50, 5);
+    expect(camera.y).toBeCloseTo(-25, 5);
+  });
+
+  it('resets cursor to default on mouseup after middle-click pan', () => {
+    const { getByTestId } = render(<TestCanvas />);
+    const canvas = getByTestId('canvas');
+
+    act(() => {
+      canvas.dispatchEvent(new MouseEvent('mousedown', {
+        button: 1, clientX: 100, clientY: 100, bubbles: true,
+      }));
+    });
+
+    expect(canvas.getAttribute('data-cursor')).toBe('grabbing');
+
+    act(() => {
+      canvas.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: 200, clientY: 150, bubbles: true,
+      }));
+    });
+
+    expect(canvas.getAttribute('data-cursor')).toBe('default');
+  });
+
+  it('does not start middle-click pan on right-click (button 2)', () => {
+    const { getByTestId } = render(<TestCanvas />);
+    const canvas = getByTestId('canvas');
+
+    act(() => {
+      canvas.dispatchEvent(new MouseEvent('mousedown', {
+        button: 2, clientX: 100, clientY: 100, bubbles: true,
+      }));
+    });
+
+    // Cursor should remain default — no pan started
+    expect(canvas.getAttribute('data-cursor')).toBe('default');
+  });
+});
+
+// ── #70: Shift+scroll horizontal pan ────────────────────────
+
+describe('useCanvasInteraction — shift+scroll pan (#70)', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('pans horizontally on shift+wheel', () => {
+    useCanvasStore.setState({ camera: { x: 0, y: 0, zoom: 1 } });
+
+    const { getByTestId } = render(<TestCanvas />);
+    const canvas = getByTestId('canvas');
+
+    act(() => {
+      canvas.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: 100, shiftKey: true, clientX: 400, clientY: 300, bubbles: true,
+      }));
+    });
+
+    const camera = useCanvasStore.getState().camera;
+    // deltaY=100 / zoom=1 → camera.x shifts by 100
+    // Pan direction: subtracting deltaY moves content left (positive camera.x means viewing further right)
+    expect(camera.x).not.toBe(0);
+    expect(camera.y).toBe(0); // Y should NOT change
+  });
+
+  it('does not change zoom on shift+wheel', () => {
+    useCanvasStore.setState({ camera: { x: 0, y: 0, zoom: 1 } });
+
+    const { getByTestId } = render(<TestCanvas />);
+    const canvas = getByTestId('canvas');
+
+    act(() => {
+      canvas.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: 100, shiftKey: true, clientX: 400, clientY: 300, bubbles: true,
+      }));
+    });
+
+    const camera = useCanvasStore.getState().camera;
+    expect(camera.zoom).toBe(1); // Zoom should remain unchanged
+  });
+
+  it('divides shift+scroll pan by zoom for consistent speed', () => {
+    useCanvasStore.setState({ camera: { x: 0, y: 0, zoom: 2 } });
+
+    const { getByTestId } = render(<TestCanvas />);
+    const canvas = getByTestId('canvas');
+
+    act(() => {
+      canvas.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: 100, shiftKey: true, clientX: 400, clientY: 300, bubbles: true,
+      }));
+    });
+
+    const camera = useCanvasStore.getState().camera;
+    // deltaY=100 / zoom=2 = 50 world units
+    expect(Math.abs(camera.x)).toBeCloseTo(50, 5);
+  });
+
+  it('still zooms on wheel without shift (regression)', () => {
+    useCanvasStore.setState({ camera: { x: 0, y: 0, zoom: 1 } });
+
+    const { getByTestId } = render(<TestCanvas />);
+    const canvas = getByTestId('canvas');
+
+    act(() => {
+      canvas.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: -100, clientX: 400, clientY: 300, bubbles: true,
+      }));
+    });
+
+    const camera = useCanvasStore.getState().camera;
+    expect(camera.zoom).toBeGreaterThan(1); // Should have zoomed in
+  });
+});

--- a/packages/engine/src/components/Canvas.tsx
+++ b/packages/engine/src/components/Canvas.tsx
@@ -37,7 +37,7 @@ function CanvasInner() {
   const containerRef = useRef<HTMLDivElement>(null);
   const renderLoopRef = useRef<RenderLoop | null>(null);
   const { canvasRef, cursor: canvasCursor } = useCanvasInteraction();
-  useSelectionInteraction(canvasRef);
+  const { getMarquee } = useSelectionInteraction(canvasRef);
   const { cursor: manipulationCursor } = useManipulationInteraction(canvasRef);
   const { getDrawPreview, textTool, cancelDraw } = useDrawingInteraction(canvasRef);
   useTouchGestures(canvasRef);
@@ -118,8 +118,11 @@ function CanvasInner() {
     const drawPreviewProvider = {
       getDrawPreview,
     };
+    const marqueeProvider = {
+      getMarquee,
+    };
     const dpr = window.devicePixelRatio || 1;
-    const loop = createRenderLoop(ctx, getCamera, width, height, roughCanvas, expressionProvider, selectionProvider, drawPreviewProvider, dpr);
+    const loop = createRenderLoop(ctx, getCamera, width, height, roughCanvas, expressionProvider, selectionProvider, drawPreviewProvider, dpr, marqueeProvider);
 
     renderLoopRef.current = loop;
     loop.start();

--- a/packages/engine/src/hooks/useCanvasInteraction.ts
+++ b/packages/engine/src/hooks/useCanvasInteraction.ts
@@ -1,8 +1,9 @@
 /**
  * Canvas interaction hook — pan and zoom.
  *
- * Pan: Space + drag. Cursor changes to grab / grabbing. [AC1]
+ * Pan: Space + drag or middle-click drag. Cursor changes to grab / grabbing. [AC1]
  * Zoom: Mouse scroll wheel, centered on cursor position. [AC2]
+ * Horizontal pan: Shift + scroll wheel. [#70]
  * Pan delta divided by zoom for consistent speed at all levels. [AC7]
  *
  * @module
@@ -35,6 +36,7 @@ export function useCanvasInteraction(): CanvasInteraction {
   // Mutable refs to avoid stale closures in event handlers
   const spaceHeldRef = useRef(false);
   const isPanningRef = useRef(false);
+  const isMiddlePanningRef = useRef(false);
   const lastMouseRef = useRef({ x: 0, y: 0 });
 
   // ── Pan: Space + drag [AC1] ──────────────────────────────
@@ -66,11 +68,17 @@ export function useCanvasInteraction(): CanvasInteraction {
       isPanningRef.current = true;
       lastMouseRef.current = { x: e.clientX, y: e.clientY };
       setCursor('grabbing');
+    } else if (e.button === 1) {
+      // Middle-click pan — same behavior as Space+drag
+      e.preventDefault();
+      isMiddlePanningRef.current = true;
+      lastMouseRef.current = { x: e.clientX, y: e.clientY };
+      setCursor('grabbing');
     }
   }, []);
 
   const handleMouseMove = useCallback((e: MouseEvent) => {
-    if (!isPanningRef.current) return;
+    if (!isPanningRef.current && !isMiddlePanningRef.current) return;
 
     const dx = e.clientX - lastMouseRef.current.x;
     const dy = e.clientY - lastMouseRef.current.y;
@@ -90,6 +98,10 @@ export function useCanvasInteraction(): CanvasInteraction {
       isPanningRef.current = false;
       setCursor(spaceHeldRef.current ? 'grab' : 'default');
     }
+    if (isMiddlePanningRef.current) {
+      isMiddlePanningRef.current = false;
+      setCursor('default');
+    }
   }, []);
 
   // ── Zoom: scroll wheel [AC2] ─────────────────────────────
@@ -98,6 +110,16 @@ export function useCanvasInteraction(): CanvasInteraction {
     e.preventDefault();
 
     const { camera, setCamera } = useCanvasStore.getState();
+
+    // Shift+scroll → horizontal pan instead of zoom
+    if (e.shiftKey) {
+      setCamera({
+        x: camera.x + e.deltaY / camera.zoom,
+        y: camera.y,
+        zoom: camera.zoom,
+      });
+      return;
+    }
 
     // Calculate new zoom level
     const zoomDelta = -e.deltaY * ZOOM_SENSITIVITY;

--- a/packages/engine/src/hooks/useSelectionInteraction.ts
+++ b/packages/engine/src/hooks/useSelectionInteraction.ts
@@ -40,6 +40,8 @@ export interface MarqueeRect {
 export interface SelectionInteraction {
   /** Current marquee rectangle in screen coordinates (null when not dragging). */
   marquee: MarqueeRect | null;
+  /** Get the current marquee rectangle (live read from ref — safe for per-frame use). */
+  getMarquee: () => MarqueeRect | null;
   /** Render the marquee overlay onto the given canvas context. */
   renderMarquee: (ctx: CanvasRenderingContext2D) => void;
 }
@@ -226,8 +228,11 @@ export function useSelectionInteraction(
     ctx.restore();
   }, []);
 
+  const getMarquee = useCallback(() => marqueeRef.current, []);
+
   return {
     marquee: marqueeRef.current,
+    getMarquee,
     renderMarquee,
   };
 }

--- a/packages/engine/src/renderer/renderLoop.ts
+++ b/packages/engine/src/renderer/renderLoop.ts
@@ -17,6 +17,11 @@ import { renderExpressions } from './primitiveRenderer.js';
 import { renderSelection } from './selectionRenderer.js';
 import { renderDrawPreview } from './drawPreviewRenderer.js';
 
+/** Marquee overlay visual styles (matches useSelectionInteraction constants). */
+const MARQUEE_STROKE_COLOR = '#4A90D9';
+const MARQUEE_FILL_COLOR = 'rgba(74, 144, 217, 0.1)';
+const MARQUEE_DASH_PATTERN: readonly number[] = [6, 3];
+
 export interface RenderLoop {
   start(): void;
   stop(): void;
@@ -43,6 +48,12 @@ export interface DrawPreviewProvider {
   getDrawPreview(): DrawPreview | null;
 }
 
+/** Callback that returns the current marquee rectangle for rendering. */
+export interface MarqueeProvider {
+  /** Screen-space marquee rectangle during drag, or null when idle. */
+  getMarquee(): { x: number; y: number; width: number; height: number } | null;
+}
+
 /**
  * Create a render loop bound to a canvas context.
  *
@@ -65,6 +76,7 @@ export function createRenderLoop(
   selectionProvider?: SelectionProvider,
   drawPreviewProvider?: DrawPreviewProvider,
   dpr: number = 1,
+  marqueeProvider?: MarqueeProvider,
 ): RenderLoop {
   let width = initialWidth;
   let height = initialHeight;
@@ -114,6 +126,21 @@ export function createRenderLoop(
       const preview = drawPreviewProvider.getDrawPreview();
       if (preview) {
         renderDrawPreview(ctx, preview);
+      }
+    }
+
+    // 7. Render marquee overlay (screen-space, after all world-space rendering)
+    if (marqueeProvider) {
+      const marquee = marqueeProvider.getMarquee();
+      if (marquee) {
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        ctx.fillStyle = MARQUEE_FILL_COLOR;
+        ctx.fillRect(marquee.x, marquee.y, marquee.width, marquee.height);
+        ctx.strokeStyle = MARQUEE_STROKE_COLOR;
+        ctx.lineWidth = 1;
+        ctx.setLineDash(MARQUEE_DASH_PATTERN as number[]);
+        ctx.strokeRect(marquee.x, marquee.y, marquee.width, marquee.height);
+        ctx.setLineDash([]);
       }
     }
 


### PR DESCRIPTION
Marquee selection rectangle now renders during drag. Middle-click drag pans. Shift+scroll pans horizontally. 13 tests. Closes #68, closes #70