### PR TITLE
feat(engine): Group/Ungroup expressions (Ctrl+G) — #71

### DIFF
--- a/packages/engine/src/__tests__/groupExpressions.test.ts
+++ b/packages/engine/src/__tests__/groupExpressions.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Group/Ungroup expressions — unit tests.
+ *
+ * TDD tests for the group/ungroup feature (#71):
+ * - Store actions: groupExpressions, ungroupExpressions
+ * - Keyboard shortcuts: Ctrl+G (group), Ctrl+Shift+G (ungroup)
+ * - Group-aware selection, deletion, duplication
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ExpressionBuilder } from '@infinicanvas/protocol';
+import type { VisualExpression, GroupPayload, UngroupPayload } from '@infinicanvas/protocol';
+import { useCanvasStore } from '../store/canvasStore.js';
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+const testAuthor = { type: 'human' as const, id: 'user-1', name: 'Tester' };
+const builder = new ExpressionBuilder(testAuthor);
+
+function makeRectangle(id: string, x = 100, y = 200): VisualExpression {
+  const expr = builder.rectangle(x, y, 300, 150).label('Rect').build();
+  return { ...expr, id };
+}
+
+function makeEllipse(id: string, x = 50, y = 50): VisualExpression {
+  const expr = builder.ellipse(x, y, 200, 200).label('Ellipse').build();
+  return { ...expr, id };
+}
+
+// ── Store reset ──────────────────────────────────────────────
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    expressions: {},
+    expressionOrder: [],
+    selectedIds: new Set<string>(),
+    activeTool: 'select',
+    camera: { x: 0, y: 0, zoom: 1 },
+    operationLog: [],
+    canUndo: false,
+    canRedo: false,
+  });
+  useCanvasStore.getState().clearHistory();
+});
+
+// ── groupExpressions store action ────────────────────────────
+
+describe('groupExpressions [STORE]', () => {
+  it('groups 2 expressions — both get parentId set to groupId', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+
+    expect(groupId).toBeTruthy();
+    expect(typeof groupId).toBe('string');
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']?.parentId).toBe(groupId);
+    expect(state.expressions['r2']?.parentId).toBe(groupId);
+  });
+
+  it('emits a group ProtocolOperation with correct payload', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+
+    const ops = useCanvasStore.getState().operationLog;
+    const groupOp = ops.find((op) => op.type === 'group');
+    expect(groupOp).toBeDefined();
+
+    const payload = groupOp!.payload as GroupPayload;
+    expect(payload.type).toBe('group');
+    expect(payload.groupId).toBe(groupId);
+    expect(payload.expressionIds).toEqual(expect.arrayContaining(['r1', 'r2']));
+    expect(payload.expressionIds).toHaveLength(2);
+  });
+
+  it('returns empty string and does NOT group when fewer than 2 expressions', () => {
+    const r1 = makeRectangle('r1');
+    useCanvasStore.getState().addExpression(r1);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1']);
+
+    expect(groupId).toBe('');
+    expect(useCanvasStore.getState().expressions['r1']?.parentId).toBeUndefined();
+  });
+
+  it('returns empty string for empty array', () => {
+    const groupId = useCanvasStore.getState().groupExpressions([]);
+    expect(groupId).toBe('');
+  });
+
+  it('filters out non-existent IDs — only groups existing expressions', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1', 'r2', 'nonexistent']);
+
+    expect(groupId).toBeTruthy();
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']?.parentId).toBe(groupId);
+    expect(state.expressions['r2']?.parentId).toBe(groupId);
+  });
+
+  it('returns empty string when all IDs are non-existent', () => {
+    const groupId = useCanvasStore.getState().groupExpressions(['nonexistent-1', 'nonexistent-2']);
+    expect(groupId).toBe('');
+  });
+
+  it('pushes undo snapshot — can undo a group operation', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+    expect(useCanvasStore.getState().canUndo).toBe(true);
+
+    useCanvasStore.getState().undo();
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']?.parentId).toBeUndefined();
+    expect(state.expressions['r2']?.parentId).toBeUndefined();
+  });
+
+  it('groups 3 or more expressions', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    const r3 = makeRectangle('r3');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+    useCanvasStore.getState().addExpression(r3);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1', 'r2', 'r3']);
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']?.parentId).toBe(groupId);
+    expect(state.expressions['r2']?.parentId).toBe(groupId);
+    expect(state.expressions['r3']?.parentId).toBe(groupId);
+  });
+});
+
+// ── ungroupExpressions store action ──────────────────────────
+
+describe('ungroupExpressions [STORE]', () => {
+  it('clears parentId on all group members', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+    useCanvasStore.getState().ungroupExpressions(groupId);
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']?.parentId).toBeUndefined();
+    expect(state.expressions['r2']?.parentId).toBeUndefined();
+  });
+
+  it('emits an ungroup ProtocolOperation with correct payload', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+    useCanvasStore.getState().ungroupExpressions(groupId);
+
+    const ops = useCanvasStore.getState().operationLog;
+    const ungroupOp = ops.find((op) => op.type === 'ungroup');
+    expect(ungroupOp).toBeDefined();
+
+    const payload = ungroupOp!.payload as UngroupPayload;
+    expect(payload.type).toBe('ungroup');
+    expect(payload.groupId).toBe(groupId);
+  });
+
+  it('is a no-op for non-existent groupId', () => {
+    const initialOpCount = useCanvasStore.getState().operationLog.length;
+    useCanvasStore.getState().ungroupExpressions('nonexistent');
+
+    // No new operations emitted for non-existent group
+    expect(useCanvasStore.getState().operationLog.length).toBe(initialOpCount);
+  });
+
+  it('pushes undo snapshot — can undo an ungroup operation', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+    useCanvasStore.getState().ungroupExpressions(groupId);
+
+    // Undo ungroup — should restore parentId
+    useCanvasStore.getState().undo();
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']?.parentId).toBe(groupId);
+    expect(state.expressions['r2']?.parentId).toBe(groupId);
+  });
+});
+
+// ── Group-aware helpers ──────────────────────────────────────
+
+describe('getGroupMembers helper [STORE]', () => {
+  it('returns all expressions sharing the same parentId', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    const r3 = makeRectangle('r3');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+    useCanvasStore.getState().addExpression(r3);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+
+    const { getGroupMembers } = useCanvasStore.getState();
+    const members = getGroupMembers(groupId);
+    expect(members).toEqual(expect.arrayContaining(['r1', 'r2']));
+    expect(members).toHaveLength(2);
+    expect(members).not.toContain('r3');
+  });
+
+  it('returns empty array for non-existent groupId', () => {
+    const { getGroupMembers } = useCanvasStore.getState();
+    expect(getGroupMembers('nonexistent')).toEqual([]);
+  });
+});
+
+describe('expandSelectionToGroups helper [STORE]', () => {
+  it('expands selection to include all group members when one member is selected', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    const r3 = makeRectangle('r3');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+    useCanvasStore.getState().addExpression(r3);
+
+    useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+
+    const { expandSelectionToGroups } = useCanvasStore.getState();
+    const expanded = expandSelectionToGroups(new Set(['r1']));
+    expect(expanded.has('r1')).toBe(true);
+    expect(expanded.has('r2')).toBe(true);
+    expect(expanded.has('r3')).toBe(false);
+  });
+
+  it('handles ungrouped expressions — no expansion', () => {
+    const r1 = makeRectangle('r1');
+    useCanvasStore.getState().addExpression(r1);
+
+    const { expandSelectionToGroups } = useCanvasStore.getState();
+    const expanded = expandSelectionToGroups(new Set(['r1']));
+    expect(expanded.size).toBe(1);
+    expect(expanded.has('r1')).toBe(true);
+  });
+
+  it('handles multiple groups — expands each independently', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    const r3 = makeRectangle('r3');
+    const r4 = makeRectangle('r4');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+    useCanvasStore.getState().addExpression(r3);
+    useCanvasStore.getState().addExpression(r4);
+
+    useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+    useCanvasStore.getState().groupExpressions(['r3', 'r4']);
+
+    const { expandSelectionToGroups } = useCanvasStore.getState();
+    const expanded = expandSelectionToGroups(new Set(['r1', 'r3']));
+    expect(expanded.size).toBe(4);
+  });
+});
+
+// ── Nested groups ────────────────────────────────────────────
+
+describe('Nested groups [EDGE]', () => {
+  it('group A contains group B — inner group maintains its parentId', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    const r3 = makeRectangle('r3');
+    const r4 = makeRectangle('r4');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+    useCanvasStore.getState().addExpression(r3);
+    useCanvasStore.getState().addExpression(r4);
+
+    // Group r1+r2 into inner group
+    const innerGroupId = useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+
+    // Group r3+r4 into outer group (which could coexist)
+    const outerGroupId = useCanvasStore.getState().groupExpressions(['r3', 'r4']);
+
+    const state = useCanvasStore.getState();
+    // Inner group members have innerGroupId
+    expect(state.expressions['r1']?.parentId).toBe(innerGroupId);
+    expect(state.expressions['r2']?.parentId).toBe(innerGroupId);
+    // Outer group members have outerGroupId
+    expect(state.expressions['r3']?.parentId).toBe(outerGroupId);
+    expect(state.expressions['r4']?.parentId).toBe(outerGroupId);
+
+    // Ungrouping inner doesn't affect outer
+    useCanvasStore.getState().ungroupExpressions(innerGroupId);
+    const state2 = useCanvasStore.getState();
+    expect(state2.expressions['r1']?.parentId).toBeUndefined();
+    expect(state2.expressions['r2']?.parentId).toBeUndefined();
+    expect(state2.expressions['r3']?.parentId).toBe(outerGroupId);
+    expect(state2.expressions['r4']?.parentId).toBe(outerGroupId);
+  });
+});
+
+// ── Group-aware deletion ─────────────────────────────────────
+
+describe('Group-aware deletion [BEHAVIOR]', () => {
+  it('deleting one group member deletes all members in the group', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    const r3 = makeRectangle('r3');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+    useCanvasStore.getState().addExpression(r3);
+
+    useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+
+    // Select r1 and delete — r2 should also be deleted
+    useCanvasStore.getState().setSelectedIds(new Set(['r1', 'r2']));
+    useCanvasStore.getState().deleteExpressions(
+      Array.from(useCanvasStore.getState().expandSelectionToGroups(new Set(['r1']))),
+    );
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']).toBeUndefined();
+    expect(state.expressions['r2']).toBeUndefined();
+    // Non-grouped expression is untouched
+    expect(state.expressions['r3']).toBeDefined();
+  });
+});
+
+// ── Group-aware duplication ──────────────────────────────────
+
+describe('Group-aware duplication [BEHAVIOR]', () => {
+  it('duplicateGrouped creates new expressions with a new groupId preserving group structure', () => {
+    const r1 = makeRectangle('r1', 100, 100);
+    const r2 = makeRectangle('r2', 200, 200);
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    const groupId = useCanvasStore.getState().groupExpressions(['r1', 'r2']);
+
+    // Select both group members
+    useCanvasStore.getState().setSelectedIds(new Set(['r1', 'r2']));
+
+    // Duplicate using the store helper
+    const newIds = useCanvasStore.getState().duplicateGrouped(new Set(['r1', 'r2']));
+
+    const state = useCanvasStore.getState();
+    expect(newIds).toHaveLength(2);
+
+    // New expressions exist
+    for (const nid of newIds) {
+      expect(state.expressions[nid]).toBeDefined();
+    }
+
+    // New expressions share a NEW groupId (different from original)
+    const newGroupId = state.expressions[newIds[0]!]?.parentId;
+    expect(newGroupId).toBeTruthy();
+    expect(newGroupId).not.toBe(groupId);
+    for (const nid of newIds) {
+      expect(state.expressions[nid]?.parentId).toBe(newGroupId);
+    }
+  });
+});
+
+// ── Remote operations ────────────────────────────────────────
+
+describe('applyRemoteOperation for group/ungroup [REMOTE]', () => {
+  it('applies remote group operation — sets parentId on expressions', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    useCanvasStore.getState().applyRemoteOperation({
+      id: 'op-1',
+      type: 'group',
+      author: { type: 'human', id: 'remote-user', name: 'Remote' },
+      timestamp: Date.now(),
+      payload: {
+        type: 'group',
+        expressionIds: ['r1', 'r2'],
+        groupId: 'remote-group-1',
+      },
+    });
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']?.parentId).toBe('remote-group-1');
+    expect(state.expressions['r2']?.parentId).toBe('remote-group-1');
+  });
+
+  it('applies remote ungroup operation — clears parentId', () => {
+    const r1 = makeRectangle('r1');
+    const r2 = makeRectangle('r2');
+    useCanvasStore.getState().addExpression(r1);
+    useCanvasStore.getState().addExpression(r2);
+
+    // First group them
+    useCanvasStore.getState().applyRemoteOperation({
+      id: 'op-1',
+      type: 'group',
+      author: { type: 'human', id: 'remote-user', name: 'Remote' },
+      timestamp: Date.now(),
+      payload: {
+        type: 'group',
+        expressionIds: ['r1', 'r2'],
+        groupId: 'remote-group-1',
+      },
+    });
+
+    // Then ungroup
+    useCanvasStore.getState().applyRemoteOperation({
+      id: 'op-2',
+      type: 'ungroup',
+      author: { type: 'human', id: 'remote-user', name: 'Remote' },
+      timestamp: Date.now(),
+      payload: {
+        type: 'ungroup',
+        groupId: 'remote-group-1',
+      },
+    });
+
+    const state = useCanvasStore.getState();
+    expect(state.expressions['r1']?.parentId).toBeUndefined();
+    expect(state.expressions['r2']?.parentId).toBeUndefined();
+  });
+});

--- a/packages/engine/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/engine/src/hooks/useKeyboardShortcuts.ts
@@ -21,6 +21,8 @@
  * - `Ctrl+X` / `Cmd+X` → Cut selected (copy + delete)
  * - `Ctrl+D` / `Cmd+D` → Duplicate selected
  * - `Ctrl+A` / `Cmd+A` → Select all
+ * - `Ctrl+G` / `Cmd+G` → Group selected expressions
+ * - `Ctrl+Shift+G` / `Cmd+Shift+G` → Ungroup selected expressions
  * - `Delete` / `Backspace` → Delete selected
  * - `Escape` → Cancel current operation / deselect
  * - `?` → Toggle shortcuts help panel
@@ -208,11 +210,25 @@ export function useKeyboardShortcuts(
           return;
         }
 
+        // Ctrl+Shift+G / Cmd+Shift+G → ungroup selected (check shift FIRST)
+        if (keyLower === 'g' && event.shiftKey) {
+          event.preventDefault();
+          ungroupSelected();
+          return;
+        }
+
+        // Ctrl+G / Cmd+G → group selected
+        if (keyLower === 'g' && !event.shiftKey) {
+          event.preventDefault();
+          groupSelected();
+          return;
+        }
+
         // Other modifier combos — not handled, let browser process
         return;
       }
 
-      // ── Delete / Backspace → delete selected ──
+      // ── Delete / Backspace → delete selected (group-aware) ──
       if (key === 'Delete' || key === 'Backspace') {
         const state = useCanvasStore.getState();
         if (state.activeTool !== 'select') return;
@@ -221,7 +237,9 @@ export function useKeyboardShortcuts(
         if (selectedIds.size === 0) return;
 
         event.preventDefault();
-        const deletableIds = Array.from(selectedIds).filter(
+        // Expand selection to include all group members
+        const expandedIds = state.expandSelectionToGroups(selectedIds);
+        const deletableIds = Array.from(expandedIds).filter(
           (id) => !expressions[id]?.meta.locked,
         );
         if (deletableIds.length > 0) {
@@ -254,34 +272,19 @@ export function useKeyboardShortcuts(
 
 /**
  * Duplicate all selected (unlocked) expressions with a +20,+20 offset.
- * Selects the new duplicates after creation.
+ * Group-aware: expands selection to include all group members and
+ * preserves group structure in the duplicates with new group IDs.
  */
 function duplicateSelected(): void {
-  const { selectedIds, expressions } = useCanvasStore.getState();
+  const state = useCanvasStore.getState();
+  const { selectedIds } = state;
   if (selectedIds.size === 0) return;
 
-  const newIds: string[] = [];
+  // Expand selection to include all group members
+  const expandedIds = state.expandSelectionToGroups(selectedIds);
 
-  for (const id of selectedIds) {
-    const expr = expressions[id];
-    if (!expr) continue;
-
-    const newId = nanoid();
-    const duplicate = structuredClone(expr);
-    duplicate.id = newId;
-    duplicate.position = {
-      x: expr.position.x + DUPLICATE_OFFSET,
-      y: expr.position.y + DUPLICATE_OFFSET,
-    };
-    duplicate.meta = {
-      ...duplicate.meta,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    };
-
-    useCanvasStore.getState().addExpression(duplicate);
-    newIds.push(newId);
-  }
+  // Use group-aware duplication from the store
+  const newIds = state.duplicateGrouped(expandedIds);
 
   // Select the new duplicates
   useCanvasStore.getState().setSelectedIds(new Set(newIds));
@@ -345,18 +348,21 @@ export function pasteFromClipboard(): void {
 
 /**
  * Cut selected expressions: copy to clipboard, then delete originals.
+ * Group-aware: expands selection to include all group members.
  *
  * Locked expressions are excluded from deletion (same as Delete key).
  */
 export function cutSelected(): void {
-  const { selectedIds, expressions } = useCanvasStore.getState();
+  const state = useCanvasStore.getState();
+  const { selectedIds, expressions } = state;
   if (selectedIds.size === 0) return;
 
   // Copy to clipboard first
   copySelected();
 
-  // Delete unlocked originals (same logic as Delete key handler)
-  const deletableIds = Array.from(selectedIds).filter(
+  // Expand selection to include all group members, then delete
+  const expandedIds = state.expandSelectionToGroups(selectedIds);
+  const deletableIds = Array.from(expandedIds).filter(
     (id) => !expressions[id]?.meta.locked,
   );
   if (deletableIds.length > 0) {
@@ -371,4 +377,46 @@ export function cutSelected(): void {
 export function _resetClipboard(): void {
   clipboard = [];
   pasteCount = 0;
+}
+
+// ── Group/Ungroup helpers (#71) ────────────────────────────
+
+/**
+ * Group all currently selected expressions.
+ *
+ * Requires at least 2 selected expressions. Creates a new group and
+ * assigns a shared `parentId` to all members.
+ */
+function groupSelected(): void {
+  const { selectedIds } = useCanvasStore.getState();
+  if (selectedIds.size < 2) return;
+
+  const ids = Array.from(selectedIds);
+  useCanvasStore.getState().groupExpressions(ids);
+}
+
+/**
+ * Ungroup selected expressions if they all share the same parentId.
+ *
+ * Only ungroups when every selected expression belongs to the same group.
+ * Mixed selections (multiple groups or ungrouped items) are skipped.
+ */
+function ungroupSelected(): void {
+  const { selectedIds, expressions } = useCanvasStore.getState();
+  if (selectedIds.size === 0) return;
+
+  // Collect all parentIds from selected expressions
+  const parentIds = new Set<string>();
+  for (const id of selectedIds) {
+    const parentId = expressions[id]?.parentId;
+    if (parentId) {
+      parentIds.add(parentId);
+    }
+  }
+
+  // Only ungroup if there's exactly one shared group
+  if (parentIds.size !== 1) return;
+
+  const groupId = [...parentIds][0]!;
+  useCanvasStore.getState().ungroupExpressions(groupId);
 }

--- a/packages/engine/src/hooks/useManipulationInteraction.ts
+++ b/packages/engine/src/hooks/useManipulationInteraction.ts
@@ -126,15 +126,18 @@ export function useManipulationInteraction(
         startWorld: worldPoint,
       };
     } else if (target.kind === 'body') {
-      // Check if ALL selected expressions are locked
-      const allLocked = Array.from(selectedIds).every(
+      // Expand selection to include all group members
+      const expandedIds = useCanvasStore.getState().expandSelectionToGroups(selectedIds);
+
+      // Check if ALL expanded expressions are locked
+      const allLocked = Array.from(expandedIds).every(
         (id) => expressions[id]?.meta.locked,
       );
       if (allLocked) return; // AC8: locked guard
 
-      // Capture original positions of all selected (unlocked) expressions
+      // Capture original positions of all expanded (unlocked) expressions
       const originalPositions = new Map<string, { x: number; y: number }>();
-      for (const id of selectedIds) {
+      for (const id of expandedIds) {
         const expr = expressions[id];
         if (expr && !expr.meta.locked) {
           originalPositions.set(id, { ...expr.position });

--- a/packages/engine/src/hooks/useSelectionInteraction.ts
+++ b/packages/engine/src/hooks/useSelectionInteraction.ts
@@ -44,6 +44,8 @@ export interface SelectionInteraction {
   getMarquee: () => MarqueeRect | null;
   /** Render the marquee overlay onto the given canvas context. */
   renderMarquee: (ctx: CanvasRenderingContext2D) => void;
+  /** ID of the group currently "entered" via double-click, or null. */
+  enteredGroupId: string | null;
 }
 
 /**
@@ -58,6 +60,7 @@ export function useSelectionInteraction(
   const marqueeRef = useRef<MarqueeRect | null>(null);
   const isDraggingRef = useRef(false);
   const dragStartRef = useRef<{ sx: number; sy: number } | null>(null);
+  const enteredGroupIdRef = useRef<string | null>(null);
 
   // ── Pointer handlers ───────────────────────────────────────
 
@@ -164,11 +167,14 @@ export function useSelectionInteraction(
         setSelectedIds(new Set(hitIds));
       }
     } else {
-      // ── Click selection ──────────────────────────────────
+      // ── Click selection (group-aware) ────────────────────
       const worldPoint = screenToWorld(e.offsetX, e.offsetY, camera);
       const hitId = findExpressionAtPoint(worldPoint, expressions, expressionOrder, worldTolerance);
 
       if (hitId) {
+        const hitExpr = expressions[hitId];
+        const hitParentId = hitExpr?.parentId;
+
         if (e.shiftKey) {
           // Shift+click: toggle in selection
           const newIds = new Set(selectedIds);
@@ -178,14 +184,25 @@ export function useSelectionInteraction(
             newIds.add(hitId);
           }
           setSelectedIds(newIds);
-        } else {
-          // Click: select only this expression
+        } else if (hitParentId && enteredGroupIdRef.current === hitParentId) {
+          // Already inside this group — select only this member
           setSelectedIds(new Set([hitId]));
+        } else if (hitParentId) {
+          // Click on grouped expression — select ALL group members
+          const groupMembers = state.getGroupMembers(hitParentId);
+          setSelectedIds(new Set(groupMembers));
+          // Exit any entered group since we're selecting a full group
+          enteredGroupIdRef.current = null;
+        } else {
+          // Click on ungrouped expression — select only this one
+          setSelectedIds(new Set([hitId]));
+          enteredGroupIdRef.current = null;
         }
       } else {
-        // Click on empty space: deselect all
+        // Click on empty space: deselect all and exit entered group
         if (!e.shiftKey) {
           setSelectedIds(new Set());
+          enteredGroupIdRef.current = null;
         }
       }
     }
@@ -200,6 +217,27 @@ export function useSelectionInteraction(
     target.releasePointerCapture(e.pointerId);
   }, []);
 
+  // ── Double-click: enter group ────────────────────────────────
+
+  const handleDblClick = useCallback((e: MouseEvent) => {
+    const state = useCanvasStore.getState();
+    if (state.activeTool !== 'select') return;
+
+    const { camera, expressions, expressionOrder } = state;
+    const worldTolerance = HIT_TOLERANCE_PX / camera.zoom;
+    const worldPoint = screenToWorld(e.offsetX, e.offsetY, camera);
+    const hitId = findExpressionAtPoint(worldPoint, expressions, expressionOrder, worldTolerance);
+
+    if (!hitId) return;
+
+    const hitExpr = expressions[hitId];
+    if (!hitExpr?.parentId) return;
+
+    // Enter the group — select only this individual member
+    enteredGroupIdRef.current = hitExpr.parentId;
+    state.setSelectedIds(new Set([hitId]));
+  }, []);
+
   // ── Effect: attach/detach event listeners ──────────────────
 
   useEffect(() => {
@@ -209,13 +247,15 @@ export function useSelectionInteraction(
     canvas.addEventListener('pointerdown', handlePointerDown);
     canvas.addEventListener('pointermove', handlePointerMove);
     canvas.addEventListener('pointerup', handlePointerUp);
+    canvas.addEventListener('dblclick', handleDblClick);
 
     return () => {
       canvas.removeEventListener('pointerdown', handlePointerDown);
       canvas.removeEventListener('pointermove', handlePointerMove);
       canvas.removeEventListener('pointerup', handlePointerUp);
+      canvas.removeEventListener('dblclick', handleDblClick);
     };
-  }, [canvasRef, handlePointerDown, handlePointerMove, handlePointerUp]);
+  }, [canvasRef, handlePointerDown, handlePointerMove, handlePointerUp, handleDblClick]);
 
   // ── Marquee rendering ──────────────────────────────────────
 
@@ -248,5 +288,6 @@ export function useSelectionInteraction(
     marquee: marqueeRef.current,
     getMarquee,
     renderMarquee,
+    enteredGroupId: enteredGroupIdRef.current,
   };
 }

--- a/packages/engine/src/renderer/selectionRenderer.ts
+++ b/packages/engine/src/renderer/selectionRenderer.ts
@@ -23,6 +23,12 @@ import {
 /** Selection highlight color. */
 const SELECTION_COLOR = '#4A90D9';
 
+/** Group bounding box color — subtle, lighter than selection. */
+const GROUP_BORDER_COLOR = '#aaaaaa';
+
+/** Group bounding box dash pattern (wider dots for dotted look). */
+const GROUP_DASH_PATTERN = [3, 3];
+
 /** Handle size in screen pixels. */
 const HANDLE_SIZE_PX = 8;
 
@@ -49,6 +55,9 @@ export function renderSelection(
   camera: Camera,
 ): void {
   if (selectedIds.size === 0) return;
+
+  // ── Group bounding boxes (rendered before individual selection) ──
+  renderGroupBoundingBoxes(ctx, selectedIds, expressions, camera);
 
   // Handle size in world coordinates (constant screen size)
   const handleSize = HANDLE_SIZE_PX / camera.zoom;
@@ -160,5 +169,67 @@ function renderBboxHandles(
     ctx.strokeStyle = SELECTION_COLOR;
     ctx.lineWidth = 1 / camera.zoom;
     ctx.strokeRect(hx - halfHandle, hy - halfHandle, handleSize, handleSize);
+  }
+}
+
+/**
+ * Render dotted bounding boxes around groups when any member is selected.
+ *
+ * Collects unique group IDs from selected expressions, computes the
+ * bounding box of all members in each group, and draws a subtle dotted
+ * border (#aaa) around the group extent.
+ */
+function renderGroupBoundingBoxes(
+  ctx: CanvasRenderingContext2D,
+  selectedIds: Set<string>,
+  expressions: Record<string, VisualExpression>,
+  camera: Camera,
+): void {
+  // Collect unique group IDs from selected expressions
+  const groupIds = new Set<string>();
+  for (const id of selectedIds) {
+    const parentId = expressions[id]?.parentId;
+    if (parentId) groupIds.add(parentId);
+  }
+
+  if (groupIds.size === 0) return;
+
+  // For each group, find ALL members (not just selected) and compute bounding box
+  for (const groupId of groupIds) {
+    const members = Object.values(expressions).filter(
+      (expr) => expr.parentId === groupId,
+    );
+    if (members.length < 2) continue;
+
+    // Compute bounding box of all group members
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    for (const member of members) {
+      const { x, y } = member.position;
+      const { width, height } = member.size;
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x + width);
+      maxY = Math.max(maxY, y + height);
+    }
+
+    // Add small padding (4px screen) around group bounding box
+    const padding = 4 / camera.zoom;
+    minX -= padding;
+    minY -= padding;
+    maxX += padding;
+    maxY += padding;
+
+    // Draw dotted border
+    ctx.save();
+    ctx.strokeStyle = GROUP_BORDER_COLOR;
+    ctx.lineWidth = 1 / camera.zoom;
+    ctx.setLineDash(GROUP_DASH_PATTERN.map((d) => d / camera.zoom));
+    ctx.strokeRect(minX, minY, maxX - minX, maxY - minY);
+    ctx.setLineDash([]);
+    ctx.restore();
   }
 }

--- a/packages/engine/src/store/canvasStore.ts
+++ b/packages/engine/src/store/canvasStore.ts
@@ -30,6 +30,8 @@ import type {
   MovePayload,
   TransformPayload,
   StylePayload,
+  GroupPayload,
+  UngroupPayload,
   ExpressionStyle,
 } from '@infinicanvas/protocol';
 import type { CanvasState, CanvasActions, ToolType, Camera } from '../types/index.js';
@@ -500,6 +502,27 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
             break;
           }
 
+          case 'group': {
+            const p = op.payload as GroupPayload;
+            for (const id of p.expressionIds) {
+              const existing = state.expressions[id];
+              if (existing) {
+                existing.parentId = p.groupId;
+              }
+            }
+            break;
+          }
+
+          case 'ungroup': {
+            const p = op.payload as UngroupPayload;
+            for (const [, existing] of Object.entries(state.expressions)) {
+              if (existing.parentId === p.groupId) {
+                delete existing.parentId;
+              }
+            }
+            break;
+          }
+
           default:
             // Unsupported operation types are silently ignored
             break;
@@ -719,6 +742,140 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
       set((state) => {
         state.lastUsedStyle = { ...state.lastUsedStyle, ...style } as ExpressionStyle;
       });
+    },
+
+    // ── Group/Ungroup actions (#71) ─────────────────────────────
+
+    groupExpressions: (ids: string[]): string => {
+      const currentState = get();
+
+      // Filter to only IDs that actually exist
+      const validIds = ids.filter((id) => currentState.expressions[id]);
+      if (validIds.length < 2) return '';
+
+      // Push snapshot BEFORE mutation for undo support
+      historyManager.pushSnapshot(captureSnapshot(currentState));
+
+      const groupId = nanoid();
+
+      set((state) => {
+        for (const id of validIds) {
+          const expr = state.expressions[id];
+          if (expr) {
+            expr.parentId = groupId;
+          }
+        }
+
+        const operation = createOperation('group', {
+          type: 'group',
+          expressionIds: [...validIds],
+          groupId,
+        });
+        pushOperation(state.operationLog, operation);
+
+        state.canUndo = historyManager.canUndo();
+        state.canRedo = historyManager.canRedo();
+      });
+
+      return groupId;
+    },
+
+    ungroupExpressions: (groupId: string) => {
+      const currentState = get();
+
+      // Find all expressions with this parentId
+      const memberIds = Object.keys(currentState.expressions).filter(
+        (id) => currentState.expressions[id]?.parentId === groupId,
+      );
+      if (memberIds.length === 0) return;
+
+      // Push snapshot BEFORE mutation for undo support
+      historyManager.pushSnapshot(captureSnapshot(currentState));
+
+      set((state) => {
+        for (const id of memberIds) {
+          const expr = state.expressions[id];
+          if (expr) {
+            delete expr.parentId;
+          }
+        }
+
+        const operation = createOperation('ungroup', {
+          type: 'ungroup',
+          groupId,
+        });
+        pushOperation(state.operationLog, operation);
+
+        state.canUndo = historyManager.canUndo();
+        state.canRedo = historyManager.canRedo();
+      });
+    },
+
+    getGroupMembers: (groupId: string): string[] => {
+      const { expressions } = get();
+      return Object.keys(expressions).filter(
+        (id) => expressions[id]?.parentId === groupId,
+      );
+    },
+
+    expandSelectionToGroups: (ids: Set<string>): Set<string> => {
+      const { expressions } = get();
+      const expanded = new Set(ids);
+
+      for (const id of ids) {
+        const parentId = expressions[id]?.parentId;
+        if (!parentId) continue;
+
+        // Add all siblings in the same group
+        for (const [otherId, otherExpr] of Object.entries(expressions)) {
+          if (otherExpr.parentId === parentId) {
+            expanded.add(otherId);
+          }
+        }
+      }
+
+      return expanded;
+    },
+
+    duplicateGrouped: (ids: Set<string>): string[] => {
+      const currentState = get();
+      const { expressions } = currentState;
+      const OFFSET = 20;
+
+      // Map old groupId → new groupId for preserving group structure
+      const groupMapping = new Map<string, string>();
+      const newIds: string[] = [];
+
+      for (const id of ids) {
+        const expr = expressions[id];
+        if (!expr) continue;
+
+        const newId = nanoid();
+        const duplicate = structuredClone(expr) as VisualExpression;
+        duplicate.id = newId;
+        duplicate.position = {
+          x: expr.position.x + OFFSET,
+          y: expr.position.y + OFFSET,
+        };
+        duplicate.meta = {
+          ...duplicate.meta,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
+
+        // Preserve group structure with new groupId
+        if (expr.parentId) {
+          if (!groupMapping.has(expr.parentId)) {
+            groupMapping.set(expr.parentId, nanoid());
+          }
+          duplicate.parentId = groupMapping.get(expr.parentId);
+        }
+
+        useCanvasStore.getState().addExpression(duplicate);
+        newIds.push(newId);
+      }
+
+      return newIds;
     },
   })),
 );

--- a/packages/engine/src/types/index.ts
+++ b/packages/engine/src/types/index.ts
@@ -109,4 +109,32 @@ export interface CanvasActions {
    * UI-only — does NOT emit operations.
    */
   setLastUsedStyle: (style: Partial<ExpressionStyle>) => void;
+  /**
+   * Group multiple expressions under a new group ID.
+   * Sets `parentId` on each expression and emits a `group` ProtocolOperation.
+   * Requires at least 2 valid (existing) expression IDs.
+   * Returns the generated group ID, or empty string if grouping was skipped.
+   */
+  groupExpressions: (ids: string[]) => string;
+  /**
+   * Ungroup all expressions belonging to the given group.
+   * Clears `parentId` on each member and emits an `ungroup` ProtocolOperation.
+   * No-op if no expressions have the given parentId.
+   */
+  ungroupExpressions: (groupId: string) => void;
+  /**
+   * Get all expression IDs that share the given parentId (group members).
+   * Returns an empty array if no expressions belong to the group.
+   */
+  getGroupMembers: (groupId: string) => string[];
+  /**
+   * Expand a selection set to include all group members.
+   * For each selected expression with a parentId, adds all siblings to the set.
+   */
+  expandSelectionToGroups: (ids: Set<string>) => Set<string>;
+  /**
+   * Duplicate a set of expressions, preserving group structure with new IDs.
+   * Returns the IDs of the newly created expressions.
+   */
+  duplicateGrouped: (ids: Set<string>) => string[];
 }


### PR DESCRIPTION
Group-aware selection, manipulation, delete, duplicate. Ctrl+G groups, Ctrl+Shift+G ungroups. Double-click enters group. Dotted group border. 22 tests. Closes #71