### PR TITLE
feat(engine): Copy/Paste/Cut + Ctrl-constrain shapes — #69 #73

### DIFF
--- a/packages/engine/src/__tests__/copyPaste.test.ts
+++ b/packages/engine/src/__tests__/copyPaste.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Unit tests for Copy / Paste / Cut keyboard shortcuts.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Acceptance criteria from Issue #69.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ExpressionBuilder } from '@infinicanvas/protocol';
+import { useCanvasStore } from '../store/canvasStore.js';
+import {
+  copySelected,
+  cutSelected,
+  pasteFromClipboard,
+  _resetClipboard,
+} from '../hooks/useKeyboardShortcuts.js';
+
+// ── Test fixtures ──────────────────────────────────────────
+
+const testAuthor = { type: 'human' as const, id: 'user-1', name: 'Test User' };
+const builder = new ExpressionBuilder(testAuthor);
+
+function makeRectangle(id: string, x = 100, y = 200) {
+  const expr = builder.rectangle(x, y, 300, 150).label('Test Rectangle').build();
+  return { ...expr, id };
+}
+
+function makeEllipse(id: string, x = 50, y = 50) {
+  const expr = builder.ellipse(x, y, 200, 200).label('Test Ellipse').build();
+  return { ...expr, id };
+}
+
+/** Reset store to clean state before each test. */
+function resetStore() {
+  useCanvasStore.setState({
+    expressions: {},
+    expressionOrder: [],
+    selectedIds: new Set<string>(),
+    activeTool: 'select',
+    camera: { x: 0, y: 0, zoom: 1 },
+    operationLog: [],
+    canUndo: false,
+    canRedo: false,
+  });
+  useCanvasStore.getState().clearHistory();
+}
+
+// ── Setup ──────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetStore();
+  _resetClipboard();
+});
+
+// ── Ctrl+C (Copy) ──────────────────────────────────────────
+
+describe('Ctrl+C — copySelected', () => {
+  it('stores selected expressions in clipboard (no visual side-effect)', () => {
+    const rect = makeRectangle('rect-1');
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+
+    copySelected();
+
+    // Store state should be unchanged — no expressions added or removed
+    const state = useCanvasStore.getState();
+    expect(Object.keys(state.expressions)).toHaveLength(1);
+    expect(state.selectedIds.has('rect-1')).toBe(true);
+  });
+
+  it('copies multiple selected expressions', () => {
+    const rect = makeRectangle('rect-1');
+    const ellipse = makeEllipse('ellipse-1');
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().addExpression(ellipse);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1', 'ellipse-1']));
+
+    copySelected();
+
+    // Paste should produce 2 new expressions
+    pasteFromClipboard();
+    const state = useCanvasStore.getState();
+    expect(Object.keys(state.expressions)).toHaveLength(4); // 2 originals + 2 pasted
+  });
+
+  it('no-op when nothing is selected', () => {
+    const rect = makeRectangle('rect-1');
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set());
+
+    copySelected();
+
+    // Paste should be a no-op since clipboard is empty
+    pasteFromClipboard();
+    const state = useCanvasStore.getState();
+    expect(Object.keys(state.expressions)).toHaveLength(1); // only the original
+  });
+});
+
+// ── Ctrl+V (Paste) ─────────────────────────────────────────
+
+describe('Ctrl+V — pasteFromClipboard', () => {
+  it('creates clones with new IDs and +20,+20 offset', () => {
+    const rect = makeRectangle('rect-1', 100, 200);
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+
+    copySelected();
+    pasteFromClipboard();
+
+    const state = useCanvasStore.getState();
+    const allIds = Object.keys(state.expressions);
+    expect(allIds).toHaveLength(2);
+
+    const pastedId = allIds.find((id) => id !== 'rect-1')!;
+    const pasted = state.expressions[pastedId]!;
+
+    // New ID (not the original)
+    expect(pasted.id).not.toBe('rect-1');
+    // Offset by +20,+20
+    expect(pasted.position.x).toBe(120);
+    expect(pasted.position.y).toBe(220);
+    // Same kind and size
+    expect(pasted.kind).toBe('rectangle');
+    expect(pasted.size.width).toBe(300);
+    expect(pasted.size.height).toBe(150);
+  });
+
+  it('selects pasted expressions (deselects originals)', () => {
+    const rect = makeRectangle('rect-1');
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+
+    copySelected();
+    pasteFromClipboard();
+
+    const state = useCanvasStore.getState();
+    // Original should not be selected
+    expect(state.selectedIds.has('rect-1')).toBe(false);
+    // One new item should be selected
+    expect(state.selectedIds.size).toBe(1);
+    const selectedId = Array.from(state.selectedIds)[0]!;
+    expect(selectedId).not.toBe('rect-1');
+  });
+
+  it('each subsequent paste offsets by additional +20,+20', () => {
+    const rect = makeRectangle('rect-1', 100, 200);
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+
+    copySelected();
+
+    // First paste: +20,+20
+    pasteFromClipboard();
+    const state1 = useCanvasStore.getState();
+    const firstPasteId = Array.from(state1.selectedIds)[0]!;
+    const firstPasted = state1.expressions[firstPasteId]!;
+    expect(firstPasted.position.x).toBe(120);
+    expect(firstPasted.position.y).toBe(220);
+
+    // Second paste: +40,+40 from original
+    pasteFromClipboard();
+    const state2 = useCanvasStore.getState();
+    const secondPasteId = Array.from(state2.selectedIds)[0]!;
+    const secondPasted = state2.expressions[secondPasteId]!;
+    expect(secondPasted.position.x).toBe(140);
+    expect(secondPasted.position.y).toBe(240);
+
+    // Third paste: +60,+60 from original
+    pasteFromClipboard();
+    const state3 = useCanvasStore.getState();
+    const thirdPasteId = Array.from(state3.selectedIds)[0]!;
+    const thirdPasted = state3.expressions[thirdPasteId]!;
+    expect(thirdPasted.position.x).toBe(160);
+    expect(thirdPasted.position.y).toBe(260);
+  });
+
+  it('no-op when clipboard is empty', () => {
+    pasteFromClipboard();
+
+    const state = useCanvasStore.getState();
+    expect(Object.keys(state.expressions)).toHaveLength(0);
+    expect(state.selectedIds.size).toBe(0);
+  });
+
+  it('preserves expression data (style, angle, data) on paste', () => {
+    const rect = makeRectangle('rect-1');
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+
+    copySelected();
+    pasteFromClipboard();
+
+    const state = useCanvasStore.getState();
+    const pastedId = Array.from(state.selectedIds)[0]!;
+    const pasted = state.expressions[pastedId]!;
+    const original = state.expressions['rect-1']!;
+
+    expect(pasted.style).toEqual(original.style);
+    expect(pasted.angle).toBe(original.angle);
+    expect(pasted.data).toEqual(original.data);
+  });
+
+  it('updates timestamps on pasted expressions', () => {
+    const rect = makeRectangle('rect-1');
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+
+    copySelected();
+
+    // Small delay to ensure timestamp differs
+    const beforePaste = Date.now();
+    pasteFromClipboard();
+
+    const state = useCanvasStore.getState();
+    const pastedId = Array.from(state.selectedIds)[0]!;
+    const pasted = state.expressions[pastedId]!;
+
+    expect(pasted.meta.createdAt).toBeGreaterThanOrEqual(beforePaste);
+    expect(pasted.meta.updatedAt).toBeGreaterThanOrEqual(beforePaste);
+  });
+});
+
+// ── Ctrl+X (Cut) ───────────────────────────────────────────
+
+describe('Ctrl+X — cutSelected', () => {
+  it('copies to clipboard and deletes originals', () => {
+    const rect = makeRectangle('rect-1');
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+
+    cutSelected();
+
+    // Original should be deleted
+    const state = useCanvasStore.getState();
+    expect(Object.keys(state.expressions)).toHaveLength(0);
+    expect(state.expressionOrder).toHaveLength(0);
+  });
+
+  it('paste works after cut', () => {
+    const rect = makeRectangle('rect-1', 100, 200);
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+
+    cutSelected();
+    pasteFromClipboard();
+
+    const state = useCanvasStore.getState();
+    expect(Object.keys(state.expressions)).toHaveLength(1);
+
+    const pastedId = Object.keys(state.expressions)[0]!;
+    const pasted = state.expressions[pastedId]!;
+    expect(pasted.id).not.toBe('rect-1');
+    expect(pasted.position.x).toBe(120);
+    expect(pasted.position.y).toBe(220);
+    expect(pasted.kind).toBe('rectangle');
+  });
+
+  it('cuts multiple selected expressions', () => {
+    const rect = makeRectangle('rect-1');
+    const ellipse = makeEllipse('ellipse-1');
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().addExpression(ellipse);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1', 'ellipse-1']));
+
+    cutSelected();
+
+    // All originals deleted
+    const state = useCanvasStore.getState();
+    expect(Object.keys(state.expressions)).toHaveLength(0);
+
+    // Paste restores both
+    pasteFromClipboard();
+    const state2 = useCanvasStore.getState();
+    expect(Object.keys(state2.expressions)).toHaveLength(2);
+  });
+
+  it('skips locked expressions during cut', () => {
+    const rect = makeRectangle('rect-1');
+    rect.meta.locked = true;
+    useCanvasStore.getState().addExpression(rect);
+
+    const ellipse = makeEllipse('ellipse-1');
+    useCanvasStore.getState().addExpression(ellipse);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1', 'ellipse-1']));
+
+    cutSelected();
+
+    // Locked expression should remain
+    const state = useCanvasStore.getState();
+    expect(state.expressions['rect-1']).toBeDefined();
+    expect(state.expressions['ellipse-1']).toBeUndefined();
+  });
+
+  it('no-op when nothing is selected', () => {
+    const rect = makeRectangle('rect-1');
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set());
+
+    cutSelected();
+
+    const state = useCanvasStore.getState();
+    expect(Object.keys(state.expressions)).toHaveLength(1);
+  });
+});
+
+// ── Copy overwrite ─────────────────────────────────────────
+
+describe('clipboard overwrite', () => {
+  it('new copy replaces previous clipboard contents', () => {
+    const rect = makeRectangle('rect-1', 100, 200);
+    const ellipse = makeEllipse('ellipse-1', 300, 400);
+
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().addExpression(ellipse);
+
+    // Copy rect
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+    copySelected();
+
+    // Copy ellipse (should replace)
+    useCanvasStore.getState().setSelectedIds(new Set(['ellipse-1']));
+    copySelected();
+
+    // Paste should produce ellipse, not rect
+    pasteFromClipboard();
+    const state = useCanvasStore.getState();
+    const pastedId = Array.from(state.selectedIds)[0]!;
+    const pasted = state.expressions[pastedId]!;
+    expect(pasted.kind).toBe('ellipse');
+  });
+
+  it('paste resets offset counter after new copy', () => {
+    const rect = makeRectangle('rect-1', 100, 200);
+    useCanvasStore.getState().addExpression(rect);
+    useCanvasStore.getState().setSelectedIds(new Set(['rect-1']));
+
+    copySelected();
+    pasteFromClipboard(); // offset +20
+    pasteFromClipboard(); // offset +40
+
+    // New copy should reset offset counter
+    const ellipse = makeEllipse('ellipse-1', 300, 400);
+    useCanvasStore.getState().addExpression(ellipse);
+    useCanvasStore.getState().setSelectedIds(new Set(['ellipse-1']));
+    copySelected();
+
+    pasteFromClipboard();
+    const state = useCanvasStore.getState();
+    const pastedId = Array.from(state.selectedIds)[0]!;
+    const pasted = state.expressions[pastedId]!;
+    // Should be +20 from ellipse origin, not +60
+    expect(pasted.position.x).toBe(320);
+    expect(pasted.position.y).toBe(420);
+  });
+});

--- a/packages/engine/src/__tests__/ctrlConstrain.test.ts
+++ b/packages/engine/src/__tests__/ctrlConstrain.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for Ctrl-constrain shapes to square/circle.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Acceptance criteria from Issue #73.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCanvasStore } from '../store/canvasStore.js';
+import { RectangleTool } from '../tools/RectangleTool.js';
+import { EllipseTool } from '../tools/EllipseTool.js';
+import { DiamondTool } from '../tools/DiamondTool.js';
+import type { ToolHandler } from '../tools/BaseTool.js';
+
+// ── Test helpers ───────────────────────────────────────────
+
+/** Stub PointerEvent for testing (jsdom doesn't fully support it). */
+function stubPointerEvent(overrides: Partial<PointerEvent> = {}): PointerEvent {
+  return { pressure: 0.5, ctrlKey: false, metaKey: false, ...overrides } as PointerEvent;
+}
+
+/** Reset store to clean state before each test. */
+function resetStore() {
+  useCanvasStore.setState({
+    expressions: {},
+    expressionOrder: [],
+    selectedIds: new Set<string>(),
+    activeTool: 'select',
+    camera: { x: 0, y: 0, zoom: 1 },
+    operationLog: [],
+    canUndo: false,
+    canRedo: false,
+  });
+  useCanvasStore.getState().clearHistory();
+}
+
+/** Get the first expression from the store. */
+function firstExpression() {
+  const exprs = useCanvasStore.getState().expressions;
+  const id = useCanvasStore.getState().expressionOrder[0];
+  return id ? exprs[id] : undefined;
+}
+
+// ── Setup ──────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetStore();
+});
+
+// ── Ctrl+drag rectangle → square ───────────────────────────
+
+describe('RectangleTool with Ctrl constrain', () => {
+  let tool: RectangleTool;
+
+  beforeEach(() => {
+    tool = new RectangleTool();
+  });
+
+  it('creates a square when Ctrl is held during drag', () => {
+    const ctrlEvent = stubPointerEvent({ ctrlKey: true });
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(250, 200, ctrlEvent); // width=150, height=100 → constrained to 150×150
+    tool.onPointerUp(250, 200, ctrlEvent);
+
+    const expr = firstExpression()!;
+    expect(expr).toBeDefined();
+    expect(expr.size.width).toBe(expr.size.height);
+    expect(expr.size.width).toBe(150); // max(150, 100) = 150
+  });
+
+  it('creates a square when Meta (Cmd) is held during drag', () => {
+    const metaEvent = stubPointerEvent({ metaKey: true });
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(300, 180, metaEvent); // width=200, height=80 → 200×200
+    tool.onPointerUp(300, 180, metaEvent);
+
+    const expr = firstExpression()!;
+    expect(expr).toBeDefined();
+    expect(expr.size.width).toBe(expr.size.height);
+    expect(expr.size.width).toBe(200);
+  });
+
+  it('preview shows constrained dimensions during Ctrl+drag', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(250, 200, stubPointerEvent({ ctrlKey: true }));
+
+    const preview = tool.getPreview()!;
+    expect(preview).not.toBeNull();
+    expect(preview.width).toBe(preview.height);
+    expect(preview.width).toBe(150);
+  });
+
+  it('returns to free aspect ratio when Ctrl is released mid-drag', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+
+    // Drag with Ctrl: constrained
+    tool.onPointerMove(250, 200, stubPointerEvent({ ctrlKey: true }));
+    const constrained = tool.getPreview()!;
+    expect(constrained.width).toBe(constrained.height);
+
+    // Continue drag without Ctrl: unconstrained
+    tool.onPointerMove(250, 200, stubPointerEvent({ ctrlKey: false }));
+    const free = tool.getPreview()!;
+    expect(free.width).toBe(150);
+    expect(free.height).toBe(100);
+  });
+
+  it('without Ctrl, drag produces free aspect ratio (baseline)', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(250, 200, stubPointerEvent());
+    tool.onPointerUp(250, 200, stubPointerEvent());
+
+    const expr = firstExpression()!;
+    expect(expr.size.width).toBe(150);
+    expect(expr.size.height).toBe(100);
+  });
+
+  it('handles negative drag direction with Ctrl', () => {
+    const ctrlEvent = stubPointerEvent({ ctrlKey: true });
+    tool.onPointerDown(250, 200, stubPointerEvent());
+    tool.onPointerMove(100, 100, ctrlEvent); // dragging top-left
+    tool.onPointerUp(100, 100, ctrlEvent);
+
+    const expr = firstExpression()!;
+    expect(expr.size.width).toBe(expr.size.height);
+    expect(expr.size.width).toBe(150); // max(150, 100)
+  });
+});
+
+// ── Ctrl+drag ellipse → circle ─────────────────────────────
+
+describe('EllipseTool with Ctrl constrain', () => {
+  let tool: EllipseTool;
+
+  beforeEach(() => {
+    tool = new EllipseTool();
+  });
+
+  it('creates a circle when Ctrl is held during drag', () => {
+    const ctrlEvent = stubPointerEvent({ ctrlKey: true });
+    tool.onPointerDown(50, 50, stubPointerEvent());
+    tool.onPointerMove(250, 150, ctrlEvent); // width=200, height=100 → 200×200
+    tool.onPointerUp(250, 150, ctrlEvent);
+
+    const expr = firstExpression()!;
+    expect(expr).toBeDefined();
+    expect(expr.kind).toBe('ellipse');
+    expect(expr.size.width).toBe(expr.size.height);
+    expect(expr.size.width).toBe(200);
+  });
+
+  it('preview shows constrained dimensions for ellipse', () => {
+    tool.onPointerDown(50, 50, stubPointerEvent());
+    tool.onPointerMove(250, 150, stubPointerEvent({ ctrlKey: true }));
+
+    const preview = tool.getPreview()!;
+    expect(preview.kind).toBe('ellipse');
+    expect(preview.width).toBe(preview.height);
+  });
+});
+
+// ── Ctrl+drag diamond → equilateral ───────────────────────
+
+describe('DiamondTool with Ctrl constrain', () => {
+  let tool: DiamondTool;
+
+  beforeEach(() => {
+    tool = new DiamondTool();
+  });
+
+  it('creates equilateral diamond when Ctrl is held during drag', () => {
+    const ctrlEvent = stubPointerEvent({ ctrlKey: true });
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(300, 200, ctrlEvent); // width=200, height=100 → 200×200
+    tool.onPointerUp(300, 200, ctrlEvent);
+
+    const expr = firstExpression()!;
+    expect(expr).toBeDefined();
+    expect(expr.kind).toBe('diamond');
+    expect(expr.size.width).toBe(expr.size.height);
+    expect(expr.size.width).toBe(200);
+  });
+
+  it('preview shows constrained dimensions for diamond', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(300, 200, stubPointerEvent({ ctrlKey: true }));
+
+    const preview = tool.getPreview()!;
+    expect(preview.kind).toBe('diamond');
+    expect(preview.width).toBe(preview.height);
+  });
+});
+
+// ── Edge cases ─────────────────────────────────────────────
+
+describe('Ctrl-constrain edge cases', () => {
+  it('constrains when height > width (takes height)', () => {
+    const tool = new RectangleTool();
+    const ctrlEvent = stubPointerEvent({ ctrlKey: true });
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(150, 300, ctrlEvent); // width=50, height=200 → 200×200
+    tool.onPointerUp(150, 300, ctrlEvent);
+
+    const expr = firstExpression()!;
+    expect(expr.size.width).toBe(200);
+    expect(expr.size.height).toBe(200);
+  });
+
+  it('constrains correctly when width equals height', () => {
+    const tool = new RectangleTool();
+    const ctrlEvent = stubPointerEvent({ ctrlKey: true });
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(200, 200, ctrlEvent); // width=100, height=100 → 100×100
+    tool.onPointerUp(200, 200, ctrlEvent);
+
+    const expr = firstExpression()!;
+    expect(expr.size.width).toBe(100);
+    expect(expr.size.height).toBe(100);
+  });
+});

--- a/packages/engine/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/engine/src/hooks/useKeyboardShortcuts.ts
@@ -16,6 +16,9 @@
  * **Actions (with modifiers):**
  * - `Ctrl+Z` / `Cmd+Z` → Undo
  * - `Ctrl+Shift+Z` / `Cmd+Shift+Z` / `Ctrl+Y` → Redo
+ * - `Ctrl+C` / `Cmd+C` → Copy selected to internal clipboard
+ * - `Ctrl+V` / `Cmd+V` → Paste from internal clipboard (+20 offset)
+ * - `Ctrl+X` / `Cmd+X` → Cut selected (copy + delete)
  * - `Ctrl+D` / `Cmd+D` → Duplicate selected
  * - `Ctrl+A` / `Cmd+A` → Select all
  * - `Delete` / `Backspace` → Delete selected
@@ -32,13 +35,22 @@
 
 import { useEffect, useCallback, useState } from 'react';
 import { nanoid } from 'nanoid';
+import type { VisualExpression } from '@infinicanvas/protocol';
 import { useCanvasStore } from '../store/canvasStore.js';
 import type { ToolType } from '../types/index.js';
 
 // ── Constants ──────────────────────────────────────────────
 
-/** Duplicate offset in world units. */
+/** Duplicate / paste offset in world units. */
 const DUPLICATE_OFFSET = 20;
+
+// ── Internal clipboard ────────────────────────────────────
+
+/** Deep clones of copied expressions (module-scoped, internal only). */
+let clipboard: VisualExpression[] = [];
+
+/** Tracks how many times paste has been invoked since last copy. */
+let pasteCount = 0;
 
 /** Map of single keys (lowercase) to tool types. */
 const KEY_TO_TOOL: Readonly<Record<string, ToolType>> = {
@@ -175,6 +187,27 @@ export function useKeyboardShortcuts(
           return;
         }
 
+        // Ctrl+C / Cmd+C → copy selected to internal clipboard
+        if (keyLower === 'c') {
+          event.preventDefault();
+          copySelected();
+          return;
+        }
+
+        // Ctrl+V / Cmd+V → paste from internal clipboard
+        if (keyLower === 'v') {
+          event.preventDefault();
+          pasteFromClipboard();
+          return;
+        }
+
+        // Ctrl+X / Cmd+X → cut selected (copy + delete)
+        if (keyLower === 'x') {
+          event.preventDefault();
+          cutSelected();
+          return;
+        }
+
         // Other modifier combos — not handled, let browser process
         return;
       }
@@ -252,4 +285,90 @@ function duplicateSelected(): void {
 
   // Select the new duplicates
   useCanvasStore.getState().setSelectedIds(new Set(newIds));
+}
+
+// ── Clipboard operations (exported for testing) ────────────
+
+/**
+ * Copy all selected expressions to the internal clipboard.
+ *
+ * Stores deep clones so pasting is independent of future mutations.
+ * Resets the paste counter for offset tracking.
+ */
+export function copySelected(): void {
+  const { selectedIds, expressions } = useCanvasStore.getState();
+  if (selectedIds.size === 0) return;
+
+  clipboard = [];
+  for (const id of selectedIds) {
+    const expr = expressions[id];
+    if (!expr) continue;
+    clipboard.push(structuredClone(expr));
+  }
+  pasteCount = 0;
+}
+
+/**
+ * Paste expressions from the internal clipboard.
+ *
+ * Creates clones with new IDs. Each subsequent paste increases
+ * the offset by +20,+20 from the original positions.
+ */
+export function pasteFromClipboard(): void {
+  if (clipboard.length === 0) return;
+
+  pasteCount += 1;
+  const offset = pasteCount * DUPLICATE_OFFSET;
+  const newIds: string[] = [];
+
+  for (const original of clipboard) {
+    const newId = nanoid();
+    const clone = structuredClone(original);
+    clone.id = newId;
+    clone.position = {
+      x: original.position.x + offset,
+      y: original.position.y + offset,
+    };
+    const now = Date.now();
+    clone.meta = {
+      ...clone.meta,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    useCanvasStore.getState().addExpression(clone);
+    newIds.push(newId);
+  }
+
+  useCanvasStore.getState().setSelectedIds(new Set(newIds));
+}
+
+/**
+ * Cut selected expressions: copy to clipboard, then delete originals.
+ *
+ * Locked expressions are excluded from deletion (same as Delete key).
+ */
+export function cutSelected(): void {
+  const { selectedIds, expressions } = useCanvasStore.getState();
+  if (selectedIds.size === 0) return;
+
+  // Copy to clipboard first
+  copySelected();
+
+  // Delete unlocked originals (same logic as Delete key handler)
+  const deletableIds = Array.from(selectedIds).filter(
+    (id) => !expressions[id]?.meta.locked,
+  );
+  if (deletableIds.length > 0) {
+    useCanvasStore.getState().deleteExpressions(deletableIds);
+  }
+}
+
+/**
+ * Reset clipboard state. Exported for test cleanup only.
+ * @internal
+ */
+export function _resetClipboard(): void {
+  clipboard = [];
+  pasteCount = 0;
 }

--- a/packages/engine/src/tools/AreaShapeTool.ts
+++ b/packages/engine/src/tools/AreaShapeTool.ts
@@ -38,6 +38,8 @@ export class AreaShapeTool implements ToolHandler {
   private startY = 0;
   private currentX = 0;
   private currentY = 0;
+  /** When true, constrain to equal width/height (square/circle). */
+  private constrain = false;
 
   constructor(kind: AreaShapeKind) {
     this.shapeKind = kind;
@@ -51,19 +53,21 @@ export class AreaShapeTool implements ToolHandler {
     this.currentY = worldY;
   }
 
-  onPointerMove(worldX: number, worldY: number, _event: PointerEvent): void {
+  onPointerMove(worldX: number, worldY: number, event: PointerEvent): void {
     if (!this.isDrawing) return;
     this.currentX = worldX;
     this.currentY = worldY;
+    this.constrain = event.ctrlKey || event.metaKey;
   }
 
-  onPointerUp(worldX: number, worldY: number, _event: PointerEvent): void {
+  onPointerUp(worldX: number, worldY: number, event: PointerEvent): void {
     if (!this.isDrawing) {
       return;
     }
 
     this.currentX = worldX;
     this.currentY = worldY;
+    this.constrain = event.ctrlKey || event.metaKey;
     this.isDrawing = false;
 
     const { x, y, width, height } = this.computeBounds();
@@ -121,12 +125,20 @@ export class AreaShapeTool implements ToolHandler {
     return { kind: this.shapeKind, x, y, width, height };
   }
 
-  /** Compute normalized bounds (handles negative drag). */
+  /** Compute normalized bounds (handles negative drag and Ctrl-constrain). */
   private computeBounds() {
+    let width = Math.abs(this.currentX - this.startX);
+    let height = Math.abs(this.currentY - this.startY);
+
+    // Ctrl/Cmd constrains to equal dimensions (square/circle/equilateral)
+    if (this.constrain) {
+      const side = Math.max(width, height);
+      width = side;
+      height = side;
+    }
+
     const x = Math.min(this.startX, this.currentX);
     const y = Math.min(this.startY, this.currentY);
-    const width = Math.abs(this.currentX - this.startX);
-    const height = Math.abs(this.currentY - this.startY);
     return { x, y, width, height };
   }
 
@@ -136,5 +148,6 @@ export class AreaShapeTool implements ToolHandler {
     this.startY = 0;
     this.currentX = 0;
     this.currentY = 0;
+    this.constrain = false;
   }
 }


### PR DESCRIPTION
Ctrl+C/V/X with internal clipboard, cascading offsets. Ctrl+drag constrains rect→square, ellipse→circle. 28 tests. Closes #69, closes #73