### PR TITLE
fix(app): Style panel visible in drawing mode — #72

### DIFF
--- a/packages/app/src/__tests__/StylePanel.test.tsx
+++ b/packages/app/src/__tests__/StylePanel.test.tsx
@@ -53,7 +53,8 @@ describe('StylePanel', () => {
 
   // ── Visibility ──
 
-  it('is hidden when no expressions are selected', () => {
+  it('is hidden when Select tool active and nothing selected', () => {
+    // activeTool defaults to 'select', selectedIds is empty
     const { container } = render(<StylePanel />);
     const panel = container.querySelector('[data-testid="style-panel"]');
     expect(panel).toBeNull();
@@ -61,6 +62,13 @@ describe('StylePanel', () => {
 
   it('is visible when expressions are selected', () => {
     setupWithSelectedExpression();
+    const { container } = render(<StylePanel />);
+    const panel = container.querySelector('[data-testid="style-panel"]');
+    expect(panel).not.toBeNull();
+  });
+
+  it('is visible when drawing tool active and nothing selected', () => {
+    useCanvasStore.setState({ activeTool: 'rectangle' });
     const { container } = render(<StylePanel />);
     const panel = container.querySelector('[data-testid="style-panel"]');
     expect(panel).not.toBeNull();
@@ -216,5 +224,79 @@ describe('StylePanel', () => {
 
     const thickRadio = container.querySelector('[name="strokeWidth"][value="4"]') as HTMLInputElement;
     expect(thickRadio?.checked).toBe(true);
+  });
+
+  // ── Drawing mode (pre-draw style) ──
+
+  it('shows lastUsedStyle values in drawing mode', () => {
+    useCanvasStore.setState({
+      activeTool: 'rectangle',
+      lastUsedStyle: { ...DEFAULT_EXPRESSION_STYLE, strokeColor: '#e03131', strokeWidth: 4 },
+    });
+    const { container } = render(<StylePanel />);
+
+    // Stroke color swatch for red should be pressed
+    const redSwatch = container.querySelector(
+      '[data-testid="stroke-color-swatch"][data-color="#e03131"]',
+    );
+    expect(redSwatch?.getAttribute('aria-pressed')).toBe('true');
+
+    // Stroke width thick radio should be checked
+    const thickRadio = container.querySelector('[name="strokeWidth"][value="4"]') as HTMLInputElement;
+    expect(thickRadio?.checked).toBe(true);
+  });
+
+  it('changing color in drawing mode updates lastUsedStyle (not expressions)', () => {
+    useCanvasStore.setState({ activeTool: 'rectangle' });
+    const { container } = render(<StylePanel />);
+
+    const blueSwatch = container.querySelector(
+      '[data-testid="stroke-color-swatch"][data-color="#1971c2"]',
+    );
+    fireEvent.click(blueSwatch!);
+
+    // lastUsedStyle should be updated
+    expect(useCanvasStore.getState().lastUsedStyle.strokeColor).toBe('#1971c2');
+
+    // No expressions should have been modified (there are none)
+    expect(Object.keys(useCanvasStore.getState().expressions)).toHaveLength(0);
+  });
+
+  it('changing fill in drawing mode updates lastUsedStyle', () => {
+    useCanvasStore.setState({ activeTool: 'ellipse' });
+    const { container } = render(<StylePanel />);
+
+    const greenSwatch = container.querySelector(
+      '[data-testid="fill-color-swatch"][data-color="#2f9e44"]',
+    );
+    fireEvent.click(greenSwatch!);
+
+    expect(useCanvasStore.getState().lastUsedStyle.backgroundColor).toBe('#2f9e44');
+  });
+
+  it('changing stroke width in drawing mode updates lastUsedStyle', () => {
+    useCanvasStore.setState({ activeTool: 'line' });
+    const { container } = render(<StylePanel />);
+
+    const thickRadio = container.querySelector('[name="strokeWidth"][value="4"]');
+    fireEvent.click(thickRadio!);
+
+    expect(useCanvasStore.getState().lastUsedStyle.strokeWidth).toBe(4);
+  });
+
+  it('still shows selected expression style when in selection mode', () => {
+    // Both selection and a non-select tool shouldn't happen normally,
+    // but selection mode takes precedence when selectedIds > 0
+    const expr = makeRectangle('rect-1');
+    useCanvasStore.getState().addExpression(expr);
+    useCanvasStore.getState().styleExpressions(['rect-1'], { strokeColor: '#9c36b5' });
+    useCanvasStore.setState({ selectedIds: new Set(['rect-1']) });
+
+    const { container } = render(<StylePanel />);
+
+    const purpleSwatch = container.querySelector(
+      '[data-testid="stroke-color-swatch"][data-color="#9c36b5"]',
+    );
+    expect(purpleSwatch?.getAttribute('aria-pressed')).toBe('true');
   });
 });

--- a/packages/app/src/components/panels/StylePanel.tsx
+++ b/packages/app/src/components/panels/StylePanel.tsx
@@ -1,9 +1,11 @@
 /**
- * StylePanel — style controls for selected expressions.
+ * StylePanel — style controls for selected expressions and pre-draw defaults.
  *
- * Appears when one or more expressions are selected. Provides controls
- * for stroke color, fill color, stroke width, fill style, roughness,
- * and opacity. Changes apply immediately via `styleExpressions`.
+ * Works in two modes:
+ * 1. **Selection mode** — when expressions are selected, shows/edits their styles
+ *    via `styleExpressions`.
+ * 2. **Drawing mode** — when a drawing tool is active and nothing is selected,
+ *    shows/edits `lastUsedStyle` so users can pick styles before drawing.
  *
  * @module
  */
@@ -128,26 +130,37 @@ function radioLabelStyle(isActive: boolean): React.CSSProperties {
 
 // ── Component ──────────────────────────────────────────────
 
-/** Style panel for editing selected expression styles. */
+/** Style panel for editing selected expression styles or pre-draw defaults. */
 export function StylePanel() {
   const selectedIds = useCanvasStore((s) => s.selectedIds);
   const expressions = useCanvasStore((s) => s.expressions);
   const styleExpressions = useCanvasStore((s) => s.styleExpressions);
+  const activeTool = useCanvasStore((s) => s.activeTool);
+  const lastUsedStyle = useCanvasStore((s) => s.lastUsedStyle);
+  const setLastUsedStyle = useCanvasStore((s) => s.setLastUsedStyle);
 
-  // Hide when nothing is selected
-  if (selectedIds.size === 0) return null;
+  // Drawing mode: tool active + nothing selected → show lastUsedStyle
+  const isDrawingMode = selectedIds.size === 0 && activeTool !== 'select';
+
+  // Hide when Select tool active and nothing selected
+  if (selectedIds.size === 0 && activeTool === 'select') return null;
 
   // Get the style of the first selected expression as reference
-  const firstSelectedId = [...selectedIds][0]!;
-  const firstExpr = expressions[firstSelectedId];
-  if (!firstExpr) return null;
+  const firstSelectedId = selectedIds.size > 0 ? [...selectedIds][0]! : undefined;
+  const firstExpr = firstSelectedId ? expressions[firstSelectedId] : undefined;
 
-  const currentStyle = firstExpr.style;
-  const ids = [...selectedIds];
+  // In selection mode, bail if expression not found
+  if (!isDrawingMode && !firstExpr) return null;
 
-  /** Apply a partial style to all selected expressions. */
+  const currentStyle = isDrawingMode ? lastUsedStyle : firstExpr!.style;
+
+  /** Apply a partial style — routes to correct handler per mode. */
   function applyStyle(style: Partial<ExpressionStyle>) {
-    styleExpressions(ids, style);
+    if (isDrawingMode) {
+      setLastUsedStyle(style);
+    } else {
+      styleExpressions([...selectedIds], style);
+    }
   }
 
   return (


### PR DESCRIPTION
Style panel shows lastUsedStyle when drawing tool active. Users can set colors before drawing. 5 tests. Closes #72