### PR TITLE
feat(engine): Line/arrow endpoint dragging — #78

### DIFF
--- a/packages/engine/src/__tests__/pointHandleSelection.test.ts
+++ b/packages/engine/src/__tests__/pointHandleSelection.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for point-based selection rendering.
+ *
+ * Verifies that lines, arrows, and freehand shapes render point handles
+ * instead of the 8 bounding-box handles.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ *
+ * @module
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { VisualExpression, ExpressionStyle } from '@infinicanvas/protocol';
+import type { Camera } from '../types/index.js';
+import { renderSelection } from '../renderer/selectionRenderer.js';
+
+// ── Mock canvas context ──────────────────────────────────────
+
+function createMockCtx() {
+  const calls: { method: string; args: unknown[] }[] = [];
+
+  const ctx = {
+    save: vi.fn(() => calls.push({ method: 'save', args: [] })),
+    restore: vi.fn(() => calls.push({ method: 'restore', args: [] })),
+    beginPath: vi.fn(() => calls.push({ method: 'beginPath', args: [] })),
+    arc: vi.fn((...args: number[]) => calls.push({ method: 'arc', args })),
+    fill: vi.fn(() => calls.push({ method: 'fill', args: [] })),
+    stroke: vi.fn(() => calls.push({ method: 'stroke', args: [] })),
+    fillRect: vi.fn((...args: number[]) => calls.push({ method: 'fillRect', args })),
+    strokeRect: vi.fn((...args: number[]) => calls.push({ method: 'strokeRect', args })),
+    setLineDash: vi.fn((pattern: number[]) => calls.push({ method: 'setLineDash', args: [pattern] })),
+    lineWidth: 1,
+    strokeStyle: '',
+    fillStyle: '',
+    _calls: calls,
+  };
+
+  return ctx as unknown as CanvasRenderingContext2D & { _calls: typeof calls };
+}
+
+// ── Test helpers ─────────────────────────────────────────────
+
+const DEFAULT_STYLE: ExpressionStyle = {
+  strokeColor: '#000000',
+  backgroundColor: 'transparent',
+  fillStyle: 'none',
+  strokeWidth: 2,
+  roughness: 1,
+  opacity: 1,
+};
+
+const DEFAULT_META = {
+  author: { type: 'agent' as const, id: 'test', name: 'Test', provider: 'test' },
+  createdAt: 0,
+  updatedAt: 0,
+  tags: [],
+  locked: false,
+};
+
+const identityCamera: Camera = { x: 0, y: 0, zoom: 1 };
+
+function makeRect(id: string, x: number, y: number, w: number, h: number): VisualExpression {
+  return {
+    id,
+    kind: 'rectangle',
+    position: { x, y },
+    size: { width: w, height: h },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: { kind: 'rectangle' },
+  };
+}
+
+function makeLine(id: string, points: [number, number][]): VisualExpression {
+  const xs = points.map(([px]) => px);
+  const ys = points.map(([, py]) => py);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  return {
+    id,
+    kind: 'line',
+    position: { x: minX, y: minY },
+    size: { width: Math.max(...xs) - minX || 1, height: Math.max(...ys) - minY || 1 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: { kind: 'line', points },
+  };
+}
+
+function makeArrow(id: string, points: [number, number][]): VisualExpression {
+  const xs = points.map(([px]) => px);
+  const ys = points.map(([, py]) => py);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  return {
+    id,
+    kind: 'arrow',
+    position: { x: minX, y: minY },
+    size: { width: Math.max(...xs) - minX || 1, height: Math.max(...ys) - minY || 1 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: { kind: 'arrow', points, endArrowhead: true },
+  };
+}
+
+function makeFreehand(id: string, points: [number, number, number][]): VisualExpression {
+  const xs = points.map(([px]) => px);
+  const ys = points.map(([, py]) => py);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  return {
+    id,
+    kind: 'freehand',
+    position: { x: minX, y: minY },
+    size: { width: Math.max(...xs) - minX || 1, height: Math.max(...ys) - minY || 1 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: { kind: 'freehand', points },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('renderSelection — point-based shapes', () => {
+  it('renders circular handles at endpoints for a line (not 8 bbox handles)', () => {
+    const ctx = createMockCtx();
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+
+    renderSelection(ctx, new Set(['l1']), expressions, identityCamera);
+
+    // Should render circular handles (arc calls) instead of square handles (fillRect)
+    const arcCalls = ctx._calls.filter((c) => c.method === 'arc');
+    expect(arcCalls).toHaveLength(2); // 2 endpoints
+
+    // Should NOT render 8 square bbox handles
+    const fillRectCalls = ctx._calls.filter((c) => c.method === 'fillRect');
+    expect(fillRectCalls).toHaveLength(0);
+  });
+
+  it('renders circular handles at each point for an arrow', () => {
+    const ctx = createMockCtx();
+    const arrow = makeArrow('a1', [[50, 50], [200, 100], [350, 50]]);
+    const expressions = { a1: arrow };
+
+    renderSelection(ctx, new Set(['a1']), expressions, identityCamera);
+
+    const arcCalls = ctx._calls.filter((c) => c.method === 'arc');
+    expect(arcCalls).toHaveLength(3); // 3 points
+  });
+
+  it('renders circular handles at first and last point only for freehand', () => {
+    const ctx = createMockCtx();
+    const freehand = makeFreehand('f1', [
+      [10, 10, 0.5],
+      [20, 15, 0.6],
+      [30, 20, 0.7],
+      [40, 25, 0.8],
+      [50, 30, 0.5],
+    ]);
+    const expressions = { f1: freehand };
+
+    renderSelection(ctx, new Set(['f1']), expressions, identityCamera);
+
+    const arcCalls = ctx._calls.filter((c) => c.method === 'arc');
+    expect(arcCalls).toHaveLength(2); // Only first and last
+  });
+
+  it('renders point handles at correct positions for a line', () => {
+    const ctx = createMockCtx();
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+
+    renderSelection(ctx, new Set(['l1']), expressions, identityCamera);
+
+    const arcCalls = ctx._calls.filter((c) => c.method === 'arc');
+
+    // arc(cx, cy, radius, startAngle, endAngle)
+    // First handle at (100, 100)
+    expect(arcCalls[0]!.args[0]).toBe(100); // cx
+    expect(arcCalls[0]!.args[1]).toBe(100); // cy
+
+    // Second handle at (300, 200)
+    expect(arcCalls[1]!.args[0]).toBe(300); // cx
+    expect(arcCalls[1]!.args[1]).toBe(200); // cy
+  });
+
+  it('still renders 8 bbox handles for rectangles', () => {
+    const ctx = createMockCtx();
+    const rect = makeRect('r1', 100, 100, 200, 200);
+    const expressions = { r1: rect };
+
+    renderSelection(ctx, new Set(['r1']), expressions, identityCamera);
+
+    // Should render 8 square handles
+    const fillRectCalls = ctx._calls.filter((c) => c.method === 'fillRect');
+    expect(fillRectCalls).toHaveLength(8);
+
+    // Should NOT render circular handles
+    const arcCalls = ctx._calls.filter((c) => c.method === 'arc');
+    expect(arcCalls).toHaveLength(0);
+  });
+
+  it('still draws dashed bounding box for lines', () => {
+    const ctx = createMockCtx();
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+
+    renderSelection(ctx, new Set(['l1']), expressions, identityCamera);
+
+    // Should set dash pattern
+    expect(ctx.setLineDash).toHaveBeenCalledWith([4, 4]);
+  });
+
+  it('adjusts point handle radius for zoom level', () => {
+    const ctx = createMockCtx();
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+    const zoomedCamera: Camera = { x: 0, y: 0, zoom: 2 };
+
+    renderSelection(ctx, new Set(['l1']), expressions, zoomedCamera);
+
+    const arcCalls = ctx._calls.filter((c) => c.method === 'arc');
+    // Handle radius should be HANDLE_SIZE_PX / 2 / zoom = 8 / 2 / 2 = 2
+    for (const call of arcCalls) {
+      expect(call.args[2]).toBe(2); // radius
+    }
+  });
+
+  it('renders mixed selection: rect gets bbox handles, line gets point handles', () => {
+    const ctx = createMockCtx();
+    const rect = makeRect('r1', 0, 0, 100, 100);
+    const line = makeLine('l1', [[200, 200], [400, 300]]);
+    const expressions = { r1: rect, l1: line };
+
+    renderSelection(ctx, new Set(['r1', 'l1']), expressions, identityCamera);
+
+    // 8 fillRect for rect bbox handles
+    const fillRectCalls = ctx._calls.filter((c) => c.method === 'fillRect');
+    expect(fillRectCalls).toHaveLength(8);
+
+    // 2 arc calls for line point handles
+    const arcCalls = ctx._calls.filter((c) => c.method === 'arc');
+    expect(arcCalls).toHaveLength(2);
+  });
+});

--- a/packages/engine/src/__tests__/pointHandles.test.ts
+++ b/packages/engine/src/__tests__/pointHandles.test.ts
@@ -1,0 +1,557 @@
+/**
+ * Unit tests for point-based handle detection and dragging.
+ *
+ * Lines, arrows, and freehand shapes use `data.points` for geometry.
+ * These tests verify:
+ * - Point handle positions are computed from data.points
+ * - Point handles are detected within tolerance
+ * - Point drag computes new points and bounding box
+ * - Type guard identifies point-based expression kinds
+ * - Freehand shows handles at first and last point only
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ *
+ * @module
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { VisualExpression, ExpressionStyle } from '@infinicanvas/protocol';
+import type { Camera } from '../types/index.js';
+import {
+  isPointBasedKind,
+  getPointHandlePositions,
+  detectPointHandle,
+  computePointDrag,
+  detectPointerTarget,
+  getCursorForTarget,
+} from '../interaction/manipulationHelpers.js';
+import type { PointHandleHit } from '../interaction/manipulationHelpers.js';
+
+// ── Test fixtures ──────────────────────────────────────────────
+
+const DEFAULT_STYLE: ExpressionStyle = {
+  strokeColor: '#000000',
+  backgroundColor: 'transparent',
+  fillStyle: 'none',
+  strokeWidth: 2,
+  roughness: 1,
+  opacity: 1,
+};
+
+const DEFAULT_META = {
+  author: { type: 'agent' as const, id: 'test', name: 'Test', provider: 'test' },
+  createdAt: 0,
+  updatedAt: 0,
+  tags: [],
+  locked: false,
+};
+
+const DEFAULT_CAMERA: Camera = { x: 0, y: 0, zoom: 1 };
+
+/** Create a line expression with given points. */
+function makeLine(
+  id: string,
+  points: [number, number][],
+): VisualExpression {
+  const xs = points.map(([px]) => px);
+  const ys = points.map(([, py]) => py);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+  return {
+    id,
+    kind: 'line',
+    position: { x: minX, y: minY },
+    size: { width: maxX - minX || 1, height: maxY - minY || 1 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: { kind: 'line', points },
+  };
+}
+
+/** Create an arrow expression with given points. */
+function makeArrow(
+  id: string,
+  points: [number, number][],
+): VisualExpression {
+  const xs = points.map(([px]) => px);
+  const ys = points.map(([, py]) => py);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+  return {
+    id,
+    kind: 'arrow',
+    position: { x: minX, y: minY },
+    size: { width: maxX - minX || 1, height: maxY - minY || 1 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: { kind: 'arrow', points, endArrowhead: true },
+  };
+}
+
+/** Create a freehand expression with given points (including pressure). */
+function makeFreehand(
+  id: string,
+  points: [number, number, number][],
+): VisualExpression {
+  const xs = points.map(([px]) => px);
+  const ys = points.map(([, py]) => py);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+  return {
+    id,
+    kind: 'freehand',
+    position: { x: minX, y: minY },
+    size: { width: maxX - minX || 1, height: maxY - minY || 1 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: { kind: 'freehand', points },
+  };
+}
+
+function makeRect(
+  id: string,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): VisualExpression {
+  return {
+    id,
+    kind: 'rectangle',
+    position: { x, y },
+    size: { width: w, height: h },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: { kind: 'rectangle' },
+  };
+}
+
+// ── isPointBasedKind ───────────────────────────────────────────
+
+describe('isPointBasedKind', () => {
+  it('returns true for line', () => {
+    expect(isPointBasedKind('line')).toBe(true);
+  });
+
+  it('returns true for arrow', () => {
+    expect(isPointBasedKind('arrow')).toBe(true);
+  });
+
+  it('returns true for freehand', () => {
+    expect(isPointBasedKind('freehand')).toBe(true);
+  });
+
+  it('returns false for rectangle', () => {
+    expect(isPointBasedKind('rectangle')).toBe(false);
+  });
+
+  it('returns false for ellipse', () => {
+    expect(isPointBasedKind('ellipse')).toBe(false);
+  });
+
+  it('returns false for text', () => {
+    expect(isPointBasedKind('text')).toBe(false);
+  });
+});
+
+// ── getPointHandlePositions ────────────────────────────────────
+
+describe('getPointHandlePositions', () => {
+  it('returns handles at each point for a line', () => {
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const handles = getPointHandlePositions(line);
+
+    expect(handles).toHaveLength(2);
+    expect(handles[0]).toEqual({ x: 100, y: 100, pointIndex: 0 });
+    expect(handles[1]).toEqual({ x: 300, y: 200, pointIndex: 1 });
+  });
+
+  it('returns handles at each point for an arrow', () => {
+    const arrow = makeArrow('a1', [[50, 50], [200, 100], [350, 50]]);
+    const handles = getPointHandlePositions(arrow);
+
+    expect(handles).toHaveLength(3);
+    expect(handles[0]).toEqual({ x: 50, y: 50, pointIndex: 0 });
+    expect(handles[1]).toEqual({ x: 200, y: 100, pointIndex: 1 });
+    expect(handles[2]).toEqual({ x: 350, y: 50, pointIndex: 2 });
+  });
+
+  it('returns handles at first and last point only for freehand', () => {
+    const freehand = makeFreehand('f1', [
+      [10, 10, 0.5],
+      [20, 15, 0.6],
+      [30, 20, 0.7],
+      [40, 25, 0.8],
+      [50, 30, 0.5],
+    ]);
+    const handles = getPointHandlePositions(freehand);
+
+    // Only first and last point for freehand
+    expect(handles).toHaveLength(2);
+    expect(handles[0]).toEqual({ x: 10, y: 10, pointIndex: 0 });
+    expect(handles[1]).toEqual({ x: 50, y: 30, pointIndex: 4 });
+  });
+
+  it('returns empty array for non-point-based expression', () => {
+    const rect = makeRect('r1', 100, 100, 200, 200);
+    const handles = getPointHandlePositions(rect);
+
+    expect(handles).toHaveLength(0);
+  });
+
+  it('returns handles for a single-point freehand', () => {
+    const freehand = makeFreehand('f1', [[10, 10, 0.5]]);
+    const handles = getPointHandlePositions(freehand);
+
+    // Single point → 1 handle (first === last)
+    expect(handles).toHaveLength(1);
+    expect(handles[0]).toEqual({ x: 10, y: 10, pointIndex: 0 });
+  });
+});
+
+// ── detectPointHandle ──────────────────────────────────────────
+
+describe('detectPointHandle', () => {
+  it('detects a point handle at exact position', () => {
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+    const selectedIds = new Set(['l1']);
+
+    const hit = detectPointHandle(
+      { x: 100, y: 100 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(hit).toEqual({ pointIndex: 0, expressionId: 'l1' });
+  });
+
+  it('detects a point handle within 8px tolerance', () => {
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+    const selectedIds = new Set(['l1']);
+
+    // 7px away from endpoint (300,200)
+    const hit = detectPointHandle(
+      { x: 293, y: 200 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(hit).toEqual({ pointIndex: 1, expressionId: 'l1' });
+  });
+
+  it('returns null outside tolerance', () => {
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+    const selectedIds = new Set(['l1']);
+
+    // 10px away — outside 8px tolerance
+    const hit = detectPointHandle(
+      { x: 110, y: 110 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(hit).toBeNull();
+  });
+
+  it('scales tolerance by camera zoom', () => {
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+    const selectedIds = new Set(['l1']);
+    const zoomedCamera: Camera = { x: 0, y: 0, zoom: 2 };
+
+    // 5 world units away = 10 screen pixels at zoom 2 → outside 8px tolerance
+    const hit = detectPointHandle(
+      { x: 105, y: 100 },
+      expressions,
+      selectedIds,
+      zoomedCamera,
+    );
+    expect(hit).toBeNull();
+
+    // 3 world units away = 6 screen pixels at zoom 2 → within tolerance
+    const hit2 = detectPointHandle(
+      { x: 103, y: 100 },
+      expressions,
+      selectedIds,
+      zoomedCamera,
+    );
+    expect(hit2).toEqual({ pointIndex: 0, expressionId: 'l1' });
+  });
+
+  it('returns null for non-point-based expressions', () => {
+    const rect = makeRect('r1', 100, 100, 200, 200);
+    const expressions = { r1: rect };
+    const selectedIds = new Set(['r1']);
+
+    const hit = detectPointHandle(
+      { x: 100, y: 100 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(hit).toBeNull();
+  });
+
+  it('ignores non-selected expressions', () => {
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+    const selectedIds = new Set<string>();
+
+    const hit = detectPointHandle(
+      { x: 100, y: 100 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(hit).toBeNull();
+  });
+
+  it('detects handles for arrow expressions', () => {
+    const arrow = makeArrow('a1', [[50, 50], [250, 150]]);
+    const expressions = { a1: arrow };
+    const selectedIds = new Set(['a1']);
+
+    const hit = detectPointHandle(
+      { x: 250, y: 150 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(hit).toEqual({ pointIndex: 1, expressionId: 'a1' });
+  });
+
+  it('detects only first/last handles for freehand', () => {
+    const freehand = makeFreehand('f1', [
+      [10, 10, 0.5],
+      [20, 15, 0.6],
+      [30, 20, 0.7],
+      [40, 25, 0.8],
+      [50, 30, 0.5],
+    ]);
+    const expressions = { f1: freehand };
+    const selectedIds = new Set(['f1']);
+
+    // Click on first point — should hit
+    const hit1 = detectPointHandle(
+      { x: 10, y: 10 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+    expect(hit1).toEqual({ pointIndex: 0, expressionId: 'f1' });
+
+    // Click on last point — should hit
+    const hit2 = detectPointHandle(
+      { x: 50, y: 30 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+    expect(hit2).toEqual({ pointIndex: 4, expressionId: 'f1' });
+
+    // Click on middle point — should NOT hit (freehand only shows first/last)
+    const hit3 = detectPointHandle(
+      { x: 30, y: 20 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+    expect(hit3).toBeNull();
+  });
+});
+
+// ── computePointDrag ───────────────────────────────────────────
+
+describe('computePointDrag', () => {
+  it('moves a single endpoint and recalculates bounding box', () => {
+    const result = computePointDrag({
+      pointIndex: 1,
+      originalPoints: [[100, 100], [300, 200]],
+      newPointPosition: { x: 400, y: 50 },
+    });
+
+    expect(result.points[0]).toEqual([100, 100]);
+    expect(result.points[1]).toEqual([400, 50]);
+    expect(result.position).toEqual({ x: 100, y: 50 });
+    expect(result.size).toEqual({ width: 300, height: 50 });
+  });
+
+  it('moves the first endpoint of a line', () => {
+    const result = computePointDrag({
+      pointIndex: 0,
+      originalPoints: [[100, 100], [300, 200]],
+      newPointPosition: { x: 50, y: 250 },
+    });
+
+    expect(result.points[0]).toEqual([50, 250]);
+    expect(result.points[1]).toEqual([300, 200]);
+    expect(result.position).toEqual({ x: 50, y: 200 });
+    expect(result.size).toEqual({ width: 250, height: 50 });
+  });
+
+  it('recalculates bounding box for multi-segment line', () => {
+    const result = computePointDrag({
+      pointIndex: 1,
+      originalPoints: [[0, 0], [100, 100], [200, 0]],
+      newPointPosition: { x: 100, y: 200 },
+    });
+
+    expect(result.points).toEqual([[0, 0], [100, 200], [200, 0]]);
+    expect(result.position).toEqual({ x: 0, y: 0 });
+    expect(result.size).toEqual({ width: 200, height: 200 });
+  });
+
+  it('handles horizontal line (zero height → minimum 1)', () => {
+    const result = computePointDrag({
+      pointIndex: 1,
+      originalPoints: [[100, 100], [300, 100]],
+      newPointPosition: { x: 400, y: 100 },
+    });
+
+    expect(result.points).toEqual([[100, 100], [400, 100]]);
+    expect(result.position).toEqual({ x: 100, y: 100 });
+    // Height is 0, but minimum bounding box dimension is 1
+    expect(result.size).toEqual({ width: 300, height: 1 });
+  });
+
+  it('handles vertical line (zero width → minimum 1)', () => {
+    const result = computePointDrag({
+      pointIndex: 1,
+      originalPoints: [[100, 100], [100, 300]],
+      newPointPosition: { x: 100, y: 400 },
+    });
+
+    expect(result.points).toEqual([[100, 100], [100, 400]]);
+    expect(result.position).toEqual({ x: 100, y: 100 });
+    expect(result.size).toEqual({ width: 1, height: 300 });
+  });
+
+  it('preserves other points when dragging one', () => {
+    const original: [number, number][] = [[0, 0], [50, 50], [100, 0], [150, 50]];
+    const result = computePointDrag({
+      pointIndex: 2,
+      originalPoints: original,
+      newPointPosition: { x: 120, y: -20 },
+    });
+
+    expect(result.points[0]).toEqual([0, 0]);
+    expect(result.points[1]).toEqual([50, 50]);
+    expect(result.points[2]).toEqual([120, -20]);
+    expect(result.points[3]).toEqual([150, 50]);
+  });
+
+  it('does not mutate original points array', () => {
+    const original: [number, number][] = [[100, 100], [300, 200]];
+    const originalCopy = original.map(p => [...p]);
+
+    computePointDrag({
+      pointIndex: 1,
+      originalPoints: original,
+      newPointPosition: { x: 400, y: 50 },
+    });
+
+    // Original should not be modified
+    expect(original).toEqual(originalCopy);
+  });
+});
+
+// ── detectPointerTarget with point-based shapes ────────────────
+
+describe('detectPointerTarget with point-based shapes', () => {
+  it('detects point handle over body for line', () => {
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+    const selectedIds = new Set(['l1']);
+
+    const target = detectPointerTarget(
+      { x: 100, y: 100 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(target.kind).toBe('point-handle');
+    if (target.kind === 'point-handle') {
+      expect(target.handle.pointIndex).toBe(0);
+      expect(target.handle.expressionId).toBe('l1');
+    }
+  });
+
+  it('detects body when inside line bounding box but not on point handle', () => {
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+    const selectedIds = new Set(['l1']);
+
+    // Inside bounding box but not near any endpoint
+    const target = detectPointerTarget(
+      { x: 200, y: 150 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(target.kind).toBe('body');
+  });
+
+  it('does not return bbox handle for line (uses point handles instead)', () => {
+    const line = makeLine('l1', [[100, 100], [300, 200]]);
+    const expressions = { l1: line };
+    const selectedIds = new Set(['l1']);
+
+    // At bounding-box NW corner (same as first point) — should be point-handle, not handle
+    const target = detectPointerTarget(
+      { x: 100, y: 100 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(target.kind).toBe('point-handle');
+  });
+
+  it('still returns bbox handle for rectangles', () => {
+    const rect = makeRect('r1', 100, 100, 200, 200);
+    const expressions = { r1: rect };
+    const selectedIds = new Set(['r1']);
+
+    const target = detectPointerTarget(
+      { x: 100, y: 100 },
+      expressions,
+      selectedIds,
+      DEFAULT_CAMERA,
+    );
+
+    expect(target.kind).toBe('handle');
+  });
+});
+
+// ── getCursorForTarget with point handles ──────────────────────
+
+describe('getCursorForTarget with point handles', () => {
+  it('returns crosshair cursor for point handle', () => {
+    const target = {
+      kind: 'point-handle' as const,
+      handle: { pointIndex: 0, expressionId: 'l1' },
+    };
+    expect(getCursorForTarget(target)).toBe('crosshair');
+  });
+});

--- a/packages/engine/src/hooks/useManipulationInteraction.ts
+++ b/packages/engine/src/hooks/useManipulationInteraction.ts
@@ -21,15 +21,17 @@
  */
 
 import { useRef, useEffect, useCallback, useState } from 'react';
+import type { VisualExpression } from '@infinicanvas/protocol';
 import { useCanvasStore } from '../store/canvasStore.js';
 import { screenToWorld } from '../camera.js';
-import { isEditableTarget } from '../utils/isEditableTarget.js';
 import {
   detectPointerTarget,
   computeResize,
+  computePointDrag,
   getCursorForTarget,
+  isPointBasedKind,
 } from '../interaction/manipulationHelpers.js';
-import type { HandleHit } from '../interaction/manipulationHelpers.js';
+import type { HandleHit, PointHandleHit } from '../interaction/manipulationHelpers.js';
 
 export interface ManipulationInteraction {
   /** Current cursor style based on pointer target. */
@@ -51,6 +53,18 @@ type DragMode =
       /** Handle being dragged. */
       handle: HandleHit;
       /** Original expression bounds before resize. */
+      originalPosition: { x: number; y: number };
+      originalSize: { width: number; height: number };
+      /** World position where drag started. */
+      startWorld: { x: number; y: number };
+    }
+  | {
+      kind: 'point-drag';
+      /** Point handle being dragged. */
+      handle: PointHandleHit;
+      /** Original points array before drag started. */
+      originalPoints: [number, number][];
+      /** Original expression bounds before drag. */
       originalPosition: { x: number; y: number };
       originalSize: { width: number; height: number };
       /** World position where drag started. */
@@ -82,7 +96,25 @@ export function useManipulationInteraction(
     // Detect target: handle or body of a selected expression
     const target = detectPointerTarget(worldPoint, expressions, selectedIds, camera);
 
-    if (target.kind === 'handle') {
+    if (target.kind === 'point-handle') {
+      const expr = expressions[target.handle.expressionId];
+      if (!expr || expr.meta.locked) return; // AC8: locked guard
+
+      // Extract points from the expression data
+      const data = expr.data as { points: [number, number][] | [number, number, number][] };
+      const originalPoints: [number, number][] = data.points.map(
+        (p) => [p[0], p[1]] as [number, number],
+      );
+
+      dragModeRef.current = {
+        kind: 'point-drag',
+        handle: target.handle,
+        originalPoints,
+        originalPosition: { ...expr.position },
+        originalSize: { ...expr.size },
+        startWorld: worldPoint,
+      };
+    } else if (target.kind === 'handle') {
       const expr = expressions[target.handle.expressionId];
       if (!expr || expr.meta.locked) return; // AC8: locked guard
 
@@ -159,6 +191,32 @@ export function useManipulationInteraction(
           expr.size = resized.size;
         }
       });
+    } else if (drag.kind === 'point-drag') {
+      // ── Transient point-drag preview ────────────────────
+      const result = computePointDrag({
+        pointIndex: drag.handle.pointIndex,
+        originalPoints: drag.originalPoints,
+        newPointPosition: worldPoint,
+      });
+
+      useCanvasStore.setState((draft) => {
+        const expr = draft.expressions[drag.handle.expressionId];
+        if (expr && isPointBasedKind(expr.data.kind)) {
+          const data = expr.data as { points: [number, number][] | [number, number, number][] };
+          // Update point — preserve pressure for freehand
+          if (expr.data.kind === 'freehand') {
+            const freehandPoints = data.points as [number, number, number][];
+            const pressure = freehandPoints[drag.handle.pointIndex]?.[2] ?? 0.5;
+            (data.points as [number, number, number][])[drag.handle.pointIndex] =
+              [worldPoint.x, worldPoint.y, pressure];
+          } else {
+            (data.points as [number, number][])[drag.handle.pointIndex] =
+              [worldPoint.x, worldPoint.y];
+          }
+          expr.position = result.position;
+          expr.size = result.size;
+        }
+      });
     } else {
       // ── Hover cursor feedback (AC10) ────────────────────
       const target = detectPointerTarget(worldPoint, expressions, selectedIds, camera);
@@ -207,6 +265,42 @@ export function useManipulationInteraction(
           { position: drag.originalPosition, size: drag.originalSize },
           { position: resized.position, size: resized.size },
         );
+      }
+    } else if (drag.kind === 'point-drag') {
+      const dx = worldPoint.x - drag.startWorld.x;
+      const dy = worldPoint.y - drag.startWorld.y;
+
+      if (Math.abs(dx) > 0.001 || Math.abs(dy) > 0.001) {
+        const result = computePointDrag({
+          pointIndex: drag.handle.pointIndex,
+          originalPoints: drag.originalPoints,
+          newPointPosition: worldPoint,
+        });
+
+        // Build updated data payload preserving kind-specific fields
+        const expr = state.expressions[drag.handle.expressionId];
+        if (expr) {
+          let updatedData: Record<string, unknown>;
+
+          if (expr.data.kind === 'freehand') {
+            // Preserve pressure values for freehand
+            const freehandData = expr.data as { kind: 'freehand'; points: [number, number, number][] };
+            const newPoints: [number, number, number][] = freehandData.points.map(
+              (p) => [p[0], p[1], p[2]] as [number, number, number],
+            );
+            const pressure = newPoints[drag.handle.pointIndex]?.[2] ?? 0.5;
+            newPoints[drag.handle.pointIndex] = [worldPoint.x, worldPoint.y, pressure];
+            updatedData = { ...expr.data, points: newPoints };
+          } else {
+            updatedData = { ...expr.data, points: result.points };
+          }
+
+          state.updateExpression(drag.handle.expressionId, {
+            data: updatedData as unknown as VisualExpression['data'],
+            position: result.position,
+            size: result.size,
+          });
+        }
       }
     }
 

--- a/packages/engine/src/interaction/manipulationHelpers.ts
+++ b/packages/engine/src/interaction/manipulationHelpers.ts
@@ -11,6 +11,21 @@
 import type { VisualExpression } from '@infinicanvas/protocol';
 import type { Camera } from '../types/index.js';
 
+// ── Point-based kind guard ─────────────────────────────────────
+
+/** Expression kinds that use `data.points` for geometry. */
+export type PointBasedKind = 'line' | 'arrow' | 'freehand';
+
+/**
+ * Check if an expression kind uses point-based geometry.
+ *
+ * Lines, arrows, and freehand shapes store their geometry in
+ * `data.points` rather than using `position`/`size` alone. [CLEAN-CODE]
+ */
+export function isPointBasedKind(kind: string): kind is PointBasedKind {
+  return kind === 'line' || kind === 'arrow' || kind === 'freehand';
+}
+
 // ── Handle types ──────────────────────────────────────────────
 
 /** The 8 resize handle positions (4 corners + 4 edge midpoints). */
@@ -22,9 +37,16 @@ export interface HandleHit {
   expressionId: string;
 }
 
+/** Result of detecting a point handle (endpoint of a line/arrow/freehand). */
+export interface PointHandleHit {
+  pointIndex: number;
+  expressionId: string;
+}
+
 /** Result of detecting what the pointer is hovering over. */
 export type PointerTarget =
   | { kind: 'handle'; handle: HandleHit }
+  | { kind: 'point-handle'; handle: PointHandleHit }
   | { kind: 'body'; expressionId: string }
   | { kind: 'none' };
 
@@ -61,10 +83,12 @@ export function getHandlePositions(
 }
 
 /**
- * Detect which handle (if any) is at the given world point.
+ * Detect which bbox handle (if any) is at the given world point.
  *
- * Checks all selected expressions' handles. Returns the first hit
- * within HANDLE_TOLERANCE_PX screen pixels of the handle center.
+ * Checks all selected non-point-based expressions' handles. Returns the
+ * first hit within HANDLE_TOLERANCE_PX screen pixels of the handle center.
+ * Point-based shapes (line, arrow, freehand) are skipped — they use
+ * point handles instead.
  */
 export function detectHandle(
   worldPoint: { x: number; y: number },
@@ -77,6 +101,9 @@ export function detectHandle(
   for (const id of selectedIds) {
     const expr = expressions[id];
     if (!expr) continue;
+
+    // Point-based shapes use point handles, not bbox handles
+    if (isPointBasedKind(expr.data.kind)) continue;
 
     const handles = getHandlePositions(expr);
     for (const handle of handles) {
@@ -91,10 +118,81 @@ export function detectHandle(
   return null;
 }
 
+// ── Point-based handle detection ──────────────────────────────
+
+/**
+ * Compute point handle positions for a point-based expression.
+ *
+ * - Lines and arrows: returns a handle at each point in `data.points`.
+ * - Freehand: returns handles at first and last point only (not all points).
+ * - Non-point-based expressions: returns empty array.
+ *
+ * @returns Array of handle positions with their point index.
+ */
+export function getPointHandlePositions(
+  expr: VisualExpression,
+): Array<{ x: number; y: number; pointIndex: number }> {
+  if (!isPointBasedKind(expr.data.kind)) return [];
+
+  const data = expr.data as { points: [number, number][] | [number, number, number][] };
+  const { points } = data;
+
+  if (points.length === 0) return [];
+
+  if (expr.data.kind === 'freehand') {
+    // Freehand: first and last point only
+    const first = points[0]!;
+    const last = points[points.length - 1]!;
+    if (points.length === 1) {
+      return [{ x: first[0], y: first[1], pointIndex: 0 }];
+    }
+    return [
+      { x: first[0], y: first[1], pointIndex: 0 },
+      { x: last[0], y: last[1], pointIndex: points.length - 1 },
+    ];
+  }
+
+  // Lines and arrows: handle at each point
+  return points.map((p, i) => ({ x: p[0], y: p[1], pointIndex: i }));
+}
+
+/**
+ * Detect which point handle (if any) is at the given world point.
+ *
+ * Only checks point-based expressions (line, arrow, freehand).
+ * Returns the first hit within HANDLE_TOLERANCE_PX screen pixels.
+ */
+export function detectPointHandle(
+  worldPoint: { x: number; y: number },
+  expressions: Record<string, VisualExpression>,
+  selectedIds: Set<string>,
+  camera: Camera,
+): PointHandleHit | null {
+  const tolerance = HANDLE_TOLERANCE_PX / camera.zoom;
+
+  for (const id of selectedIds) {
+    const expr = expressions[id];
+    if (!expr || !isPointBasedKind(expr.data.kind)) continue;
+
+    const handles = getPointHandlePositions(expr);
+    for (const handle of handles) {
+      const dx = worldPoint.x - handle.x;
+      const dy = worldPoint.y - handle.y;
+      if (Math.abs(dx) <= tolerance && Math.abs(dy) <= tolerance) {
+        return { pointIndex: handle.pointIndex, expressionId: id };
+      }
+    }
+  }
+
+  return null;
+}
+
 /**
  * Detect what the pointer is targeting: a handle, a shape body, or nothing.
  *
- * Priority: handles first (so users can grab edges), then body.
+ * Priority: point handles (for point-based shapes) → bbox handles → body.
+ * Point-based shapes (line, arrow, freehand) use point handles instead
+ * of the 8 bounding-box handles.
  */
 export function detectPointerTarget(
   worldPoint: { x: number; y: number },
@@ -102,7 +200,13 @@ export function detectPointerTarget(
   selectedIds: Set<string>,
   camera: Camera,
 ): PointerTarget {
-  // Check handles first
+  // Check point handles first (for line/arrow/freehand)
+  const pointHandle = detectPointHandle(worldPoint, expressions, selectedIds, camera);
+  if (pointHandle) {
+    return { kind: 'point-handle', handle: pointHandle };
+  }
+
+  // Check bbox handles (only for non-point-based shapes)
   const handle = detectHandle(worldPoint, expressions, selectedIds, camera);
   if (handle) {
     return { kind: 'handle', handle };
@@ -148,6 +252,8 @@ export function getCursorForTarget(target: PointerTarget): string {
   switch (target.kind) {
     case 'handle':
       return HANDLE_CURSORS[target.handle.type];
+    case 'point-handle':
+      return 'crosshair';
     case 'body':
       return 'move';
     case 'none':
@@ -274,4 +380,58 @@ export function computeResize(input: ResizeInput): ResizeResult {
 /** Check if a handle is a corner handle (resizes both dimensions). */
 function isCornerHandle(type: HandleType): boolean {
   return type === 'nw' || type === 'ne' || type === 'se' || type === 'sw';
+}
+
+// ── Point drag computation ────────────────────────────────────
+
+interface PointDragInput {
+  /** Index of the point being dragged. */
+  pointIndex: number;
+  /** Original points array (not mutated). */
+  originalPoints: [number, number][];
+  /** New world position for the dragged point. */
+  newPointPosition: { x: number; y: number };
+}
+
+interface PointDragResult {
+  /** Updated points array with the dragged point moved. */
+  points: [number, number][];
+  /** Recalculated bounding-box position (top-left). */
+  position: { x: number; y: number };
+  /** Recalculated bounding-box size. Zero dimensions are clamped to 1. */
+  size: { width: number; height: number };
+}
+
+/**
+ * Compute the result of dragging a single point in a point-based shape.
+ *
+ * Updates the specific point, then recalculates the bounding box
+ * (position and size) from all points. Does not mutate the original
+ * points array. [CLEAN-CODE]
+ */
+export function computePointDrag(input: PointDragInput): PointDragResult {
+  const { pointIndex, originalPoints, newPointPosition } = input;
+
+  // Clone points and update the dragged point
+  const points: [number, number][] = originalPoints.map(
+    (p) => [p[0], p[1]] as [number, number],
+  );
+  points[pointIndex] = [newPointPosition.x, newPointPosition.y];
+
+  // Recalculate bounding box from all points
+  const xs = points.map((p) => p[0]);
+  const ys = points.map((p) => p[1]);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+
+  return {
+    points,
+    position: { x: minX, y: minY },
+    size: {
+      width: maxX - minX || 1,
+      height: maxY - minY || 1,
+    },
+  };
 }

--- a/packages/engine/src/renderer/selectionRenderer.ts
+++ b/packages/engine/src/renderer/selectionRenderer.ts
@@ -3,7 +3,9 @@
  *
  * Renders after all expressions in the render loop:
  * - Dashed bounding box in selection color (#4A90D9)
- * - 8 resize handles (4 corners + 4 edge midpoints)
+ * - For point-based shapes (line, arrow, freehand): circular handles
+ *   at each point (or first/last for freehand)
+ * - For other shapes: 8 resize handles (4 corners + 4 edge midpoints)
  *
  * Handle sizes are constant in screen pixels (8×8), scaled inversely
  * by zoom to maintain consistent visual size.
@@ -13,6 +15,10 @@
 
 import type { VisualExpression } from '@infinicanvas/protocol';
 import type { Camera } from '../types/index.js';
+import {
+  isPointBasedKind,
+  getPointHandlePositions,
+} from '../interaction/manipulationHelpers.js';
 
 /** Selection highlight color. */
 const SELECTION_COLOR = '#4A90D9';
@@ -26,8 +32,10 @@ const DASH_PATTERN = [4, 4];
 /**
  * Render selection UI for all selected expressions.
  *
- * For each selected expression: draws a dashed bounding box and
- * 8 resize handles (white squares with selection-colored borders).
+ * For point-based shapes (line, arrow, freehand): draws a dashed bounding
+ * box and circular handles at each data point.
+ * For other shapes: draws a dashed bounding box and 8 resize handles
+ * (white squares with selection-colored borders).
  *
  * @param ctx - Canvas 2D rendering context (with camera transform applied)
  * @param selectedIds - Set of currently selected expression IDs
@@ -62,29 +70,81 @@ export function renderSelection(
     ctx.setLineDash([]); // Reset dash
     ctx.restore();
 
-    // ── 8 resize handles ─────────────────────────────────────
-    const handlePoints = [
-      // Corners
-      { hx: x, hy: y },                             // top-left
-      { hx: x + width, hy: y },                     // top-right
-      { hx: x + width, hy: y + height },             // bottom-right
-      { hx: x, hy: y + height },                     // bottom-left
-      // Edge midpoints
-      { hx: x + width / 2, hy: y },                 // top-mid
-      { hx: x + width, hy: y + height / 2 },         // right-mid
-      { hx: x + width / 2, hy: y + height },         // bottom-mid
-      { hx: x, hy: y + height / 2 },                 // left-mid
-    ];
-
-    for (const { hx, hy } of handlePoints) {
-      // White fill
-      ctx.fillStyle = '#ffffff';
-      ctx.fillRect(hx - halfHandle, hy - halfHandle, handleSize, handleSize);
-
-      // Selection-colored border
-      ctx.strokeStyle = SELECTION_COLOR;
-      ctx.lineWidth = 1 / camera.zoom;
-      ctx.strokeRect(hx - halfHandle, hy - halfHandle, handleSize, handleSize);
+    if (isPointBasedKind(expr.data.kind)) {
+      // ── Circular point handles for line/arrow/freehand ───
+      renderPointHandles(ctx, expr, camera, halfHandle);
+    } else {
+      // ── 8 resize handles for other shapes ───────────────
+      renderBboxHandles(ctx, expr, camera, handleSize, halfHandle);
     }
+  }
+}
+
+/**
+ * Render circular handles at each data point of a point-based expression.
+ *
+ * Handles are white circles with selection-colored borders, sized
+ * to match the standard handle size in screen pixels.
+ */
+function renderPointHandles(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  camera: Camera,
+  radius: number,
+): void {
+  const pointHandles = getPointHandlePositions(expr);
+
+  for (const { x: px, y: py } of pointHandles) {
+    ctx.beginPath();
+    ctx.arc(px, py, radius, 0, Math.PI * 2);
+
+    // White fill
+    ctx.fillStyle = '#ffffff';
+    ctx.fill();
+
+    // Selection-colored border
+    ctx.strokeStyle = SELECTION_COLOR;
+    ctx.lineWidth = 1 / camera.zoom;
+    ctx.stroke();
+  }
+}
+
+/**
+ * Render the 8 bounding-box resize handles (4 corners + 4 edge midpoints).
+ *
+ * Handles are white squares with selection-colored borders.
+ */
+function renderBboxHandles(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  camera: Camera,
+  handleSize: number,
+  halfHandle: number,
+): void {
+  const { x, y } = expr.position;
+  const { width, height } = expr.size;
+
+  const handlePoints = [
+    // Corners
+    { hx: x, hy: y },                             // top-left
+    { hx: x + width, hy: y },                     // top-right
+    { hx: x + width, hy: y + height },             // bottom-right
+    { hx: x, hy: y + height },                     // bottom-left
+    // Edge midpoints
+    { hx: x + width / 2, hy: y },                 // top-mid
+    { hx: x + width, hy: y + height / 2 },         // right-mid
+    { hx: x + width / 2, hy: y + height },         // bottom-mid
+    { hx: x, hy: y + height / 2 },                 // left-mid
+  ];
+
+  for (const { hx, hy } of handlePoints) {
+    // White fill
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(hx - halfHandle, hy - halfHandle, handleSize, handleSize);
+
+    // Selection-colored border
+    ctx.strokeStyle = SELECTION_COLOR;
+    ctx.lineWidth = 1 / camera.zoom;
+    ctx.strokeRect(hx - halfHandle, hy - halfHandle, handleSize, handleSize);
   }
 }


### PR DESCRIPTION
Point-based selection handles (circles at endpoints), endpoint drag with bbox recalc. Freehand shows first/last point only. 39 tests. Closes #78