### PR TITLE
feat(engine): Double-click to edit text & shape labels — #75 #79

### DIFF
--- a/packages/engine/src/__tests__/useInlineEditor.test.tsx
+++ b/packages/engine/src/__tests__/useInlineEditor.test.tsx
@@ -1,0 +1,577 @@
+/**
+ * Unit tests for useInlineEditor hook.
+ *
+ * Covers: double-click to edit text, sticky-notes, and shape labels.
+ * Verifies startEditing, commitEdit, cancelEdit, and expression data updates.
+ *
+ * @vitest-environment jsdom
+ * @module
+ */
+
+import React from 'react';
+import { render, cleanup, act } from '@testing-library/react';
+import { useInlineEditor } from '../hooks/useInlineEditor.js';
+import { useCanvasStore } from '../store/canvasStore.js';
+import type { VisualExpression, ExpressionStyle } from '@infinicanvas/protocol';
+import type { InlineEditorState } from '../hooks/useInlineEditor.js';
+
+// ── Test helpers ─────────────────────────────────────────────
+
+const DEFAULT_STYLE: ExpressionStyle = {
+  strokeColor: '#000000',
+  backgroundColor: 'transparent',
+  fillStyle: 'none',
+  strokeWidth: 2,
+  roughness: 1,
+  opacity: 1,
+};
+
+const DEFAULT_META = {
+  author: { type: 'agent' as const, id: 'test', name: 'Test', provider: 'test' },
+  createdAt: 0,
+  updatedAt: 0,
+  tags: [],
+  locked: false,
+};
+
+function makeText(id: string, x: number, y: number, text: string): VisualExpression {
+  return {
+    id,
+    kind: 'text',
+    position: { x, y },
+    size: { width: 200, height: 50 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: { ...DEFAULT_META },
+    data: { kind: 'text', text, fontSize: 16, fontFamily: 'sans-serif', textAlign: 'left' as const },
+  };
+}
+
+function makeRect(id: string, x: number, y: number, label?: string): VisualExpression {
+  return {
+    id,
+    kind: 'rectangle',
+    position: { x, y },
+    size: { width: 150, height: 100 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: { ...DEFAULT_META },
+    data: { kind: 'rectangle', ...(label !== undefined ? { label } : {}) },
+  };
+}
+
+function makeEllipse(id: string, x: number, y: number, label?: string): VisualExpression {
+  return {
+    id,
+    kind: 'ellipse',
+    position: { x, y },
+    size: { width: 150, height: 100 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: { ...DEFAULT_META },
+    data: { kind: 'ellipse', ...(label !== undefined ? { label } : {}) },
+  };
+}
+
+function makeDiamond(id: string, x: number, y: number, label?: string): VisualExpression {
+  return {
+    id,
+    kind: 'diamond',
+    position: { x, y },
+    size: { width: 150, height: 100 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: { ...DEFAULT_META },
+    data: { kind: 'diamond', ...(label !== undefined ? { label } : {}) },
+  };
+}
+
+function makeStickyNote(id: string, x: number, y: number, text: string): VisualExpression {
+  return {
+    id,
+    kind: 'sticky-note',
+    position: { x, y },
+    size: { width: 200, height: 200 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: { ...DEFAULT_META },
+    data: { kind: 'sticky-note', text, color: '#FFEB3B' },
+  };
+}
+
+function makeLine(id: string): VisualExpression {
+  return {
+    id,
+    kind: 'line',
+    position: { x: 0, y: 0 },
+    size: { width: 100, height: 100 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: { ...DEFAULT_META },
+    data: { kind: 'line', points: [[0, 0], [100, 100]] as [number, number][] },
+  };
+}
+
+/** Reset store to clean state. */
+function resetStore() {
+  useCanvasStore.setState({
+    expressions: {},
+    expressionOrder: [],
+    selectedIds: new Set<string>(),
+    activeTool: 'select',
+    camera: { x: 0, y: 0, zoom: 1 },
+  });
+}
+
+/**
+ * Render the hook inside a fresh component and return an accessor.
+ * Uses a local ref pattern to avoid cross-test contamination
+ * from module-level variables.
+ */
+function renderEditor() {
+  const stateRef = { current: null as InlineEditorState | null };
+
+  function Harness() {
+    const canvasRef = React.useRef<HTMLCanvasElement>(null);
+    const state = useInlineEditor(canvasRef);
+    stateRef.current = state;
+    return <canvas ref={canvasRef} data-testid="canvas" width={800} height={600} />;
+  }
+
+  const rendered = render(<Harness />);
+  const getState = () => stateRef.current!;
+  return { getState, ...rendered };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('useInlineEditor — startEditing', () => {
+  beforeEach(() => { cleanup(); resetStore(); });
+  afterEach(() => { cleanup(); });
+
+  it('starts editing a text expression', () => {
+    const expr = makeText('t1', 100, 100, 'Hello');
+    useCanvasStore.setState({ expressions: { t1: expr }, expressionOrder: ['t1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('t1'); });
+    expect(getState().editingId).toBe('t1');
+  });
+
+  it('starts editing a sticky-note expression', () => {
+    const expr = makeStickyNote('s1', 100, 100, 'Sticky text');
+    useCanvasStore.setState({ expressions: { s1: expr }, expressionOrder: ['s1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('s1'); });
+    expect(getState().editingId).toBe('s1');
+  });
+
+  it('starts editing a rectangle expression for label', () => {
+    const expr = makeRect('r1', 100, 100, 'Label');
+    useCanvasStore.setState({ expressions: { r1: expr }, expressionOrder: ['r1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('r1'); });
+    expect(getState().editingId).toBe('r1');
+  });
+
+  it('starts editing an ellipse expression for label', () => {
+    const expr = makeEllipse('e1', 100, 100);
+    useCanvasStore.setState({ expressions: { e1: expr }, expressionOrder: ['e1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('e1'); });
+    expect(getState().editingId).toBe('e1');
+  });
+
+  it('starts editing a diamond expression for label', () => {
+    const expr = makeDiamond('d1', 100, 100, 'Decision');
+    useCanvasStore.setState({ expressions: { d1: expr }, expressionOrder: ['d1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('d1'); });
+    expect(getState().editingId).toBe('d1');
+  });
+
+  it('does not start editing for unsupported kind (line)', () => {
+    const expr = makeLine('l1');
+    useCanvasStore.setState({ expressions: { l1: expr }, expressionOrder: ['l1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('l1'); });
+    expect(getState().editingId).toBeNull();
+  });
+
+  it('does not start editing for non-existent expression', () => {
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('nonexistent'); });
+    expect(getState().editingId).toBeNull();
+  });
+
+  it('does not start editing for locked expression', () => {
+    const expr = makeText('t1', 100, 100, 'Hello');
+    expr.meta.locked = true;
+    useCanvasStore.setState({ expressions: { t1: expr }, expressionOrder: ['t1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('t1'); });
+    expect(getState().editingId).toBeNull();
+  });
+});
+
+describe('useInlineEditor — getEditingText', () => {
+  beforeEach(() => { cleanup(); resetStore(); });
+  afterEach(() => { cleanup(); });
+
+  it('returns current text for text expression', () => {
+    const expr = makeText('t1', 100, 100, 'Hello World');
+    useCanvasStore.setState({ expressions: { t1: expr }, expressionOrder: ['t1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('t1'); });
+    expect(getState().getEditingText()).toBe('Hello World');
+  });
+
+  it('returns current label for rectangle expression', () => {
+    const expr = makeRect('r1', 100, 100, 'My Label');
+    useCanvasStore.setState({ expressions: { r1: expr }, expressionOrder: ['r1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('r1'); });
+    expect(getState().getEditingText()).toBe('My Label');
+  });
+
+  it('returns empty string for rectangle with no label', () => {
+    const expr = makeRect('r1', 100, 100);
+    useCanvasStore.setState({ expressions: { r1: expr }, expressionOrder: ['r1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('r1'); });
+    expect(getState().getEditingText()).toBe('');
+  });
+
+  it('returns current text for sticky-note expression', () => {
+    const expr = makeStickyNote('s1', 100, 100, 'Sticky Content');
+    useCanvasStore.setState({ expressions: { s1: expr }, expressionOrder: ['s1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('s1'); });
+    expect(getState().getEditingText()).toBe('Sticky Content');
+  });
+
+  it('returns empty string when not editing', () => {
+    const { getState } = renderEditor();
+    expect(getState().getEditingText()).toBe('');
+  });
+});
+
+describe('useInlineEditor — commitEdit for text expressions', () => {
+  beforeEach(() => { cleanup(); resetStore(); });
+  afterEach(() => { cleanup(); });
+
+  it('updates text expression with new text', () => {
+    const expr = makeText('t1', 100, 100, 'Old text');
+    useCanvasStore.setState({ expressions: { t1: expr }, expressionOrder: ['t1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('t1'); });
+    act(() => { getState().commitEdit('New text'); });
+
+    const updated = useCanvasStore.getState().expressions['t1'];
+    expect(updated).toBeDefined();
+    expect(updated.data).toEqual(
+      expect.objectContaining({ kind: 'text', text: 'New text' }),
+    );
+    expect(getState().editingId).toBeNull();
+  });
+
+  it('deletes text expression when committed with empty text', () => {
+    const expr = makeText('t1', 100, 100, 'Will be deleted');
+    useCanvasStore.setState({ expressions: { t1: expr }, expressionOrder: ['t1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('t1'); });
+    act(() => { getState().commitEdit(''); });
+
+    expect(useCanvasStore.getState().expressions['t1']).toBeUndefined();
+    expect(getState().editingId).toBeNull();
+  });
+
+  it('deletes text expression when committed with whitespace-only text', () => {
+    const expr = makeText('t1', 100, 100, 'Will be deleted');
+    useCanvasStore.setState({ expressions: { t1: expr }, expressionOrder: ['t1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('t1'); });
+    act(() => { getState().commitEdit('   '); });
+
+    expect(useCanvasStore.getState().expressions['t1']).toBeUndefined();
+    expect(getState().editingId).toBeNull();
+  });
+
+  it('preserves font properties when updating text', () => {
+    const expr = makeText('t1', 100, 100, 'Old');
+    useCanvasStore.setState({ expressions: { t1: expr }, expressionOrder: ['t1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('t1'); });
+    act(() => { getState().commitEdit('New'); });
+
+    const updated = useCanvasStore.getState().expressions['t1'];
+    expect(updated.data).toEqual({
+      kind: 'text',
+      text: 'New',
+      fontSize: 16,
+      fontFamily: 'sans-serif',
+      textAlign: 'left',
+    });
+  });
+});
+
+describe('useInlineEditor — commitEdit for shape labels', () => {
+  beforeEach(() => { cleanup(); resetStore(); });
+  afterEach(() => { cleanup(); });
+
+  it('updates rectangle label with new text', () => {
+    const expr = makeRect('r1', 100, 100, 'Old Label');
+    useCanvasStore.setState({ expressions: { r1: expr }, expressionOrder: ['r1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('r1'); });
+    act(() => { getState().commitEdit('New Label'); });
+
+    const updated = useCanvasStore.getState().expressions['r1'];
+    expect(updated).toBeDefined();
+    expect(updated.data).toEqual({ kind: 'rectangle', label: 'New Label' });
+    expect(getState().editingId).toBeNull();
+  });
+
+  it('removes rectangle label when committed with empty text', () => {
+    const expr = makeRect('r1', 100, 100, 'Will be removed');
+    useCanvasStore.setState({ expressions: { r1: expr }, expressionOrder: ['r1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('r1'); });
+    act(() => { getState().commitEdit(''); });
+
+    const updated = useCanvasStore.getState().expressions['r1'];
+    expect(updated).toBeDefined();
+    expect((updated.data as { label?: string }).label).toBeUndefined();
+    expect(getState().editingId).toBeNull();
+  });
+
+  it('updates ellipse label', () => {
+    const expr = makeEllipse('e1', 100, 100, 'Circle');
+    useCanvasStore.setState({ expressions: { e1: expr }, expressionOrder: ['e1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('e1'); });
+    act(() => { getState().commitEdit('Ellipse Label'); });
+
+    expect(useCanvasStore.getState().expressions['e1'].data).toEqual({
+      kind: 'ellipse',
+      label: 'Ellipse Label',
+    });
+  });
+
+  it('updates diamond label', () => {
+    const expr = makeDiamond('d1', 100, 100, 'Yes/No');
+    useCanvasStore.setState({ expressions: { d1: expr }, expressionOrder: ['d1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('d1'); });
+    act(() => { getState().commitEdit('Decision Point'); });
+
+    expect(useCanvasStore.getState().expressions['d1'].data).toEqual({
+      kind: 'diamond',
+      label: 'Decision Point',
+    });
+  });
+
+  it('adds label to rectangle that had no label', () => {
+    const expr = makeRect('r1', 100, 100);
+    useCanvasStore.setState({ expressions: { r1: expr }, expressionOrder: ['r1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('r1'); });
+    act(() => { getState().commitEdit('Brand New Label'); });
+
+    expect(useCanvasStore.getState().expressions['r1'].data).toEqual({
+      kind: 'rectangle',
+      label: 'Brand New Label',
+    });
+  });
+});
+
+describe('useInlineEditor — commitEdit for sticky-note', () => {
+  beforeEach(() => { cleanup(); resetStore(); });
+  afterEach(() => { cleanup(); });
+
+  it('updates sticky-note text', () => {
+    const expr = makeStickyNote('s1', 100, 100, 'Old note');
+    useCanvasStore.setState({ expressions: { s1: expr }, expressionOrder: ['s1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('s1'); });
+    act(() => { getState().commitEdit('Updated note'); });
+
+    const updated = useCanvasStore.getState().expressions['s1'];
+    expect(updated).toBeDefined();
+    expect(updated.data).toEqual(
+      expect.objectContaining({ kind: 'sticky-note', text: 'Updated note' }),
+    );
+  });
+
+  it('deletes sticky-note when text is empty', () => {
+    const expr = makeStickyNote('s1', 100, 100, 'Will be deleted');
+    useCanvasStore.setState({ expressions: { s1: expr }, expressionOrder: ['s1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('s1'); });
+    act(() => { getState().commitEdit(''); });
+
+    expect(useCanvasStore.getState().expressions['s1']).toBeUndefined();
+  });
+
+  it('preserves sticky-note color when updating text', () => {
+    const expr = makeStickyNote('s1', 100, 100, 'Old');
+    useCanvasStore.setState({ expressions: { s1: expr }, expressionOrder: ['s1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('s1'); });
+    act(() => { getState().commitEdit('New'); });
+
+    expect(useCanvasStore.getState().expressions['s1'].data).toEqual({
+      kind: 'sticky-note',
+      text: 'New',
+      color: '#FFEB3B',
+    });
+  });
+});
+
+describe('useInlineEditor — cancelEdit', () => {
+  beforeEach(() => { cleanup(); resetStore(); });
+  afterEach(() => { cleanup(); });
+
+  it('clears editing state without modifying expression', () => {
+    const expr = makeText('t1', 100, 100, 'Original');
+    useCanvasStore.setState({ expressions: { t1: expr }, expressionOrder: ['t1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().startEditing('t1'); });
+    expect(getState().editingId).toBe('t1');
+
+    act(() => { getState().cancelEdit(); });
+    expect(getState().editingId).toBeNull();
+    expect((useCanvasStore.getState().expressions['t1'].data as { text: string }).text).toBe('Original');
+  });
+
+  it('is a no-op when not editing', () => {
+    const { getState } = renderEditor();
+    act(() => { getState().cancelEdit(); });
+    expect(getState().editingId).toBeNull();
+  });
+});
+
+describe('useInlineEditor — commitEdit when not editing', () => {
+  beforeEach(() => { cleanup(); resetStore(); });
+  afterEach(() => { cleanup(); });
+
+  it('is a no-op when not editing', () => {
+    const expr = makeText('t1', 100, 100, 'Hello');
+    useCanvasStore.setState({ expressions: { t1: expr }, expressionOrder: ['t1'] });
+
+    const { getState } = renderEditor();
+    act(() => { getState().commitEdit('Should not change anything'); });
+
+    expect((useCanvasStore.getState().expressions['t1'].data as { text: string }).text).toBe('Hello');
+  });
+});
+
+describe('useInlineEditor — double-click event integration', () => {
+  beforeEach(() => { cleanup(); resetStore(); });
+  afterEach(() => { cleanup(); });
+
+  function fireDblClick(canvas: HTMLElement, offsetX: number, offsetY: number) {
+    const event = new MouseEvent('dblclick', { bubbles: true, clientX: offsetX, clientY: offsetY });
+    Object.defineProperty(event, 'offsetX', { value: offsetX });
+    Object.defineProperty(event, 'offsetY', { value: offsetY });
+    canvas.dispatchEvent(event);
+  }
+
+  it('starts editing when canvas receives dblclick on a text expression', () => {
+    const expr = makeText('t1', 100, 100, 'Dblclick me');
+    useCanvasStore.setState({
+      expressions: { t1: expr },
+      expressionOrder: ['t1'],
+      activeTool: 'select',
+    });
+
+    const { getState, getByTestId } = renderEditor();
+    const canvas = getByTestId('canvas');
+
+    act(() => { fireDblClick(canvas, 150, 150); });
+    expect(getState().editingId).toBe('t1');
+  });
+
+  it('starts editing when canvas receives dblclick on a rectangle', () => {
+    const expr = makeRect('r1', 100, 100, 'Box Label');
+    useCanvasStore.setState({
+      expressions: { r1: expr },
+      expressionOrder: ['r1'],
+      activeTool: 'select',
+    });
+
+    const { getState, getByTestId } = renderEditor();
+    const canvas = getByTestId('canvas');
+
+    act(() => { fireDblClick(canvas, 150, 150); });
+    expect(getState().editingId).toBe('r1');
+  });
+
+  it('does not start editing on dblclick when tool is not select', () => {
+    const expr = makeText('t1', 100, 100, 'Text');
+    useCanvasStore.setState({
+      expressions: { t1: expr },
+      expressionOrder: ['t1'],
+      activeTool: 'rectangle',
+    });
+
+    const { getState, getByTestId } = renderEditor();
+    const canvas = getByTestId('canvas');
+
+    act(() => { fireDblClick(canvas, 150, 150); });
+    expect(getState().editingId).toBeNull();
+  });
+
+  it('does not start editing on dblclick on empty space', () => {
+    const expr = makeText('t1', 500, 500, 'Far away');
+    useCanvasStore.setState({
+      expressions: { t1: expr },
+      expressionOrder: ['t1'],
+      activeTool: 'select',
+    });
+
+    const { getState, getByTestId } = renderEditor();
+    const canvas = getByTestId('canvas');
+
+    act(() => { fireDblClick(canvas, 10, 10); });
+    expect(getState().editingId).toBeNull();
+  });
+
+  it('does not start editing on dblclick on non-editable expression (line)', () => {
+    const expr = makeLine('l1');
+    useCanvasStore.setState({
+      expressions: { l1: expr },
+      expressionOrder: ['l1'],
+      activeTool: 'select',
+    });
+
+    const { getState, getByTestId } = renderEditor();
+    const canvas = getByTestId('canvas');
+
+    act(() => { fireDblClick(canvas, 50, 50); });
+    expect(getState().editingId).toBeNull();
+  });
+});

--- a/packages/engine/src/components/Canvas.tsx
+++ b/packages/engine/src/components/Canvas.tsx
@@ -18,6 +18,7 @@ import { useCanvasInteraction } from '../hooks/useCanvasInteraction.js';
 import { useSelectionInteraction } from '../hooks/useSelectionInteraction.js';
 import { useManipulationInteraction } from '../hooks/useManipulationInteraction.js';
 import { useDrawingInteraction } from '../hooks/useDrawingInteraction.js';
+import { useInlineEditor } from '../hooks/useInlineEditor.js';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts.js';
 import { useTouchGestures } from '../hooks/useTouchGestures.js';
 import { useMetadataTooltip, formatRelativeTime } from '../hooks/useMetadataTooltip.js';
@@ -25,6 +26,7 @@ import { useCanvasStore } from '../store/canvasStore.js';
 import { worldToScreen } from '../camera.js';
 import { createRenderLoop } from '../renderer/renderLoop.js';
 import type { RenderLoop } from '../renderer/renderLoop.js';
+import type { VisualExpression } from '@infinicanvas/protocol';
 
 /** Minimum canvas dimensions to prevent zero-size or negative canvas. */
 const MIN_WIDTH = 1;
@@ -40,6 +42,7 @@ function CanvasInner() {
   const { getMarquee } = useSelectionInteraction(canvasRef);
   const { cursor: manipulationCursor } = useManipulationInteraction(canvasRef);
   const { getDrawPreview, textTool, cancelDraw } = useDrawingInteraction(canvasRef);
+  const inlineEditor = useInlineEditor(canvasRef);
   useTouchGestures(canvasRef);
   const tooltip = useMetadataTooltip(canvasRef);
 
@@ -49,6 +52,11 @@ function CanvasInner() {
 
   // Check text tool input position on each render
   const textInputPos = textTool.getInputPosition();
+
+  // Inline editor: look up the expression being edited
+  const editingExpr = useCanvasStore((s) =>
+    inlineEditor.editingId ? s.expressions[inlineEditor.editingId] ?? null : null,
+  );
 
   // Manipulation cursor takes priority, then drawing crosshair/text, then canvas default
   let cursor = canvasCursor;
@@ -196,6 +204,20 @@ function CanvasInner() {
           }}
         />
       )}
+      {/* Inline edit overlay for double-click editing [#75, #79] */}
+      {editingExpr && (
+        <InlineEditOverlay
+          expression={editingExpr}
+          initialText={inlineEditor.getEditingText()}
+          camera={camera}
+          onCommit={(text) => {
+            inlineEditor.commitEdit(text);
+          }}
+          onCancel={() => {
+            inlineEditor.cancelEdit();
+          }}
+        />
+      )}
       {/* Keyboard shortcuts help panel */}
       {showShortcutsHelp && (
         <ShortcutsHelpPanel onClose={() => setShowShortcutsHelp(false)} />
@@ -296,6 +318,114 @@ function TextInputOverlay({ worldX, worldY, camera, onCommit, onCancel }: TextIn
         background: 'white',
         resize: 'both',
         zIndex: 10,
+      }}
+    />
+  );
+}
+
+// ── Inline Edit Overlay ────────────────────────────────────
+
+interface InlineEditOverlayProps {
+  expression: VisualExpression;
+  initialText: string;
+  camera: { x: number; y: number; zoom: number };
+  onCommit: (text: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Textarea overlay for inline editing of text, sticky-note text, and shape labels.
+ *
+ * Positioned at the expression's world coordinates. Sized to match the expression.
+ * Enter commits, ESC cancels, blur commits. Auto-focuses and selects text on mount.
+ *
+ * [#75, #79]
+ */
+function InlineEditOverlay({ expression, initialText, camera, onCommit, onCancel }: InlineEditOverlayProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const committedRef = useRef(false);
+
+  // Convert world position to screen position
+  const screenPos = worldToScreen(
+    expression.position.x,
+    expression.position.y,
+    camera,
+  );
+
+  // Scale expression dimensions to screen
+  const screenWidth = expression.size.width * camera.zoom;
+  const screenHeight = expression.size.height * camera.zoom;
+
+  // Determine font size based on expression kind
+  const isText = expression.kind === 'text';
+  const isStickyNote = expression.kind === 'sticky-note';
+  const data = expression.data as Record<string, unknown>;
+  const baseFontSize = isText && typeof data.fontSize === 'number'
+    ? data.fontSize
+    : isStickyNote ? 14 : 14;
+  const scaledFontSize = baseFontSize * camera.zoom;
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.focus();
+      textarea.select();
+    }
+  }, []);
+
+  const doCommit = () => {
+    if (committedRef.current) return;
+    committedRef.current = true;
+    onCommit(textareaRef.current?.value ?? '');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      doCommit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      committedRef.current = true; // Prevent blur from also committing
+      onCancel();
+    }
+  };
+
+  const handleBlur = () => {
+    doCommit();
+  };
+
+  return (
+    <textarea
+      ref={textareaRef}
+      data-testid="inline-edit-overlay"
+      defaultValue={initialText}
+      onKeyDown={handleKeyDown}
+      onBlur={handleBlur}
+      style={{
+        position: 'absolute',
+        left: `${screenPos.x}px`,
+        top: `${screenPos.y}px`,
+        width: `${Math.max(screenWidth, 100)}px`,
+        height: `${Math.max(screenHeight, 32)}px`,
+        padding: '4px 8px',
+        border: '2px solid #4A90D9',
+        borderRadius: '4px',
+        outline: 'none',
+        fontSize: `${scaledFontSize}px`,
+        fontFamily: isText && typeof data.fontFamily === 'string'
+          ? data.fontFamily
+          : 'sans-serif',
+        textAlign: (isText && typeof data.textAlign === 'string'
+          ? data.textAlign
+          : 'center') as React.CSSProperties['textAlign'],
+        background: isStickyNote && typeof data.color === 'string'
+          ? data.color
+          : 'white',
+        resize: 'none',
+        zIndex: 10,
+        boxSizing: 'border-box',
+        overflow: 'hidden',
+        lineHeight: 1.4,
       }}
     />
   );

--- a/packages/engine/src/hooks/useInlineEditor.ts
+++ b/packages/engine/src/hooks/useInlineEditor.ts
@@ -1,0 +1,221 @@
+/**
+ * Inline editor hook — double-click to edit text and shape labels.
+ *
+ * Listens for `dblclick` events on the canvas element. When a double-click
+ * lands on an editable expression (text, sticky-note, rectangle, ellipse,
+ * diamond), opens inline editing mode.
+ *
+ * Editable expression kinds and their editable fields:
+ * - `text` → `data.text` (delete expression if empty on save)
+ * - `sticky-note` → `data.text` (delete expression if empty on save)
+ * - `rectangle` → `data.label` (remove label if empty on save)
+ * - `ellipse` → `data.label` (remove label if empty on save)
+ * - `diamond` → `data.label` (remove label if empty on save)
+ *
+ * @module
+ */
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { useCanvasStore } from '../store/canvasStore.js';
+import { screenToWorld } from '../camera.js';
+import { findExpressionAtPoint } from '../interaction/selectionManager.js';
+
+/** Hit-test tolerance in screen pixels (matches useSelectionInteraction). */
+const HIT_TOLERANCE_PX = 5;
+
+/**
+ * Configuration for each editable expression kind.
+ *
+ * - `field`: which property of `data` holds the editable text
+ * - `deleteOnEmpty`: if true, the expression is deleted when text is empty;
+ *   if false, the field is set to `undefined` (label removed)
+ */
+interface EditableKindConfig {
+  field: 'text' | 'label';
+  deleteOnEmpty: boolean;
+}
+
+/** Exported for testing — which expression kinds support inline editing. */
+export const EDITABLE_KINDS: Record<string, EditableKindConfig> = {
+  'text': { field: 'text', deleteOnEmpty: true },
+  'sticky-note': { field: 'text', deleteOnEmpty: true },
+  'rectangle': { field: 'label', deleteOnEmpty: false },
+  'ellipse': { field: 'label', deleteOnEmpty: false },
+  'diamond': { field: 'label', deleteOnEmpty: false },
+};
+
+/** Public interface returned by the useInlineEditor hook. */
+export interface InlineEditorState {
+  /** ID of the expression currently being edited, or null. */
+  editingId: string | null;
+  /** Begin editing an expression by ID. No-op if kind is not editable or locked. */
+  startEditing: (id: string) => void;
+  /** Commit the current edit with the given text. Clears editing state. */
+  commitEdit: (newText: string) => void;
+  /** Cancel the current edit without modifying the expression. */
+  cancelEdit: () => void;
+  /** Get the current editable text for the expression being edited. */
+  getEditingText: () => string;
+}
+
+/**
+ * Hook for inline editing of text and shape labels via double-click.
+ *
+ * Attaches a `dblclick` event listener to the provided canvas ref.
+ * Only activates when the active tool is `select`.
+ */
+export function useInlineEditor(
+  canvasRef: React.RefObject<HTMLCanvasElement>,
+): InlineEditorState {
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  // Ref keeps editingId in sync for stable callbacks [CLEAN-CODE]
+  const editingIdRef = useRef<string | null>(null);
+  editingIdRef.current = editingId;
+
+  // ── Start editing ──────────────────────────────────────────
+
+  const startEditing = useCallback((id: string) => {
+    const state = useCanvasStore.getState();
+    const expression = state.expressions[id];
+
+    // Guard: expression must exist
+    if (!expression) return;
+
+    // Guard: expression must not be locked [S5-3]
+    if (expression.meta.locked) return;
+
+    // Guard: expression kind must be editable
+    if (!EDITABLE_KINDS[expression.kind]) return;
+
+    setEditingId(id);
+  }, []);
+
+  // ── Get current text for the editing expression ────────────
+
+  const getEditingText = useCallback((): string => {
+    const id = editingIdRef.current;
+    if (!id) return '';
+
+    const state = useCanvasStore.getState();
+    const expression = state.expressions[id];
+    if (!expression) return '';
+
+    const config = EDITABLE_KINDS[expression.kind];
+    if (!config) return '';
+
+    const data = expression.data as Record<string, unknown>;
+    const value = data[config.field];
+    return typeof value === 'string' ? value : '';
+  }, []);
+
+  // ── Commit edit ────────────────────────────────────────────
+
+  const commitEdit = useCallback((newText: string) => {
+    const id = editingIdRef.current;
+    if (!id) return;
+
+    const state = useCanvasStore.getState();
+    const expression = state.expressions[id];
+
+    if (!expression) {
+      setEditingId(null);
+      return;
+    }
+
+    const config = EDITABLE_KINDS[expression.kind];
+    if (!config) {
+      setEditingId(null);
+      return;
+    }
+
+    const trimmed = newText.trim();
+
+    if (!trimmed) {
+      // Empty text handling
+      if (config.deleteOnEmpty) {
+        // Text and sticky-note: delete the expression
+        state.deleteExpressions([id]);
+      } else {
+        // Shapes: remove the label (set to undefined)
+        const updatedData = { ...expression.data } as Record<string, unknown>;
+        delete updatedData[config.field];
+        state.updateExpression(id, {
+          data: updatedData as typeof expression.data,
+        });
+      }
+    } else {
+      // Non-empty text: update the field
+      const updatedData = {
+        ...expression.data,
+        [config.field]: trimmed,
+      };
+      state.updateExpression(id, {
+        data: updatedData as typeof expression.data,
+      });
+    }
+
+    setEditingId(null);
+  }, []);
+
+  // ── Cancel edit ────────────────────────────────────────────
+
+  const cancelEdit = useCallback(() => {
+    setEditingId(null);
+  }, []);
+
+  // ── Double-click listener ──────────────────────────────────
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const handleDblClick = (e: MouseEvent) => {
+      const state = useCanvasStore.getState();
+
+      // Only respond in select mode
+      if (state.activeTool !== 'select') return;
+
+      const { camera, expressions, expressionOrder } = state;
+      const worldTolerance = HIT_TOLERANCE_PX / camera.zoom;
+
+      // Convert screen position to world coordinates
+      const worldPoint = screenToWorld(e.offsetX, e.offsetY, camera);
+
+      // Find expression under cursor
+      const hitId = findExpressionAtPoint(
+        worldPoint,
+        expressions,
+        expressionOrder,
+        worldTolerance,
+      );
+
+      if (!hitId) return;
+
+      const expression = expressions[hitId];
+      if (!expression) return;
+
+      // Only start editing for editable kinds
+      if (!EDITABLE_KINDS[expression.kind]) return;
+
+      // Don't edit locked expressions
+      if (expression.meta.locked) return;
+
+      setEditingId(hitId);
+    };
+
+    canvas.addEventListener('dblclick', handleDblClick);
+
+    return () => {
+      canvas.removeEventListener('dblclick', handleDblClick);
+    };
+  }, [canvasRef]);
+
+  return {
+    editingId,
+    startEditing,
+    commitEdit,
+    cancelEdit,
+    getEditingText,
+  };
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -151,6 +151,8 @@ export type {
 } from './hooks/useKeyboardShortcuts.js';
 export { useSelectionInteraction } from './hooks/useSelectionInteraction.js';
 export type { SelectionInteraction, MarqueeRect } from './hooks/useSelectionInteraction.js';
+export { useInlineEditor, EDITABLE_KINDS } from './hooks/useInlineEditor.js';
+export type { InlineEditorState } from './hooks/useInlineEditor.js';
 export { useManipulationInteraction } from './hooks/useManipulationInteraction.js';
 export type { ManipulationInteraction } from './hooks/useManipulationInteraction.js';
 export { useDrawingInteraction } from './hooks/useDrawingInteraction.js';


### PR DESCRIPTION
Double-click text/sticky/shapes to edit inline. Enter commits, ESC cancels. Empty text deletes, empty label removes. 33 tests. Closes #75, closes #79