### PR TITLE
feat(engine,protocol): Connectable arrows — snap to shapes, follow on move

### DIFF
--- a/packages/engine/src/__tests__/connectorBindings.test.ts
+++ b/packages/engine/src/__tests__/connectorBindings.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Unit tests for arrow connector bindings.
+ *
+ * Tests the ArrowTool snap/bind behavior, canvasStore bound arrow
+ * updates on move/transform/delete, and binding data integrity.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCanvasStore } from '../store/canvasStore.js';
+import { ArrowTool } from '../tools/ArrowTool.js';
+import type { VisualExpression, ArrowData } from '@infinicanvas/protocol';
+import { DEFAULT_EXPRESSION_STYLE } from '@infinicanvas/protocol';
+
+// ── Test helpers ───────────────────────────────────────────
+
+function stubPointerEvent(overrides: Partial<PointerEvent> = {}): PointerEvent {
+  return { pressure: 0.5, ...overrides } as PointerEvent;
+}
+
+function resetStore() {
+  useCanvasStore.setState({
+    expressions: {},
+    expressionOrder: [],
+    selectedIds: new Set<string>(),
+    activeTool: 'select',
+    camera: { x: 0, y: 0, zoom: 1 },
+    operationLog: [],
+    canUndo: false,
+    canRedo: false,
+  });
+  useCanvasStore.getState().clearHistory();
+}
+
+function makeRectExpression(
+  id: string,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): VisualExpression {
+  const now = Date.now();
+  return {
+    id,
+    kind: 'rectangle',
+    position: { x, y },
+    size: { width: w, height: h },
+    angle: 0,
+    style: { ...DEFAULT_EXPRESSION_STYLE },
+    meta: {
+      author: { type: 'human', id: 'test', name: 'Test' },
+      createdAt: now,
+      updatedAt: now,
+      tags: [],
+      locked: false,
+    },
+    data: { kind: 'rectangle', label: 'Test' },
+  };
+}
+
+function makeEllipseExpression(
+  id: string,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): VisualExpression {
+  const now = Date.now();
+  return {
+    id,
+    kind: 'ellipse',
+    position: { x, y },
+    size: { width: w, height: h },
+    angle: 0,
+    style: { ...DEFAULT_EXPRESSION_STYLE },
+    meta: {
+      author: { type: 'human', id: 'test', name: 'Test' },
+      createdAt: now,
+      updatedAt: now,
+      tags: [],
+      locked: false,
+    },
+    data: { kind: 'ellipse', label: 'Test' },
+  };
+}
+
+function getExpressionById(id: string): VisualExpression | undefined {
+  return useCanvasStore.getState().expressions[id];
+}
+
+function getAllArrows(): VisualExpression[] {
+  const { expressions } = useCanvasStore.getState();
+  return Object.values(expressions).filter((e) => e.kind === 'arrow');
+}
+
+function getArrowData(expr: VisualExpression): ArrowData {
+  return expr.data as ArrowData;
+}
+
+// ── ArrowTool binding tests ──────────────────────────────────
+
+describe('ArrowTool — snap binding', () => {
+  let tool: ArrowTool;
+
+  beforeEach(() => {
+    resetStore();
+    tool = new ArrowTool();
+  });
+
+  it('creates a binding when arrow starts on a shape edge', () => {
+    // Add a rectangle at (100, 100) size (200, 100)
+    // Right edge center: (300, 150)
+    const rect = makeRectExpression('rect1', 100, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    // Draw arrow starting at right edge of rect → far away
+    tool.onPointerDown(300, 150, stubPointerEvent());
+    tool.onPointerMove(500, 300, stubPointerEvent());
+    tool.onPointerUp(500, 300, stubPointerEvent());
+
+    const arrows = getAllArrows();
+    expect(arrows.length).toBe(1);
+    const data = getArrowData(arrows[0]!);
+    expect(data.startBinding).toBeDefined();
+    expect(data.startBinding!.expressionId).toBe('rect1');
+    expect(data.startBinding!.anchor).toBe('right');
+  });
+
+  it('creates a binding when arrow ends on a shape edge', () => {
+    const rect = makeRectExpression('rect1', 400, 100, 200, 100);
+    // Left edge center: (400, 150)
+    useCanvasStore.getState().addExpression(rect);
+
+    // Draw arrow from far away → ending at left edge of rect
+    tool.onPointerDown(100, 150, stubPointerEvent());
+    tool.onPointerMove(400, 150, stubPointerEvent());
+    tool.onPointerUp(400, 150, stubPointerEvent());
+
+    const arrows = getAllArrows();
+    expect(arrows.length).toBe(1);
+    const data = getArrowData(arrows[0]!);
+    expect(data.endBinding).toBeDefined();
+    expect(data.endBinding!.expressionId).toBe('rect1');
+    expect(data.endBinding!.anchor).toBe('left');
+  });
+
+  it('creates bindings on both ends when drawing between two shapes', () => {
+    const rect1 = makeRectExpression('rect1', 100, 100, 200, 100);
+    const rect2 = makeRectExpression('rect2', 500, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect1);
+    useCanvasStore.getState().addExpression(rect2);
+
+    // Draw from right edge of rect1 (300, 150) to left edge of rect2 (500, 150)
+    tool.onPointerDown(300, 150, stubPointerEvent());
+    tool.onPointerMove(500, 150, stubPointerEvent());
+    tool.onPointerUp(500, 150, stubPointerEvent());
+
+    const arrows = getAllArrows();
+    expect(arrows.length).toBe(1);
+    const data = getArrowData(arrows[0]!);
+    expect(data.startBinding).toBeDefined();
+    expect(data.startBinding!.expressionId).toBe('rect1');
+    expect(data.endBinding).toBeDefined();
+    expect(data.endBinding!.expressionId).toBe('rect2');
+  });
+
+  it('does not create binding when arrow start is far from any shape', () => {
+    const rect = makeRectExpression('rect1', 100, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    // Draw arrow far from any shape
+    tool.onPointerDown(500, 500, stubPointerEvent());
+    tool.onPointerMove(700, 700, stubPointerEvent());
+    tool.onPointerUp(700, 700, stubPointerEvent());
+
+    const arrows = getAllArrows();
+    expect(arrows.length).toBe(1);
+    const data = getArrowData(arrows[0]!);
+    expect(data.startBinding).toBeUndefined();
+    expect(data.endBinding).toBeUndefined();
+  });
+
+  it('snaps start point to the anchor position when binding', () => {
+    const rect = makeRectExpression('rect1', 100, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    // Start near right edge but not exactly on it: (295, 155)
+    // Right edge center is (300, 150)
+    tool.onPointerDown(295, 155, stubPointerEvent());
+    tool.onPointerMove(600, 400, stubPointerEvent());
+    tool.onPointerUp(600, 400, stubPointerEvent());
+
+    const arrows = getAllArrows();
+    const data = getArrowData(arrows[0]!);
+    expect(data.startBinding).toBeDefined();
+    // The start point should be snapped to the anchor position
+    expect(data.points[0]).toEqual([300, 150]);
+  });
+
+  it('snaps end point to the anchor position when binding', () => {
+    const rect = makeRectExpression('rect1', 400, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    // End near left edge but not exactly: (405, 155)
+    // Left edge center is (400, 150)
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(405, 155, stubPointerEvent());
+    tool.onPointerUp(405, 155, stubPointerEvent());
+
+    const arrows = getAllArrows();
+    const data = getArrowData(arrows[0]!);
+    expect(data.endBinding).toBeDefined();
+    // The end point should be snapped to the anchor position
+    expect(data.points[data.points.length - 1]).toEqual([400, 150]);
+  });
+
+  it('does not bind arrow to itself', () => {
+    // This test verifies that binding only targets shapes, not arrows
+    // Arrows are non-bindable by kind check
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(200, 200, stubPointerEvent());
+    tool.onPointerUp(200, 200, stubPointerEvent());
+
+    const arrows = getAllArrows();
+    expect(arrows.length).toBe(1);
+    const data = getArrowData(arrows[0]!);
+    expect(data.startBinding).toBeUndefined();
+    expect(data.endBinding).toBeUndefined();
+  });
+
+  it('preserves existing arrow behavior when no shapes are nearby', () => {
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(300, 200, stubPointerEvent());
+    tool.onPointerUp(300, 200, stubPointerEvent());
+
+    const arrows = getAllArrows();
+    expect(arrows.length).toBe(1);
+    const data = getArrowData(arrows[0]!);
+    expect(data.endArrowhead).toBe(true);
+    expect(data.startBinding).toBeUndefined();
+    expect(data.endBinding).toBeUndefined();
+    expect(data.points.length).toBe(2);
+  });
+
+  it('provides snap preview info during drawing', () => {
+    const rect = makeRectExpression('rect1', 400, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    // Move near left edge of rect (400, 150)
+    tool.onPointerMove(405, 155, stubPointerEvent());
+
+    const preview = tool.getPreview();
+    expect(preview).not.toBeNull();
+    // Preview should have snap info
+    expect(preview!.snapPoint).toBeDefined();
+    expect(preview!.snapPoint!.x).toBe(400);
+    expect(preview!.snapPoint!.y).toBe(150);
+    expect(preview!.snapTargetId).toBe('rect1');
+  });
+
+  it('clears snap preview when endpoint moves away from shape', () => {
+    const rect = makeRectExpression('rect1', 400, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    tool.onPointerDown(100, 100, stubPointerEvent());
+    tool.onPointerMove(405, 155, stubPointerEvent()); // near rect
+    tool.onPointerMove(250, 250, stubPointerEvent()); // far away
+
+    const preview = tool.getPreview();
+    expect(preview).not.toBeNull();
+    expect(preview!.snapPoint).toBeUndefined();
+    expect(preview!.snapTargetId).toBeUndefined();
+  });
+});
+
+// ── Canvas store — bound arrow updates ───────────────────────
+
+describe('canvasStore — bound arrow updates', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('updates arrow endpoint when bound shape is moved', () => {
+    // Setup: rect1 at (100,100) size (200,100), arrow bound to right edge (300, 150)
+    const rect = makeRectExpression('rect1', 100, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    const now = Date.now();
+    const arrow: VisualExpression = {
+      id: 'arrow1',
+      kind: 'arrow',
+      position: { x: 300, y: 150 },
+      size: { width: 200, height: 150 },
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: { type: 'human', id: 'test', name: 'Test' },
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: {
+        kind: 'arrow',
+        points: [[300, 150], [500, 300]] as [number, number][],
+        endArrowhead: true,
+        startBinding: { expressionId: 'rect1', anchor: 'right' as const },
+      },
+    };
+    useCanvasStore.getState().addExpression(arrow);
+
+    // Move rect1 by (50, 50) → new right edge center: (350, 200)
+    useCanvasStore.getState().moveExpressions([
+      { id: 'rect1', from: { x: 100, y: 100 }, to: { x: 150, y: 150 } },
+    ]);
+
+    const updatedArrow = getExpressionById('arrow1')!;
+    const data = getArrowData(updatedArrow);
+    // Start point should follow to new anchor position (350, 200)
+    expect(data.points[0]).toEqual([350, 200]);
+    // End point should remain unchanged
+    expect(data.points[1]).toEqual([500, 300]);
+  });
+
+  it('updates arrow both endpoints when both bound shapes move', () => {
+    const rect1 = makeRectExpression('rect1', 100, 100, 100, 100);
+    const rect2 = makeRectExpression('rect2', 400, 100, 100, 100);
+    useCanvasStore.getState().addExpression(rect1);
+    useCanvasStore.getState().addExpression(rect2);
+
+    const now = Date.now();
+    const arrow: VisualExpression = {
+      id: 'arrow1',
+      kind: 'arrow',
+      position: { x: 200, y: 150 },
+      size: { width: 200, height: 1 },
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: { type: 'human', id: 'test', name: 'Test' },
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: {
+        kind: 'arrow',
+        points: [[200, 150], [400, 150]] as [number, number][],
+        endArrowhead: true,
+        startBinding: { expressionId: 'rect1', anchor: 'right' as const },
+        endBinding: { expressionId: 'rect2', anchor: 'left' as const },
+      },
+    };
+    useCanvasStore.getState().addExpression(arrow);
+
+    // Move both rects down by 100
+    useCanvasStore.getState().moveExpressions([
+      { id: 'rect1', from: { x: 100, y: 100 }, to: { x: 100, y: 200 } },
+      { id: 'rect2', from: { x: 400, y: 100 }, to: { x: 400, y: 200 } },
+    ]);
+
+    const updatedArrow = getExpressionById('arrow1')!;
+    const data = getArrowData(updatedArrow);
+    // Start: right edge of rect1 at (100,200) size (100,100) → (200, 250)
+    expect(data.points[0]).toEqual([200, 250]);
+    // End: left edge of rect2 at (400,200) size (100,100) → (400, 250)
+    expect(data.points[1]).toEqual([400, 250]);
+  });
+
+  it('updates arrow endpoint when bound shape is resized', () => {
+    const rect = makeRectExpression('rect1', 100, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    const now = Date.now();
+    const arrow: VisualExpression = {
+      id: 'arrow1',
+      kind: 'arrow',
+      position: { x: 300, y: 150 },
+      size: { width: 200, height: 150 },
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: { type: 'human', id: 'test', name: 'Test' },
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: {
+        kind: 'arrow',
+        points: [[300, 150], [500, 300]] as [number, number][],
+        endArrowhead: true,
+        startBinding: { expressionId: 'rect1', anchor: 'right' as const },
+      },
+    };
+    useCanvasStore.getState().addExpression(arrow);
+
+    // Resize rect1: position stays same, width doubles to 400
+    useCanvasStore.getState().transformExpression(
+      'rect1',
+      { position: { x: 100, y: 100 }, size: { width: 200, height: 100 } },
+      { position: { x: 100, y: 100 }, size: { width: 400, height: 100 } },
+    );
+
+    const updatedArrow = getExpressionById('arrow1')!;
+    const data = getArrowData(updatedArrow);
+    // Right edge of resized rect: x(100) + width(400) = 500, cy = 150
+    expect(data.points[0]).toEqual([500, 150]);
+  });
+
+  it('clears binding when bound shape is deleted', () => {
+    const rect = makeRectExpression('rect1', 100, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    const now = Date.now();
+    const arrow: VisualExpression = {
+      id: 'arrow1',
+      kind: 'arrow',
+      position: { x: 300, y: 150 },
+      size: { width: 200, height: 150 },
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: { type: 'human', id: 'test', name: 'Test' },
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: {
+        kind: 'arrow',
+        points: [[300, 150], [500, 300]] as [number, number][],
+        endArrowhead: true,
+        startBinding: { expressionId: 'rect1', anchor: 'right' as const },
+      },
+    };
+    useCanvasStore.getState().addExpression(arrow);
+
+    // Delete rect1
+    useCanvasStore.getState().deleteExpressions(['rect1']);
+
+    const updatedArrow = getExpressionById('arrow1')!;
+    const data = getArrowData(updatedArrow);
+    // Binding should be cleared
+    expect(data.startBinding).toBeUndefined();
+    // Arrow still exists with its endpoint preserved
+    expect(data.points[0]).toEqual([300, 150]);
+    expect(data.points.length).toBe(2);
+  });
+
+  it('preserves arrow position when bound shape is deleted', () => {
+    const rect = makeRectExpression('rect1', 100, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    const now = Date.now();
+    const arrow: VisualExpression = {
+      id: 'arrow1',
+      kind: 'arrow',
+      position: { x: 200, y: 100 },
+      size: { width: 200, height: 200 },
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: { type: 'human', id: 'test', name: 'Test' },
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: {
+        kind: 'arrow',
+        points: [[200, 100], [400, 300]] as [number, number][],
+        endArrowhead: true,
+        startBinding: { expressionId: 'rect1', anchor: 'top' as const },
+        endBinding: { expressionId: 'rect1', anchor: 'bottom' as const },
+      },
+    };
+    useCanvasStore.getState().addExpression(arrow);
+
+    // Delete rect1 — arrow should survive
+    useCanvasStore.getState().deleteExpressions(['rect1']);
+
+    const updatedArrow = getExpressionById('arrow1');
+    expect(updatedArrow).toBeDefined();
+    const data = getArrowData(updatedArrow!);
+    expect(data.startBinding).toBeUndefined();
+    expect(data.endBinding).toBeUndefined();
+  });
+
+  it('does not update unbound arrows when a shape moves', () => {
+    const rect = makeRectExpression('rect1', 100, 100, 200, 100);
+    useCanvasStore.getState().addExpression(rect);
+
+    const now = Date.now();
+    // Free-standing arrow (no bindings)
+    const arrow: VisualExpression = {
+      id: 'arrow1',
+      kind: 'arrow',
+      position: { x: 0, y: 0 },
+      size: { width: 50, height: 50 },
+      angle: 0,
+      style: { ...DEFAULT_EXPRESSION_STYLE },
+      meta: {
+        author: { type: 'human', id: 'test', name: 'Test' },
+        createdAt: now,
+        updatedAt: now,
+        tags: [],
+        locked: false,
+      },
+      data: {
+        kind: 'arrow',
+        points: [[0, 0], [50, 50]] as [number, number][],
+        endArrowhead: true,
+      },
+    };
+    useCanvasStore.getState().addExpression(arrow);
+
+    // Move the rect
+    useCanvasStore.getState().moveExpressions([
+      { id: 'rect1', from: { x: 100, y: 100 }, to: { x: 200, y: 200 } },
+    ]);
+
+    // Arrow should be completely unchanged (its points don't move)
+    const updatedArrow = getExpressionById('arrow1')!;
+    const data = getArrowData(updatedArrow);
+    expect(data.points[0]).toEqual([0, 0]);
+    expect(data.points[1]).toEqual([50, 50]);
+  });
+});

--- a/packages/engine/src/__tests__/connectorHelpers.test.ts
+++ b/packages/engine/src/__tests__/connectorHelpers.test.ts
@@ -1,0 +1,459 @@
+/**
+ * Unit tests for connector helper functions.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Pure functions for snap detection, anchor calculation, and binding resolution.
+ *
+ * @module
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import { DEFAULT_EXPRESSION_STYLE } from '@infinicanvas/protocol';
+import {
+  findSnapPoint,
+  getAnchorPoint,
+  resolveBindings,
+} from '../interaction/connectorHelpers.js';
+
+// ── Test helpers ───────────────────────────────────────────
+
+/** Create a minimal VisualExpression for testing. */
+function makeExpression(
+  overrides: Partial<VisualExpression> & { id: string; kind: string },
+): VisualExpression {
+  return {
+    position: { x: 0, y: 0 },
+    size: { width: 100, height: 100 },
+    angle: 0,
+    style: { ...DEFAULT_EXPRESSION_STYLE },
+    meta: {
+      author: { type: 'human', id: 'test', name: 'Test' },
+      createdAt: 0,
+      updatedAt: 0,
+      tags: [],
+      locked: false,
+    },
+    data: { kind: 'rectangle' } as VisualExpression['data'],
+    ...overrides,
+  };
+}
+
+/** Create a rectangle expression at given position and size. */
+function makeRect(
+  id: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): VisualExpression {
+  return makeExpression({
+    id,
+    kind: 'rectangle',
+    position: { x, y },
+    size: { width, height },
+    data: { kind: 'rectangle', label: '' },
+  });
+}
+
+/** Create an ellipse expression at given position and size. */
+function makeEllipse(
+  id: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): VisualExpression {
+  return makeExpression({
+    id,
+    kind: 'ellipse',
+    position: { x, y },
+    size: { width, height },
+    data: { kind: 'ellipse', label: '' },
+  });
+}
+
+/** Create a diamond expression at given position and size. */
+function makeDiamond(
+  id: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): VisualExpression {
+  return makeExpression({
+    id,
+    kind: 'diamond',
+    position: { x, y },
+    size: { width, height },
+    data: { kind: 'diamond', label: '' },
+  });
+}
+
+/** Create an arrow expression with given points and optional bindings. */
+function makeArrow(
+  id: string,
+  points: [number, number][],
+  bindings?: {
+    startBinding?: { expressionId: string; anchor: string };
+    endBinding?: { expressionId: string; anchor: string };
+  },
+): VisualExpression {
+  const { position, size } = computeBoundingBox(points);
+  return makeExpression({
+    id,
+    kind: 'arrow',
+    position,
+    size,
+    data: {
+      kind: 'arrow',
+      points,
+      endArrowhead: true,
+      ...(bindings?.startBinding && {
+        startBinding: {
+          expressionId: bindings.startBinding.expressionId,
+          anchor: bindings.startBinding.anchor as 'top' | 'right' | 'bottom' | 'left' | 'center' | 'auto',
+        },
+      }),
+      ...(bindings?.endBinding && {
+        endBinding: {
+          expressionId: bindings.endBinding.expressionId,
+          anchor: bindings.endBinding.anchor as 'top' | 'right' | 'bottom' | 'left' | 'center' | 'auto',
+        },
+      }),
+    },
+  });
+}
+
+/** Compute bounding box from points (mirrors ArrowTool helper). */
+function computeBoundingBox(points: [number, number][]) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const [px, py] of points) {
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+    if (px > maxX) maxX = px;
+    if (py > maxY) maxY = py;
+  }
+  return {
+    position: { x: minX, y: minY },
+    size: { width: Math.max(maxX - minX, 1), height: Math.max(maxY - minY, 1) },
+  };
+}
+
+// ── findSnapPoint ────────────────────────────────────────────
+
+describe('findSnapPoint', () => {
+  it('returns snap point when world point is near a rectangle top edge', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+    // Point near top edge center (200, 100) — within 20px
+    const result = findSnapPoint({ x: 200, y: 90 }, rect, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor).toBe('top');
+    expect(result!.point.x).toBe(200); // center of top edge
+    expect(result!.point.y).toBe(100); // top edge y
+  });
+
+  it('returns snap point when near rectangle right edge', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+    // Point near right edge center (300, 150) — within 20px
+    const result = findSnapPoint({ x: 310, y: 150 }, rect, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor).toBe('right');
+    expect(result!.point.x).toBe(300); // right edge x
+    expect(result!.point.y).toBe(150); // center of right edge
+  });
+
+  it('returns snap point when near rectangle bottom edge', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+    // Point near bottom edge center (200, 200) — within 20px
+    const result = findSnapPoint({ x: 200, y: 215 }, rect, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor).toBe('bottom');
+    expect(result!.point.x).toBe(200);
+    expect(result!.point.y).toBe(200);
+  });
+
+  it('returns snap point when near rectangle left edge', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+    // Point near left edge center (100, 150)
+    const result = findSnapPoint({ x: 85, y: 150 }, rect, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor).toBe('left');
+    expect(result!.point.x).toBe(100);
+    expect(result!.point.y).toBe(150);
+  });
+
+  it('returns null when world point is far from any edge', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+    // Point far away
+    const result = findSnapPoint({ x: 500, y: 500 }, rect, 20);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when snap distance is 0', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+    // Even right on the edge, snap distance 0 means no snap
+    const result = findSnapPoint({ x: 200, y: 101 }, rect, 0);
+    expect(result).toBeNull();
+  });
+
+  it('snaps to nearest edge anchor when point is equidistant from edges', () => {
+    // Use a square shape where anchor points are equidistant from center
+    const rect = makeRect('r1', 100, 100, 100, 100);
+    // Point near top-right, close to right edge center (200, 150)
+    // Right anchor: (200, 150), distance from (210, 145): sqrt(100+25) ≈ 11.2
+    // Top anchor: (150, 100), distance from (210, 145): sqrt(3600+2025) ≈ 75
+    const result = findSnapPoint({ x: 210, y: 145 }, rect, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor).toBe('right');
+  });
+
+  it('returns snap point for ellipse at 0° (right)', () => {
+    const ellipse = makeEllipse('e1', 100, 100, 200, 100);
+    // Right edge of ellipse: center(200, 150) + rx(100, 0) = (300, 150)
+    const result = findSnapPoint({ x: 310, y: 150 }, ellipse, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor).toBe('right');
+    expect(result!.point.x).toBe(300);
+    expect(result!.point.y).toBe(150);
+  });
+
+  it('returns snap point for ellipse at 90° (bottom)', () => {
+    const ellipse = makeEllipse('e1', 100, 100, 200, 100);
+    // Bottom edge of ellipse: center(200, 150) + ry(0, 50) = (200, 200)
+    const result = findSnapPoint({ x: 200, y: 215 }, ellipse, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor).toBe('bottom');
+    expect(result!.point.x).toBe(200);
+    expect(result!.point.y).toBe(200);
+  });
+
+  it('returns snap point for diamond at top vertex', () => {
+    const diamond = makeDiamond('d1', 100, 100, 200, 100);
+    // Top vertex: (cx, y) = (200, 100)
+    const result = findSnapPoint({ x: 200, y: 85 }, diamond, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor).toBe('top');
+    expect(result!.point.x).toBe(200);
+    expect(result!.point.y).toBe(100);
+  });
+
+  it('returns snap point for diamond at right vertex', () => {
+    const diamond = makeDiamond('d1', 100, 100, 200, 100);
+    // Right vertex: (x + width, cy) = (300, 150)
+    const result = findSnapPoint({ x: 315, y: 150 }, diamond, 20);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor).toBe('right');
+    expect(result!.point.x).toBe(300);
+    expect(result!.point.y).toBe(150);
+  });
+
+  it('ignores non-shape kinds (arrow, line, freehand, text)', () => {
+    const arrow = makeArrow('a1', [[0, 0], [100, 100]]);
+    const result = findSnapPoint({ x: 50, y: 50 }, arrow, 20);
+    expect(result).toBeNull();
+  });
+});
+
+// ── getAnchorPoint ───────────────────────────────────────────
+
+describe('getAnchorPoint', () => {
+  describe('rectangle anchors', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+
+    it('returns top edge center for "top" anchor', () => {
+      const pt = getAnchorPoint(rect, 'top');
+      expect(pt.x).toBe(200); // x + width/2
+      expect(pt.y).toBe(100); // y
+    });
+
+    it('returns right edge center for "right" anchor', () => {
+      const pt = getAnchorPoint(rect, 'right');
+      expect(pt.x).toBe(300); // x + width
+      expect(pt.y).toBe(150); // y + height/2
+    });
+
+    it('returns bottom edge center for "bottom" anchor', () => {
+      const pt = getAnchorPoint(rect, 'bottom');
+      expect(pt.x).toBe(200); // x + width/2
+      expect(pt.y).toBe(200); // y + height
+    });
+
+    it('returns left edge center for "left" anchor', () => {
+      const pt = getAnchorPoint(rect, 'left');
+      expect(pt.x).toBe(100); // x
+      expect(pt.y).toBe(150); // y + height/2
+    });
+
+    it('returns bounding box center for "center" anchor', () => {
+      const pt = getAnchorPoint(rect, 'center');
+      expect(pt.x).toBe(200);
+      expect(pt.y).toBe(150);
+    });
+
+    it('returns bounding box center for "auto" anchor', () => {
+      const pt = getAnchorPoint(rect, 'auto');
+      expect(pt.x).toBe(200);
+      expect(pt.y).toBe(150);
+    });
+  });
+
+  describe('ellipse anchors', () => {
+    const ellipse = makeEllipse('e1', 100, 100, 200, 100);
+
+    it('returns top (90°) point for "top" anchor', () => {
+      const pt = getAnchorPoint(ellipse, 'top');
+      expect(pt.x).toBe(200); // cx
+      expect(pt.y).toBe(100); // cy - ry
+    });
+
+    it('returns right (0°) point for "right" anchor', () => {
+      const pt = getAnchorPoint(ellipse, 'right');
+      expect(pt.x).toBe(300); // cx + rx
+      expect(pt.y).toBe(150); // cy
+    });
+
+    it('returns bottom (270°) point for "bottom" anchor', () => {
+      const pt = getAnchorPoint(ellipse, 'bottom');
+      expect(pt.x).toBe(200); // cx
+      expect(pt.y).toBe(200); // cy + ry
+    });
+
+    it('returns left (180°) point for "left" anchor', () => {
+      const pt = getAnchorPoint(ellipse, 'left');
+      expect(pt.x).toBe(100); // cx - rx
+      expect(pt.y).toBe(150); // cy
+    });
+  });
+
+  describe('diamond anchors', () => {
+    const diamond = makeDiamond('d1', 100, 100, 200, 100);
+
+    it('returns top vertex for "top" anchor', () => {
+      const pt = getAnchorPoint(diamond, 'top');
+      expect(pt.x).toBe(200); // cx
+      expect(pt.y).toBe(100); // y (top vertex)
+    });
+
+    it('returns right vertex for "right" anchor', () => {
+      const pt = getAnchorPoint(diamond, 'right');
+      expect(pt.x).toBe(300); // x + width
+      expect(pt.y).toBe(150); // cy
+    });
+
+    it('returns bottom vertex for "bottom" anchor', () => {
+      const pt = getAnchorPoint(diamond, 'bottom');
+      expect(pt.x).toBe(200); // cx
+      expect(pt.y).toBe(200); // y + height
+    });
+
+    it('returns left vertex for "left" anchor', () => {
+      const pt = getAnchorPoint(diamond, 'left');
+      expect(pt.x).toBe(100); // x
+      expect(pt.y).toBe(150); // cy
+    });
+  });
+});
+
+// ── resolveBindings ──────────────────────────────────────────
+
+describe('resolveBindings', () => {
+  it('returns original points when arrow has no bindings', () => {
+    const arrow = makeArrow('a1', [[0, 0], [100, 100]]);
+    const expressions: Record<string, VisualExpression> = {
+      a1: arrow,
+    };
+
+    const resolved = resolveBindings(arrow, expressions);
+    expect(resolved).toEqual([[0, 0], [100, 100]]);
+  });
+
+  it('resolves start binding to target shape anchor point', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+    const arrow = makeArrow('a1', [[0, 0], [400, 400]], {
+      startBinding: { expressionId: 'r1', anchor: 'right' },
+    });
+    const expressions: Record<string, VisualExpression> = {
+      r1: rect,
+      a1: arrow,
+    };
+
+    const resolved = resolveBindings(arrow, expressions);
+    // Start point should resolve to right edge of rect (300, 150)
+    expect(resolved[0]).toEqual([300, 150]);
+    // End point unchanged
+    expect(resolved[resolved.length - 1]).toEqual([400, 400]);
+  });
+
+  it('resolves end binding to target shape anchor point', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+    const arrow = makeArrow('a1', [[0, 0], [400, 400]], {
+      endBinding: { expressionId: 'r1', anchor: 'top' },
+    });
+    const expressions: Record<string, VisualExpression> = {
+      r1: rect,
+      a1: arrow,
+    };
+
+    const resolved = resolveBindings(arrow, expressions);
+    // Start point unchanged
+    expect(resolved[0]).toEqual([0, 0]);
+    // End point should resolve to top edge of rect (200, 100)
+    expect(resolved[resolved.length - 1]).toEqual([200, 100]);
+  });
+
+  it('resolves both start and end bindings', () => {
+    const rect1 = makeRect('r1', 100, 100, 200, 100);
+    const rect2 = makeRect('r2', 500, 100, 200, 100);
+    const arrow = makeArrow('a1', [[0, 0], [400, 400]], {
+      startBinding: { expressionId: 'r1', anchor: 'right' },
+      endBinding: { expressionId: 'r2', anchor: 'left' },
+    });
+    const expressions: Record<string, VisualExpression> = {
+      r1: rect1,
+      r2: rect2,
+      a1: arrow,
+    };
+
+    const resolved = resolveBindings(arrow, expressions);
+    // Start → right edge of rect1 (300, 150)
+    expect(resolved[0]).toEqual([300, 150]);
+    // End → left edge of rect2 (500, 150)
+    expect(resolved[resolved.length - 1]).toEqual([500, 150]);
+  });
+
+  it('returns original points when bound expression does not exist', () => {
+    const arrow = makeArrow('a1', [[0, 0], [100, 100]], {
+      startBinding: { expressionId: 'nonexistent', anchor: 'top' },
+    });
+    const expressions: Record<string, VisualExpression> = {
+      a1: arrow,
+    };
+
+    const resolved = resolveBindings(arrow, expressions);
+    // Should fall back to original points
+    expect(resolved[0]).toEqual([0, 0]);
+  });
+
+  it('returns original points for non-arrow expressions', () => {
+    const rect = makeRect('r1', 100, 100, 200, 100);
+    const expressions: Record<string, VisualExpression> = {
+      r1: rect,
+    };
+
+    const resolved = resolveBindings(rect, expressions);
+    expect(resolved).toEqual([]);
+  });
+});

--- a/packages/engine/src/interaction/connectorHelpers.ts
+++ b/packages/engine/src/interaction/connectorHelpers.ts
@@ -1,0 +1,198 @@
+/**
+ * Connector helper functions for arrow bindings.
+ *
+ * Pure functions for snap detection, anchor point calculation,
+ * and binding resolution. Used by ArrowTool during drawing and
+ * by canvasStore when bound shapes move.
+ *
+ * @module
+ */
+
+import type { VisualExpression, ArrowData, ArrowBinding } from '@infinicanvas/protocol';
+
+/** Kinds that support snap/binding (shapes with meaningful edges). */
+const BINDABLE_KINDS = new Set(['rectangle', 'ellipse', 'diamond', 'sticky-note']);
+
+/**
+ * Find the nearest connection point on a shape's edge.
+ *
+ * Returns the closest anchor point and its world position if the
+ * given world point is within `snapDistance` of any edge anchor.
+ * Returns null if no anchor is close enough or the expression
+ * is not a bindable shape. [CLEAN-CODE]
+ */
+export function findSnapPoint(
+  worldPoint: { x: number; y: number },
+  targetExpression: VisualExpression,
+  snapDistance: number,
+): { point: { x: number; y: number }; anchor: string } | null {
+  if (snapDistance <= 0) return null;
+  if (!BINDABLE_KINDS.has(targetExpression.kind)) return null;
+
+  const anchors: Array<{ anchor: string; point: { x: number; y: number } }> =
+    getAnchorPoints(targetExpression);
+
+  let closest: { anchor: string; point: { x: number; y: number }; dist: number } | null = null;
+
+  for (const { anchor, point } of anchors) {
+    const dist = Math.hypot(worldPoint.x - point.x, worldPoint.y - point.y);
+    if (dist <= snapDistance && (closest === null || dist < closest.dist)) {
+      closest = { anchor, point, dist };
+    }
+  }
+
+  if (!closest) return null;
+  return { point: closest.point, anchor: closest.anchor };
+}
+
+/**
+ * Get the connection point for a specific anchor on a shape.
+ *
+ * Supports rectangle, ellipse, diamond, and sticky-note shapes.
+ * For 'center' and 'auto' anchors, returns the bounding box center.
+ * [CLEAN-CODE] [SRP]
+ */
+export function getAnchorPoint(
+  expression: VisualExpression,
+  anchor: string,
+): { x: number; y: number } {
+  const { x, y } = expression.position;
+  const { width, height } = expression.size;
+  const cx = x + width / 2;
+  const cy = y + height / 2;
+
+  if (anchor === 'center' || anchor === 'auto') {
+    return { x: cx, y: cy };
+  }
+
+  // All bindable shapes share the same anchor positions
+  // (edge center for rect/sticky-note, cardinal points for ellipse,
+  //  vertices for diamond) — which happen to be at the same coordinates.
+  switch (anchor) {
+    case 'top':
+      return { x: cx, y };
+    case 'right':
+      return { x: x + width, y: cy };
+    case 'bottom':
+      return { x: cx, y: y + height };
+    case 'left':
+      return { x, y: cy };
+    default:
+      return { x: cx, y: cy };
+  }
+}
+
+/**
+ * Recalculate arrow endpoints based on bindings.
+ *
+ * If the arrow has start/end bindings, replaces the first/last point
+ * with the resolved anchor position on the bound shape. Returns a new
+ * points array (does not mutate the original). [CLEAN-CODE] [SRP]
+ *
+ * Returns an empty array for non-arrow expressions.
+ */
+export function resolveBindings(
+  arrowExpr: VisualExpression,
+  expressions: Record<string, VisualExpression>,
+): [number, number][] {
+  if (arrowExpr.data.kind !== 'arrow') return [];
+
+  const arrowData = arrowExpr.data as ArrowData;
+  const points: [number, number][] = arrowData.points.map(
+    (p) => [p[0], p[1]] as [number, number],
+  );
+
+  if (points.length === 0) return points;
+
+  // Resolve start binding
+  if (arrowData.startBinding) {
+    const resolved = resolveBinding(arrowData.startBinding, expressions);
+    if (resolved) {
+      points[0] = [resolved.x, resolved.y];
+    }
+  }
+
+  // Resolve end binding
+  if (arrowData.endBinding) {
+    const resolved = resolveBinding(arrowData.endBinding, expressions);
+    if (resolved) {
+      points[points.length - 1] = [resolved.x, resolved.y];
+    }
+  }
+
+  return points;
+}
+
+/**
+ * Find all arrows bound to a given expression ID.
+ *
+ * Scans all expressions and returns IDs of arrows that have
+ * a startBinding or endBinding referencing the target ID.
+ * [CLEAN-CODE]
+ */
+export function findBoundArrows(
+  targetId: string,
+  expressions: Record<string, VisualExpression>,
+): string[] {
+  const result: string[] = [];
+  for (const [id, expr] of Object.entries(expressions)) {
+    if (expr.data.kind !== 'arrow') continue;
+    const data = expr.data as ArrowData;
+    if (
+      data.startBinding?.expressionId === targetId ||
+      data.endBinding?.expressionId === targetId
+    ) {
+      result.push(id);
+    }
+  }
+  return result;
+}
+
+/**
+ * Clear bindings that reference a deleted expression.
+ *
+ * Returns a new ArrowData with the referencing bindings removed,
+ * or undefined if no change is needed. [CLEAN-CODE]
+ */
+export function clearBindingsForDeletedExpression(
+  arrowData: ArrowData,
+  deletedId: string,
+): ArrowData | undefined {
+  let changed = false;
+  const updated = { ...arrowData };
+
+  if (arrowData.startBinding?.expressionId === deletedId) {
+    updated.startBinding = undefined;
+    changed = true;
+  }
+  if (arrowData.endBinding?.expressionId === deletedId) {
+    updated.endBinding = undefined;
+    changed = true;
+  }
+
+  return changed ? updated : undefined;
+}
+
+// ── Internal helpers ─────────────────────────────────────────
+
+/** Get all four anchor points for a bindable expression. */
+function getAnchorPoints(
+  expr: VisualExpression,
+): Array<{ anchor: string; point: { x: number; y: number } }> {
+  return [
+    { anchor: 'top', point: getAnchorPoint(expr, 'top') },
+    { anchor: 'right', point: getAnchorPoint(expr, 'right') },
+    { anchor: 'bottom', point: getAnchorPoint(expr, 'bottom') },
+    { anchor: 'left', point: getAnchorPoint(expr, 'left') },
+  ];
+}
+
+/** Resolve a single binding to a world coordinate. */
+function resolveBinding(
+  binding: ArrowBinding,
+  expressions: Record<string, VisualExpression>,
+): { x: number; y: number } | null {
+  const target = expressions[binding.expressionId];
+  if (!target) return null;
+  return getAnchorPoint(target, binding.anchor);
+}

--- a/packages/engine/src/renderer/primitiveRenderer.ts
+++ b/packages/engine/src/renderer/primitiveRenderer.ts
@@ -19,6 +19,7 @@ import { isVisible } from './viewportCulling.js';
 import { createDrawableCache } from './drawableCache.js';
 import type { DrawableCache } from './drawableCache.js';
 import { getCompositeRenderer } from './compositeRegistry.js';
+import { resolveBindings } from '../interaction/connectorHelpers.js';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -120,7 +121,7 @@ export function renderExpressions(
     ctx.save();
     ctx.globalAlpha = expr.style.opacity;
 
-    renderPrimitive(ctx, roughCanvas, expr);
+    renderPrimitive(ctx, roughCanvas, expr, expressions);
 
     ctx.restore();
   }
@@ -135,6 +136,7 @@ function renderPrimitive(
   ctx: CanvasRenderingContext2D,
   roughCanvas: RoughCanvas,
   expr: VisualExpression,
+  expressions: Record<string, VisualExpression>,
 ): void {
   const { kind } = expr;
 
@@ -152,7 +154,7 @@ function renderPrimitive(
       renderLine(ctx, roughCanvas, expr);
       break;
     case 'arrow':
-      renderArrow(ctx, roughCanvas, expr);
+      renderArrow(ctx, roughCanvas, expr, expressions);
       break;
     case 'freehand':
       renderFreehand(ctx, expr);
@@ -283,16 +285,21 @@ function renderLine(
   }
 }
 
-/** Render arrow with arrowheads. [AC6] */
+/** Render arrow with arrowheads and connector bindings. [AC6] */
 function renderArrow(
   ctx: CanvasRenderingContext2D,
   rc: RoughCanvas,
   expr: VisualExpression,
+  expressions: Record<string, VisualExpression>,
 ): void {
   if (expr.data.kind !== 'arrow') return;
-  const { points, startArrowhead, endArrowhead } = expr.data;
+  const { startArrowhead, endArrowhead } = expr.data;
   const options = mapStyleToRoughOptions(expr.style);
   const offset = computePositionOffset(expr);
+
+  // Resolve binding positions for connected arrows [CLEAN-CODE]
+  const points = resolveBindings(expr, expressions);
+  if (points.length < 2) return;
 
   if (offset.x !== 0 || offset.y !== 0) {
     ctx.save();

--- a/packages/engine/src/store/canvasStore.ts
+++ b/packages/engine/src/store/canvasStore.ts
@@ -41,6 +41,12 @@ import { invalidateLayoutCache as invalidateFlowchartCache } from '../renderer/c
 import { invalidateLayoutCache as invalidateSequenceCache } from '../renderer/composites/sequenceDiagramRenderer.js';
 import { invalidateLayoutCache as invalidateMindMapCache } from '../renderer/composites/mindMapRenderer.js';
 import { invalidateLayoutCache as invalidateReasoningCache } from '../renderer/composites/reasoningChainRenderer.js';
+import {
+  findBoundArrows,
+  getAnchorPoint,
+  clearBindingsForDeletedExpression,
+} from '../interaction/connectorHelpers.js';
+import type { ArrowData } from '@infinicanvas/protocol';
 
 // Enable immer support for Set/Map (used by selectedIds: Set<string>)
 enableMapSet();
@@ -139,6 +145,66 @@ function translateExpressionPoints(
     for (const point of points) {
       point[0] += dx;
       point[1] += dy;
+    }
+  }
+}
+
+/**
+ * Update all arrows bound to the given expression IDs.
+ *
+ * After moving or resizing a shape, finds all arrows that reference
+ * it via startBinding or endBinding and recalculates the bound
+ * endpoint to the current anchor position. [CLEAN-CODE]
+ */
+function updateBoundArrows(
+  state: CanvasState,
+  movedIds: Set<string>,
+): void {
+  for (const targetId of movedIds) {
+    const target = state.expressions[targetId];
+    if (!target) continue;
+
+    const arrowIds = findBoundArrows(targetId, state.expressions);
+    for (const arrowId of arrowIds) {
+      // Skip if the arrow itself was part of the move
+      if (movedIds.has(arrowId)) continue;
+
+      const arrow = state.expressions[arrowId];
+      if (!arrow || arrow.data.kind !== 'arrow') continue;
+
+      const data = arrow.data as ArrowData;
+      const points = data.points;
+      if (points.length === 0) continue;
+
+      let changed = false;
+
+      if (data.startBinding?.expressionId === targetId) {
+        const anchorPt = getAnchorPoint(target, data.startBinding.anchor);
+        points[0] = [anchorPt.x, anchorPt.y];
+        changed = true;
+      }
+
+      if (data.endBinding?.expressionId === targetId) {
+        const anchorPt = getAnchorPoint(target, data.endBinding.anchor);
+        points[points.length - 1] = [anchorPt.x, anchorPt.y];
+        changed = true;
+      }
+
+      // Update the arrow's bounding box to reflect new point positions
+      if (changed) {
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        for (const [px, py] of points) {
+          if (px < minX) minX = px;
+          if (py < minY) minY = py;
+          if (px > maxX) maxX = px;
+          if (py > maxY) maxY = py;
+        }
+        arrow.position = { x: minX, y: minY };
+        arrow.size = {
+          width: Math.max(maxX - minX, 1),
+          height: Math.max(maxY - minY, 1),
+        };
+      }
     }
   }
 }
@@ -300,6 +366,21 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
 
       set((state) => {
         const idSet = new Set(existingIds);
+
+        // Clear bindings in surviving arrows that reference deleted shapes [CLEAN-CODE]
+        for (const deletedId of existingIds) {
+          for (const [arrowId, expr] of Object.entries(state.expressions)) {
+            if (idSet.has(arrowId)) continue; // skip if this arrow is also being deleted
+            if (expr.data.kind !== 'arrow') continue;
+            const updated = clearBindingsForDeletedExpression(
+              expr.data as ArrowData,
+              deletedId,
+            );
+            if (updated) {
+              expr.data = updated;
+            }
+          }
+        }
 
         for (const id of existingIds) {
           delete state.expressions[id];
@@ -649,6 +730,10 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
           }
         }
 
+        // Update arrows bound to the moved shapes [CLEAN-CODE]
+        const movedIds = new Set(moves.map((m) => m.id));
+        updateBoundArrows(state, movedIds);
+
         for (const move of moves) {
           const operation = createOperation('move', {
             type: 'move',
@@ -687,6 +772,9 @@ export const useCanvasStore = create<CanvasState & CanvasActions>()(
 
         expr.position = { ...final.position };
         expr.size = { ...final.size };
+
+        // Update arrows bound to the resized shape [CLEAN-CODE]
+        updateBoundArrows(state, new Set([id]));
 
         const operation = createOperation('transform', {
           type: 'transform',

--- a/packages/engine/src/tools/ArrowTool.ts
+++ b/packages/engine/src/tools/ArrowTool.ts
@@ -1,19 +1,24 @@
 /**
- * Arrow drawing tool.
+ * Arrow drawing tool with connector binding support.
  *
- * Same as LineTool but creates arrows with endArrowhead: true.
+ * Creates arrows with endArrowhead: true. When drawing starts or ends
+ * near a shape edge, the arrow binds to that shape so it follows on move.
  * Minimum distance: 5px. Auto-switches to Select after creation.
  *
  * @module
  */
 
 import { nanoid } from 'nanoid';
-import type { VisualExpression } from '@infinicanvas/protocol';
+import type { VisualExpression, ArrowBinding } from '@infinicanvas/protocol';
 import type { ToolHandler, DrawPreview } from './BaseTool.js';
 import { useCanvasStore } from '../store/canvasStore.js';
+import { findSnapPoint } from '../interaction/connectorHelpers.js';
 
 /** Minimum arrow length in world units. */
 const MIN_ARROW_LENGTH = 5;
+
+/** Snap distance in world units for connector binding. */
+const SNAP_DISTANCE = 20;
 
 /** Human author for locally-drawn expressions. */
 const LOCAL_AUTHOR = {
@@ -29,6 +34,9 @@ export class ArrowTool implements ToolHandler {
   private startY = 0;
   private endX = 0;
   private endY = 0;
+  private startBinding: ArrowBinding | undefined = undefined;
+  private currentSnapPoint: { x: number; y: number } | undefined = undefined;
+  private currentSnapTargetId: string | undefined = undefined;
 
   onPointerDown(worldX: number, worldY: number, _event: PointerEvent): void {
     this.isDrawing = true;
@@ -36,12 +44,35 @@ export class ArrowTool implements ToolHandler {
     this.startY = worldY;
     this.endX = worldX;
     this.endY = worldY;
+
+    // Check for start binding [CLEAN-CODE]
+    const snap = this.findNearestSnap(worldX, worldY);
+    if (snap) {
+      this.startBinding = {
+        expressionId: snap.targetId,
+        anchor: snap.anchor as ArrowBinding['anchor'],
+      };
+      this.startX = snap.point.x;
+      this.startY = snap.point.y;
+    } else {
+      this.startBinding = undefined;
+    }
   }
 
   onPointerMove(worldX: number, worldY: number, _event: PointerEvent): void {
     if (!this.isDrawing) return;
     this.endX = worldX;
     this.endY = worldY;
+
+    // Check for end snap indicator [CLEAN-CODE]
+    const snap = this.findNearestSnap(worldX, worldY);
+    if (snap) {
+      this.currentSnapPoint = snap.point;
+      this.currentSnapTargetId = snap.targetId;
+    } else {
+      this.currentSnapPoint = undefined;
+      this.currentSnapTargetId = undefined;
+    }
   }
 
   onPointerUp(worldX: number, worldY: number, _event: PointerEvent): void {
@@ -50,6 +81,18 @@ export class ArrowTool implements ToolHandler {
     this.endX = worldX;
     this.endY = worldY;
     this.isDrawing = false;
+
+    // Check for end binding [CLEAN-CODE]
+    let endBinding: ArrowBinding | undefined;
+    const snap = this.findNearestSnap(worldX, worldY);
+    if (snap) {
+      endBinding = {
+        expressionId: snap.targetId,
+        anchor: snap.anchor as ArrowBinding['anchor'],
+      };
+      this.endX = snap.point.x;
+      this.endY = snap.point.y;
+    }
 
     const length = Math.hypot(this.endX - this.startX, this.endY - this.startY);
     if (length < MIN_ARROW_LENGTH) {
@@ -85,6 +128,8 @@ export class ArrowTool implements ToolHandler {
         points,
         startArrowhead: false,
         endArrowhead: true,
+        ...(this.startBinding && { startBinding: this.startBinding }),
+        ...(endBinding && { endBinding }),
       },
     };
 
@@ -118,6 +163,8 @@ export class ArrowTool implements ToolHandler {
       width: size.width,
       height: size.height,
       points,
+      snapPoint: this.currentSnapPoint,
+      snapTargetId: this.currentSnapTargetId,
     };
   }
 
@@ -126,10 +173,40 @@ export class ArrowTool implements ToolHandler {
     this.startY = 0;
     this.endX = 0;
     this.endY = 0;
+    this.startBinding = undefined;
+    this.currentSnapPoint = undefined;
+    this.currentSnapTargetId = undefined;
+  }
+
+  /**
+   * Find the nearest snap target among all canvas expressions.
+   *
+   * Iterates all expressions and returns the closest snap point
+   * within SNAP_DISTANCE, or null if none found. [SRP]
+   */
+  private findNearestSnap(
+    worldX: number,
+    worldY: number,
+  ): { point: { x: number; y: number }; anchor: string; targetId: string } | null {
+    const { expressions } = useCanvasStore.getState();
+    let best: { point: { x: number; y: number }; anchor: string; targetId: string; dist: number } | null = null;
+
+    for (const [id, expr] of Object.entries(expressions)) {
+      const snap = findSnapPoint({ x: worldX, y: worldY }, expr, SNAP_DISTANCE);
+      if (snap) {
+        const dist = Math.hypot(worldX - snap.point.x, worldY - snap.point.y);
+        if (!best || dist < best.dist) {
+          best = { point: snap.point, anchor: snap.anchor, targetId: id, dist };
+        }
+      }
+    }
+
+    return best ? { point: best.point, anchor: best.anchor, targetId: best.targetId } : null;
   }
 }
 
-/** Compute axis-aligned bounding box from a set of points. */
+/** Compute axis-aligned bounding box from a set of points.
+ * Ensures minimum size of 1 to satisfy Zod positive() constraint. */
 function computeBoundingBox(points: [number, number][]) {
   let minX = Infinity;
   let minY = Infinity;
@@ -145,6 +222,9 @@ function computeBoundingBox(points: [number, number][]) {
 
   return {
     position: { x: minX, y: minY },
-    size: { width: maxX - minX, height: maxY - minY },
+    size: {
+      width: Math.max(maxX - minX, 1),
+      height: Math.max(maxY - minY, 1),
+    },
   };
 }

--- a/packages/engine/src/tools/BaseTool.ts
+++ b/packages/engine/src/tools/BaseTool.ts
@@ -31,6 +31,10 @@ export interface DrawPreview {
   height: number;
   /** Points for line/arrow/freehand previews. */
   points?: [number, number][];
+  /** Snap point for connector preview (arrow tool). */
+  snapPoint?: { x: number; y: number };
+  /** ID of the shape being snapped to (arrow tool). */
+  snapTargetId?: string;
 }
 
 /**

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -17,6 +17,8 @@ export type {
   DiamondData,
   LineData,
   ArrowData,
+  ArrowBinding,
+  ArrowAnchor,
   FreehandData,
   TextData,
   StickyNoteData,

--- a/packages/protocol/src/schema/primitives.ts
+++ b/packages/protocol/src/schema/primitives.ts
@@ -31,6 +31,17 @@ export interface LineData {
   points: [number, number][];
 }
 
+/** Anchor position on a shape's edge for arrow binding. */
+export type ArrowAnchor = 'center' | 'top' | 'right' | 'bottom' | 'left' | 'auto';
+
+/** Binding that connects an arrow endpoint to a shape. */
+export interface ArrowBinding {
+  /** ID of the bound shape expression. */
+  expressionId: string;
+  /** Where on the shape the arrow attaches. */
+  anchor: ArrowAnchor;
+}
+
 /** Data for an arrow expression with optional arrowheads. */
 export interface ArrowData {
   kind: 'arrow';
@@ -40,6 +51,10 @@ export interface ArrowData {
   startArrowhead?: boolean;
   /** Whether to render an arrowhead at the end. */
   endArrowhead?: boolean;
+  /** Binding for the start endpoint to a shape. */
+  startBinding?: ArrowBinding;
+  /** Binding for the end endpoint to a shape. */
+  endBinding?: ArrowBinding;
 }
 
 /** Data for a freehand drawing expression. */

--- a/packages/protocol/src/validation/schemas.ts
+++ b/packages/protocol/src/validation/schemas.ts
@@ -107,11 +107,18 @@ export const lineDataSchema = z.object({
   points: z.array(point2dSchema).min(2),
 });
 
+const arrowBindingSchema = z.object({
+  expressionId: z.string().min(1),
+  anchor: z.enum(['center', 'top', 'right', 'bottom', 'left', 'auto']),
+});
+
 export const arrowDataSchema = z.object({
   kind: z.literal('arrow'),
   points: z.array(point2dSchema).min(2),
   startArrowhead: z.boolean().optional(),
   endArrowhead: z.boolean().optional(),
+  startBinding: arrowBindingSchema.optional(),
+  endBinding: arrowBindingSchema.optional(),
 });
 
 const point3dSchema = z.tuple([z.number(), z.number(), z.number()]);


### PR DESCRIPTION
Arrows snap to shape edges during drawing. Bound arrows follow when shapes move/resize. Bindings cleared on shape delete. 48 tests.