### PR TITLE
feat: draw.io export/import — MCP tools + UI (#91)

### DIFF
--- a/packages/app/src/__tests__/ExportMenu.test.tsx
+++ b/packages/app/src/__tests__/ExportMenu.test.tsx
@@ -10,8 +10,13 @@
  */
 
 import { render, cleanup, fireEvent } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
 import { ExportMenu } from '../components/panels/ExportMenu.js';
+
+beforeAll(() => {
+  globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+  globalThis.URL.revokeObjectURL = vi.fn();
+});
 
 describe('ExportMenu', () => {
   afterEach(() => {
@@ -32,7 +37,9 @@ describe('ExportMenu', () => {
     expect(container.querySelector('[data-action="export-png"]')).not.toBeNull();
     expect(container.querySelector('[data-action="export-svg"]')).not.toBeNull();
     expect(container.querySelector('[data-action="export-json"]')).not.toBeNull();
+    expect(container.querySelector('[data-action="export-drawio"]')).not.toBeNull();
     expect(container.querySelector('[data-action="import-json"]')).not.toBeNull();
+    expect(container.querySelector('[data-action="import-drawio"]')).not.toBeNull();
   });
 
   it('hides menu options by default', () => {
@@ -75,5 +82,48 @@ describe('ExportMenu', () => {
     fireEvent.click(jsonOption);
     // Menu should close after action
     expect(container.querySelector('[data-action="export-json"]')).toBeNull();
+  });
+
+  // ── draw.io export/import options ───────────────────────
+
+  it('renders Export draw.io option when menu is open', () => {
+    const { container } = render(<ExportMenu />);
+    fireEvent.click(container.querySelector('[aria-label="Export menu"]')!);
+    const drawioExport = container.querySelector('[data-action="export-drawio"]');
+    expect(drawioExport).not.toBeNull();
+    expect(drawioExport?.textContent).toContain('Export .drawio');
+  });
+
+  it('renders Import draw.io option when menu is open', () => {
+    const { container } = render(<ExportMenu />);
+    fireEvent.click(container.querySelector('[aria-label="Export menu"]')!);
+    const drawioImport = container.querySelector('[data-action="import-drawio"]');
+    expect(drawioImport).not.toBeNull();
+    expect(drawioImport?.textContent).toContain('Import .drawio');
+  });
+
+  it('has hidden file input for draw.io import accepting .drawio and .xml', () => {
+    const { container } = render(<ExportMenu />);
+    const drawioInput = container.querySelector('input[accept*=".drawio"]') as HTMLInputElement | null;
+    expect(drawioInput).not.toBeNull();
+    expect(drawioInput?.accept).toContain('.drawio');
+    expect(drawioInput?.accept).toContain('.xml');
+    expect(drawioInput?.style.display).toBe('none');
+  });
+
+  it('closes menu when Export draw.io is clicked', () => {
+    const { container } = render(<ExportMenu />);
+    fireEvent.click(container.querySelector('[aria-label="Export menu"]')!);
+    const drawioExport = container.querySelector('[data-action="export-drawio"]')!;
+    fireEvent.click(drawioExport);
+    expect(container.querySelector('[data-action="export-drawio"]')).toBeNull();
+  });
+
+  it('closes menu when Import draw.io is clicked', () => {
+    const { container } = render(<ExportMenu />);
+    fireEvent.click(container.querySelector('[aria-label="Export menu"]')!);
+    const drawioImport = container.querySelector('[data-action="import-drawio"]')!;
+    fireEvent.click(drawioImport);
+    expect(container.querySelector('[data-action="import-drawio"]')).toBeNull();
   });
 });

--- a/packages/app/src/components/panels/ExportMenu.tsx
+++ b/packages/app/src/components/panels/ExportMenu.tsx
@@ -1,8 +1,9 @@
 /**
  * ExportMenu — dropdown menu for export and import actions.
  *
- * Provides Export PNG, Export SVG, Export JSON, and Import JSON
- * options. Uses file input for JSON import with validation. [CLEAN-CODE]
+ * Provides Export PNG, Export SVG, Export JSON, Export .drawio,
+ * Import JSON, and Import .drawio options. Uses file inputs for
+ * JSON and draw.io import with validation. [CLEAN-CODE]
  *
  * @module
  */
@@ -10,6 +11,7 @@
 import { useState, useRef, useCallback } from 'react';
 import { useCanvasStore, useUiStore } from '@infinicanvas/engine';
 import { exportToJson, importFromJson, buildSvgString, downloadSvg, exportToPng } from '@infinicanvas/engine';
+import { expressionsToDrawio, drawioToExpressions } from '@infinicanvas/protocol';
 import { Download } from 'lucide-react';
 
 /** Menu option definition. */
@@ -23,6 +25,7 @@ interface MenuOption {
 export function ExportMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const drawioFileInputRef = useRef<HTMLInputElement>(null);
 
   const handleExportJson = useCallback(() => {
     const { expressions, expressionOrder } = useCanvasStore.getState();
@@ -79,6 +82,62 @@ export function ExportMenu() {
     setIsOpen(false);
   }, []);
 
+  const handleExportDrawio = useCallback(() => {
+    const { expressions, expressionOrder } = useCanvasStore.getState();
+    const expressionArray = expressionOrder
+      .map((id) => expressions[id])
+      .filter((e): e is NonNullable<typeof e> => e != null);
+    const xml = expressionsToDrawio(expressionArray);
+    const blob = new Blob([xml], { type: 'application/xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'infinicanvas-export.drawio';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    setIsOpen(false);
+  }, []);
+
+  const handleImportDrawio = useCallback(() => {
+    drawioFileInputRef.current?.click();
+    setIsOpen(false);
+  }, []);
+
+  const handleDrawioFileSelected = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const content = reader.result as string;
+      try {
+        const imported = drawioToExpressions(content);
+        if (imported.length === 0) {
+          alert('No drawable elements found in the draw.io file.');
+          return;
+        }
+        const store = useCanvasStore.getState();
+        const mergedExpressions = { ...store.expressions };
+        const mergedOrder = [...store.expressionOrder];
+        for (const expr of imported) {
+          mergedExpressions[expr.id] = expr;
+          mergedOrder.push(expr.id);
+        }
+        store.replaceState(Object.values(mergedExpressions), mergedOrder);
+      } catch (err) {
+        console.error('[ExportMenu] draw.io import failed:', err);
+        alert(`Import failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    };
+    reader.onerror = () => alert('Failed to read file.');
+    reader.readAsText(file);
+
+    // Reset input so same file can be re-imported
+    e.target.value = '';
+  }, []);
+
   const handleFileSelected = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -98,6 +157,7 @@ export function ExportMenu() {
         alert(`Import failed: ${result.error}`);
       }
     };
+    reader.onerror = () => alert('Failed to read file.');
     reader.readAsText(file);
 
     // Reset input so same file can be re-imported
@@ -108,7 +168,9 @@ export function ExportMenu() {
     { action: 'export-png', label: 'Export PNG', onClick: handleExportPng },
     { action: 'export-svg', label: 'Export SVG', onClick: handleExportSvg },
     { action: 'export-json', label: 'Export JSON', onClick: handleExportJson },
+    { action: 'export-drawio', label: 'Export .drawio', onClick: handleExportDrawio },
     { action: 'import-json', label: 'Import JSON', onClick: handleImportJson },
+    { action: 'import-drawio', label: 'Import .drawio', onClick: handleImportDrawio },
   ];
 
   return (
@@ -183,6 +245,16 @@ export function ExportMenu() {
         type="file"
         accept=".json,application/json"
         onChange={handleFileSelected}
+        style={{ display: 'none' }}
+        aria-hidden="true"
+      />
+
+      {/* Hidden file input for draw.io import */}
+      <input
+        ref={drawioFileInputRef}
+        type="file"
+        accept=".drawio,.xml,application/xml"
+        onChange={handleDrawioFileSelected}
         style={{ display: 'none' }}
         aria-hidden="true"
       />

--- a/packages/mcp-server/src/__tests__/drawioTools-qa.test.ts
+++ b/packages/mcp-server/src/__tests__/drawioTools-qa.test.ts
@@ -1,0 +1,730 @@
+/**
+ * QA Guardian — Integration, contract, and edge-case tests for draw.io tools.
+ *
+ * Tests the MCP tool layer (drawioTools.ts) at integration boundaries:
+ * round-trip fidelity, error handling, gateway interaction, and edge cases
+ * not covered by Developer unit tests.
+ *
+ * Does NOT duplicate protocol-level serializer tests (drawio.test.ts, drawio-qa.test.ts).
+ * Tests BEHAVIOR through the public interface, not implementation details.
+ *
+ * Ticket #91 — draw.io Export/Import
+ *
+ * @module
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import { drawioToExpressions } from '@infinicanvas/protocol';
+import type { IGatewayClient } from '../gatewayClient.js';
+import {
+  executeExportDrawio,
+  executeImportDrawio,
+} from '../tools/drawioTools.js';
+import { DEFAULT_STYLE, MCP_AUTHOR } from '../defaults.js';
+
+// ── Test helpers ───────────────────────────────────────────
+
+function createExpression(
+  overrides: Partial<VisualExpression> & { id: string; kind: VisualExpression['kind'] },
+): VisualExpression {
+  const now = Date.now();
+  return {
+    position: { x: 0, y: 0 },
+    size: { width: 100, height: 100 },
+    angle: 0,
+    style: { ...DEFAULT_STYLE },
+    meta: {
+      author: MCP_AUTHOR,
+      createdAt: now,
+      updatedAt: now,
+      tags: [],
+      locked: false,
+    },
+    data: { kind: 'rectangle' as const, label: undefined },
+    ...overrides,
+  };
+}
+
+function createMockClient(expressions: VisualExpression[] = []): IGatewayClient {
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    getSessionId: vi.fn().mockReturnValue('test-session'),
+    sendCreate: vi.fn().mockResolvedValue(undefined),
+    sendBatchCreate: vi.fn().mockResolvedValue(undefined),
+    sendDelete: vi.fn().mockResolvedValue(undefined),
+    sendMorph: vi.fn().mockResolvedValue(undefined),
+    sendStyle: vi.fn().mockResolvedValue(undefined),
+    getState: vi.fn().mockReturnValue(expressions),
+  };
+}
+
+// Valid draw.io XML for reuse across tests
+const VALID_DRAWIO_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <mxCell id="cell-1" value="Hello" style="rounded=1;fillColor=#ffffff;strokeColor=#000000;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+      <mxGeometry x="100" y="200" width="160" height="80" as="geometry"/>
+    </mxCell>
+  </root>
+</mxGraphModel>`;
+
+// ── [AC-3][AC-4] Round-trip fidelity ─────────────────────
+
+describe('[AC-3][AC-4] Export → Import round-trip fidelity', () => {
+  it('[AC-3][AC-4] rectangle survives export → import round-trip', () => {
+    const expressions = [
+      createExpression({
+        id: 'rect-rt',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Round Trip' },
+        position: { x: 100, y: 200 },
+        size: { width: 160, height: 80 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    // Export
+    const xml = executeExportDrawio(client);
+
+    // Import the exported XML via the protocol deserializer
+    const imported = drawioToExpressions(xml);
+    expect(imported).toHaveLength(1);
+    expect(imported[0]!.position).toEqual({ x: 100, y: 200 });
+    expect(imported[0]!.size).toEqual({ width: 160, height: 80 });
+    // Label should survive (data is kind-specific)
+    expect((imported[0]!.data as { label?: string }).label).toBe('Round Trip');
+  });
+
+  it('[AC-3][AC-4] multiple expression types survive round-trip', () => {
+    const expressions = [
+      createExpression({
+        id: 'rect-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Box' },
+        position: { x: 0, y: 0 },
+        size: { width: 120, height: 60 },
+      }),
+      createExpression({
+        id: 'ellipse-1',
+        kind: 'ellipse',
+        data: { kind: 'ellipse', label: 'Circle' },
+        position: { x: 200, y: 0 },
+        size: { width: 100, height: 100 },
+      }),
+      createExpression({
+        id: 'text-1',
+        kind: 'text',
+        data: { kind: 'text', text: 'Label', fontSize: 14, fontFamily: 'sans-serif', textAlign: 'left' as const },
+        position: { x: 0, y: 200 },
+        size: { width: 80, height: 30 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    const imported = drawioToExpressions(xml);
+
+    expect(imported).toHaveLength(3);
+
+    // Verify each kind survived
+    const kinds = imported.map((e) => e.kind);
+    expect(kinds).toContain('rectangle');
+    expect(kinds).toContain('ellipse');
+    expect(kinds).toContain('text');
+  });
+
+  it('[AC-3][AC-4] arrow with bindings survives round-trip', () => {
+    const expressions = [
+      createExpression({
+        id: 'arrow-1',
+        kind: 'arrow',
+        data: {
+          kind: 'arrow',
+          points: [[0, 0], [100, 100]] as [number, number][],
+          label: 'connects',
+          startBinding: { expressionId: 'src', anchor: 'auto' },
+          endBinding: { expressionId: 'tgt', anchor: 'auto' },
+        },
+        position: { x: 0, y: 0 },
+        size: { width: 0, height: 0 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    const imported = drawioToExpressions(xml);
+
+    expect(imported).toHaveLength(1);
+    expect(imported[0]!.kind).toBe('arrow');
+
+    const arrowData = imported[0]!.data as { kind: string; label?: string; startBinding?: unknown; endBinding?: unknown };
+    expect(arrowData.label).toBe('connects');
+  });
+
+  it('[AC-3][AC-4] diamond expression survives round-trip', () => {
+    const expressions = [
+      createExpression({
+        id: 'diamond-1',
+        kind: 'diamond',
+        data: { kind: 'diamond', label: 'Decision' },
+        position: { x: 50, y: 50 },
+        size: { width: 120, height: 120 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    const imported = drawioToExpressions(xml);
+
+    expect(imported).toHaveLength(1);
+    expect(imported[0]!.kind).toBe('diamond');
+    expect((imported[0]!.data as { label?: string }).label).toBe('Decision');
+  });
+
+  it('[AC-3][AC-4] sticky note survives round-trip with color', () => {
+    const expressions = [
+      createExpression({
+        id: 'note-1',
+        kind: 'sticky-note',
+        data: { kind: 'sticky-note', text: 'Remember this', color: '#FF9800' },
+        position: { x: 300, y: 300 },
+        size: { width: 200, height: 200 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    const imported = drawioToExpressions(xml);
+
+    expect(imported).toHaveLength(1);
+    expect(imported[0]!.kind).toBe('sticky-note');
+    const noteData = imported[0]!.data as { text: string; color: string };
+    expect(noteData.text).toBe('Remember this');
+    expect(noteData.color).toBe('#FF9800');
+  });
+});
+
+// ── [AC-4] Import gateway interaction ────────────────────
+
+describe('[AC-4] Import creates expressions via gateway', () => {
+  let client: IGatewayClient;
+
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  it('[AC-4] sendBatchCreate receives correctly structured expressions', async () => {
+    const result = await executeImportDrawio(client, { xml: VALID_DRAWIO_XML });
+
+    expect(client.sendBatchCreate).toHaveBeenCalledOnce();
+    const batch = vi.mocked(client.sendBatchCreate).mock.calls[0]![0];
+
+    // Verify the expression structure
+    expect(batch).toHaveLength(1);
+    const expr = batch[0]!;
+    expect(expr.id).toBe('cell-1');
+    expect(expr.kind).toBe('rectangle');
+    expect(expr.position).toEqual({ x: 100, y: 200 });
+    expect(expr.size).toEqual({ width: 160, height: 80 });
+    expect(result).toContain('1');
+  });
+
+  it('[AC-4] import result message includes accurate count', async () => {
+    const multiXml = `<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <mxCell id="c1" value="A" style="" vertex="1" parent="1">
+      <mxGeometry x="0" y="0" width="100" height="50" as="geometry"/>
+    </mxCell>
+    <mxCell id="c2" value="B" style="" vertex="1" parent="1">
+      <mxGeometry x="200" y="0" width="100" height="50" as="geometry"/>
+    </mxCell>
+    <mxCell id="c3" value="C" style="" vertex="1" parent="1">
+      <mxGeometry x="400" y="0" width="100" height="50" as="geometry"/>
+    </mxCell>
+  </root>
+</mxGraphModel>`;
+
+    const result = await executeImportDrawio(client, { xml: multiXml });
+    expect(result).toContain('3');
+    expect(result.toLowerCase()).toContain('import');
+  });
+
+  it('[EDGE] sendBatchCreate rejection is not caught — error propagates', async () => {
+    const failingClient = createMockClient();
+    vi.mocked(failingClient.sendBatchCreate).mockRejectedValue(
+      new Error('Gateway connection lost'),
+    );
+
+    // The tool does NOT wrap sendBatchCreate in try/catch, so the error propagates.
+    // This is correct behavior — the MCP framework handles tool exceptions.
+    await expect(
+      executeImportDrawio(failingClient, { xml: VALID_DRAWIO_XML }),
+    ).rejects.toThrow('Gateway connection lost');
+  });
+
+  it('[EDGE] empty drawable cells — sendBatchCreate is not called', async () => {
+    const emptyCanvasXml = `<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+  </root>
+</mxGraphModel>`;
+
+    const result = await executeImportDrawio(client, { xml: emptyCanvasXml });
+    expect(client.sendBatchCreate).not.toHaveBeenCalled();
+    expect(result).toContain('0');
+  });
+});
+
+// ── [AC-3] Export output validation ──────────────────────
+
+describe('[AC-3] Export produces valid draw.io XML', () => {
+  it('[AC-3] exported XML is parseable by the draw.io deserializer', () => {
+    const expressions = [
+      createExpression({
+        id: 'verify-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Parseable' },
+        position: { x: 10, y: 20 },
+        size: { width: 150, height: 75 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+
+    // Should not throw when parsed by the protocol deserializer
+    const parsed = drawioToExpressions(xml);
+    expect(parsed).toHaveLength(1);
+  });
+
+  it('[AC-3] exported XML contains XML declaration', () => {
+    const client = createMockClient([]);
+    const xml = executeExportDrawio(client);
+    expect(xml).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+  });
+
+  it('[AC-3] exported XML contains infrastructure cells', () => {
+    const client = createMockClient([]);
+    const xml = executeExportDrawio(client);
+    expect(xml).toContain('<mxCell id="0"/>');
+    expect(xml).toContain('<mxCell id="1" parent="0"/>');
+  });
+
+  it('[AC-3] exported XML contains mxGeometry with position and size', () => {
+    const expressions = [
+      createExpression({
+        id: 'geo-test',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Geo' },
+        position: { x: 42, y: 84 },
+        size: { width: 200, height: 100 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    expect(xml).toContain('x="42"');
+    expect(xml).toContain('y="84"');
+    expect(xml).toContain('width="200"');
+    expect(xml).toContain('height="100"');
+  });
+});
+
+// ── [EDGE] Import error handling ─────────────────────────
+
+describe('[EDGE] Import error handling', () => {
+  let client: IGatewayClient;
+
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  it('[EDGE] whitespace-only XML returns error', async () => {
+    const result = await executeImportDrawio(client, { xml: '   \n\t  ' });
+    expect(result.toLowerCase()).toMatch(/empty|failed/);
+    expect(client.sendBatchCreate).not.toHaveBeenCalled();
+  });
+
+  it('[EDGE] non-drawio XML (valid XML, wrong format) returns error', async () => {
+    const htmlXml = '<html><body><p>Not a diagram</p></body></html>';
+    const result = await executeImportDrawio(client, { xml: htmlXml });
+    expect(result.toLowerCase()).toMatch(/failed|invalid|error|mxgraphmodel/);
+    expect(client.sendBatchCreate).not.toHaveBeenCalled();
+  });
+
+  it('[EDGE] XML with mxGraphModel text in a non-structural position', async () => {
+    // The text "mxGraphModel" appears in a value attribute, not as element
+    const trickXml = '<root><item value="mxGraphModel reference"/></root>';
+    const result = await executeImportDrawio(client, { xml: trickXml });
+    // Even though the string "mxGraphModel" appears, there are no drawable cells
+    // The serializer won't find mxGraphModel element structure
+    // Should either succeed with 0 expressions or return a descriptive message
+    expect(client.sendBatchCreate).not.toHaveBeenCalled();
+  });
+
+  it('[EDGE] XML with only infrastructure cells (id 0, 1) returns zero imports', async () => {
+    const infraOnlyXml = `<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+  </root>
+</mxGraphModel>`;
+
+    const result = await executeImportDrawio(client, { xml: infraOnlyXml });
+    expect(result).toContain('0');
+    expect(client.sendBatchCreate).not.toHaveBeenCalled();
+  });
+
+  it('[EDGE] import does not modify canvas state on parse failure', async () => {
+    await executeImportDrawio(client, { xml: '' });
+    await executeImportDrawio(client, { xml: '<broken>>>>' });
+    await executeImportDrawio(client, { xml: '<xml>valid but wrong</xml>' });
+
+    // None of the above should have called sendBatchCreate
+    expect(client.sendBatchCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ── [EDGE] Special characters and encoding ───────────────
+
+describe('[EDGE] Special characters in export/import', () => {
+  it('[EDGE] expression with HTML entities in label exports safely', () => {
+    const expressions = [
+      createExpression({
+        id: 'entities-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'A < B & C > D' },
+        position: { x: 0, y: 0 },
+        size: { width: 200, height: 100 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    // Raw unescaped label should NOT appear in the XML
+    expect(xml).not.toContain('A < B');
+    expect(xml).not.toContain('C > D');
+    // Escaped versions should be present
+    expect(xml).toContain('&lt;');
+    expect(xml).toContain('&amp;');
+    expect(xml).toContain('&gt;');
+  });
+
+  it('[EDGE] expression with Unicode characters exports and round-trips', () => {
+    const expressions = [
+      createExpression({
+        id: 'unicode-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: '日本語テスト 🎨 Ñoño' },
+        position: { x: 0, y: 0 },
+        size: { width: 200, height: 100 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    const imported = drawioToExpressions(xml);
+
+    expect(imported).toHaveLength(1);
+    expect((imported[0]!.data as { label?: string }).label).toBe('日本語テスト 🎨 Ñoño');
+  });
+
+  it('[EDGE] expression with quotes in label exports safely', () => {
+    const expressions = [
+      createExpression({
+        id: 'quotes-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'He said "hello" & she said \'hi\'' },
+        position: { x: 0, y: 0 },
+        size: { width: 250, height: 100 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    // Should produce valid XML (parseable)
+    const imported = drawioToExpressions(xml);
+    expect(imported).toHaveLength(1);
+  });
+});
+
+// ── [EDGE] Boundary values ───────────────────────────────
+
+describe('[EDGE] Boundary values for export/import', () => {
+  it('[EDGE] expression at negative coordinates exports and round-trips', () => {
+    const expressions = [
+      createExpression({
+        id: 'neg-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Negative' },
+        position: { x: -500, y: -300 },
+        size: { width: 100, height: 50 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    const imported = drawioToExpressions(xml);
+    expect(imported[0]!.position).toEqual({ x: -500, y: -300 });
+  });
+
+  it('[EDGE] expression with zero dimensions exports correctly', () => {
+    const expressions = [
+      createExpression({
+        id: 'zero-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Zero' },
+        position: { x: 0, y: 0 },
+        size: { width: 0, height: 0 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    expect(xml).toContain('mxGraphModel');
+    // Should not crash
+  });
+
+  it('[EDGE] expression with very large coordinates exports correctly', () => {
+    const expressions = [
+      createExpression({
+        id: 'large-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Far Away' },
+        position: { x: 999999, y: 999999 },
+        size: { width: 100, height: 100 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    const imported = drawioToExpressions(xml);
+    expect(imported[0]!.position).toEqual({ x: 999999, y: 999999 });
+  });
+
+  it('[EDGE] empty canvas exports valid XML with zero user cells', () => {
+    const client = createMockClient([]);
+
+    const xml = executeExportDrawio(client);
+    const imported = drawioToExpressions(xml);
+    expect(imported).toHaveLength(0);
+    expect(xml).toContain('mxGraphModel');
+  });
+
+  it('[EDGE] rotation angle is preserved through export', () => {
+    const expressions = [
+      createExpression({
+        id: 'rotated-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Rotated' },
+        position: { x: 100, y: 100 },
+        size: { width: 120, height: 60 },
+        angle: 45,
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    expect(xml).toContain('rotation=45');
+
+    const imported = drawioToExpressions(xml);
+    expect(imported[0]!.angle).toBe(45);
+  });
+});
+
+// ── [CONTRACT] MCP tool contract ─────────────────────────
+
+describe('[CONTRACT] MCP tool interface contract', () => {
+  it('[CONTRACT] export tool returns string (not object, not array)', () => {
+    const client = createMockClient([]);
+    const result = executeExportDrawio(client);
+    expect(typeof result).toBe('string');
+  });
+
+  it('[CONTRACT] import tool returns a promise of string', async () => {
+    const client = createMockClient();
+    const result = executeImportDrawio(client, { xml: VALID_DRAWIO_XML });
+    expect(result).toBeInstanceOf(Promise);
+    const resolved = await result;
+    expect(typeof resolved).toBe('string');
+  });
+
+  it('[CONTRACT] import success message mentions count and "import"', async () => {
+    const client = createMockClient();
+    const result = await executeImportDrawio(client, { xml: VALID_DRAWIO_XML });
+    // Must contain the word "import" (case-insensitive) and the count
+    expect(result.toLowerCase()).toContain('import');
+    expect(result).toMatch(/\d+/);
+  });
+
+  it('[CONTRACT] import error messages start with "Import failed:"', async () => {
+    const client = createMockClient();
+
+    const emptyResult = await executeImportDrawio(client, { xml: '' });
+    expect(emptyResult).toMatch(/^Import failed:/);
+
+    const invalidResult = await executeImportDrawio(client, { xml: '<not>drawio</not>' });
+    expect(invalidResult).toMatch(/^Import failed:/);
+  });
+
+  it('[CONTRACT] export always returns XML starting with declaration', () => {
+    const client = createMockClient([]);
+    const xml = executeExportDrawio(client);
+    expect(xml.startsWith('<?xml')).toBe(true);
+  });
+});
+
+// ── [COVERAGE] Scale test ────────────────────────────────
+
+describe('[COVERAGE] Scale and performance', () => {
+  it('[COVERAGE] export handles 100 expressions without error', () => {
+    const expressions: VisualExpression[] = [];
+    for (let i = 0; i < 100; i++) {
+      expressions.push(
+        createExpression({
+          id: `bulk-${i}`,
+          kind: 'rectangle',
+          data: { kind: 'rectangle', label: `Shape ${i}` },
+          position: { x: (i % 10) * 200, y: Math.floor(i / 10) * 150 },
+          size: { width: 160, height: 80 },
+        }),
+      );
+    }
+    const client = createMockClient(expressions);
+
+    const start = performance.now();
+    const xml = executeExportDrawio(client);
+    const duration = performance.now() - start;
+
+    // Verify all 100 exported
+    const imported = drawioToExpressions(xml);
+    expect(imported).toHaveLength(100);
+
+    // Performance: should complete well under 200ms (AC from PO ticket)
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('[COVERAGE] import handles 100 cells via gateway batch', async () => {
+    // Build XML with 100 cells
+    const cells = Array.from({ length: 100 }, (_, i) =>
+      `    <mxCell id="c${i}" value="Cell ${i}" style="" vertex="1" parent="1">
+      <mxGeometry x="${(i % 10) * 200}" y="${Math.floor(i / 10) * 150}" width="160" height="80" as="geometry"/>
+    </mxCell>`,
+    ).join('\n');
+
+    const bulkXml = `<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+${cells}
+  </root>
+</mxGraphModel>`;
+
+    const client = createMockClient();
+
+    const start = performance.now();
+    const result = await executeImportDrawio(client, { xml: bulkXml });
+    const duration = performance.now() - start;
+
+    expect(result).toContain('100');
+    expect(client.sendBatchCreate).toHaveBeenCalledOnce();
+    const batch = vi.mocked(client.sendBatchCreate).mock.calls[0]![0];
+    expect(batch).toHaveLength(100);
+
+    // Performance: should complete well under 200ms
+    expect(duration).toBeLessThan(200);
+  });
+});
+
+// ── [COVERAGE] Style preservation ────────────────────────
+
+describe('[COVERAGE] Visual style preservation through export', () => {
+  it('[COVERAGE] dashed stroke exports correctly', () => {
+    const expressions = [
+      createExpression({
+        id: 'dashed-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Dashed' },
+        style: { ...DEFAULT_STYLE, strokeStyle: 'dashed' as const },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    expect(xml).toContain('dashed=1');
+    expect(xml).toContain('dashPattern=8 5');
+  });
+
+  it('[COVERAGE] dotted stroke exports with distinct pattern', () => {
+    const expressions = [
+      createExpression({
+        id: 'dotted-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Dotted' },
+        style: { ...DEFAULT_STYLE, strokeStyle: 'dotted' as const },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    expect(xml).toContain('dashed=1');
+    expect(xml).toContain('dashPattern=1 3');
+  });
+
+  it('[COVERAGE] semi-transparent opacity exports as draw.io percentage', () => {
+    const expressions = [
+      createExpression({
+        id: 'opacity-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Semi' },
+        style: { ...DEFAULT_STYLE, opacity: 0.5 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    expect(xml).toContain('opacity=50');
+  });
+
+  it('[COVERAGE] fully opaque does not export redundant opacity', () => {
+    const expressions = [
+      createExpression({
+        id: 'opaque-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Opaque' },
+        style: { ...DEFAULT_STYLE, opacity: 1 },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    expect(xml).not.toContain('opacity=');
+  });
+
+  it('[COVERAGE] transparent fill exports as fillColor=none', () => {
+    const expressions = [
+      createExpression({
+        id: 'nofill-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'No Fill' },
+        style: { ...DEFAULT_STYLE, backgroundColor: 'transparent' },
+      }),
+    ];
+    const client = createMockClient(expressions);
+
+    const xml = executeExportDrawio(client);
+    expect(xml).toContain('fillColor=none');
+  });
+});

--- a/packages/mcp-server/src/__tests__/drawioTools.test.ts
+++ b/packages/mcp-server/src/__tests__/drawioTools.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for draw.io export/import MCP tools.
+ *
+ * Verifies canvas-to-drawio export, drawio-to-canvas import,
+ * and error handling for invalid XML input.
+ *
+ * @module
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VisualExpression } from '@infinicanvas/protocol';
+import type { IGatewayClient } from '../gatewayClient.js';
+import {
+  executeExportDrawio,
+  executeImportDrawio,
+} from '../tools/drawioTools.js';
+import { DEFAULT_STYLE, MCP_AUTHOR } from '../defaults.js';
+
+// ── Test helpers ───────────────────────────────────────────
+
+function createExpression(
+  overrides: Partial<VisualExpression> & { id: string; kind: VisualExpression['kind'] },
+): VisualExpression {
+  const now = Date.now();
+  return {
+    position: { x: 0, y: 0 },
+    size: { width: 100, height: 100 },
+    angle: 0,
+    style: { ...DEFAULT_STYLE },
+    meta: {
+      author: MCP_AUTHOR,
+      createdAt: now,
+      updatedAt: now,
+      tags: [],
+      locked: false,
+    },
+    data: { kind: 'rectangle' as const, label: undefined },
+    ...overrides,
+  };
+}
+
+function createMockClient(expressions: VisualExpression[] = []): IGatewayClient {
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    getSessionId: vi.fn().mockReturnValue('test-session'),
+    sendCreate: vi.fn().mockResolvedValue(undefined),
+    sendBatchCreate: vi.fn().mockResolvedValue(undefined),
+    sendDelete: vi.fn().mockResolvedValue(undefined),
+    sendMorph: vi.fn().mockResolvedValue(undefined),
+    sendStyle: vi.fn().mockResolvedValue(undefined),
+    getState: vi.fn().mockReturnValue(expressions),
+  };
+}
+
+// ── canvas_export_drawio ──────────────────────────────────
+
+describe('executeExportDrawio', () => {
+  let client: IGatewayClient;
+
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  it('returns valid XML containing mxGraphModel', () => {
+    const expressions = [
+      createExpression({
+        id: 'rect-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'Box' },
+        position: { x: 100, y: 200 },
+        size: { width: 160, height: 80 },
+      }),
+    ];
+    client = createMockClient(expressions);
+
+    const result = executeExportDrawio(client);
+    expect(result).toContain('mxGraphModel');
+    expect(result).toContain('<?xml');
+  });
+
+  it('returns XML with expression data preserved', () => {
+    const expressions = [
+      createExpression({
+        id: 'rect-1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'My Box' },
+        position: { x: 50, y: 75 },
+        size: { width: 200, height: 100 },
+      }),
+    ];
+    client = createMockClient(expressions);
+
+    const result = executeExportDrawio(client);
+    expect(result).toContain('My Box');
+  });
+
+  it('returns empty-canvas XML when no expressions exist', () => {
+    const result = executeExportDrawio(client);
+    expect(result).toContain('mxGraphModel');
+    // Should still be valid XML, just with no user cells beyond root cells
+  });
+
+  it('calls getState on the gateway client', () => {
+    executeExportDrawio(client);
+    expect(client.getState).toHaveBeenCalledOnce();
+  });
+
+  it('handles multiple expressions', () => {
+    const expressions = [
+      createExpression({
+        id: 'r1',
+        kind: 'rectangle',
+        data: { kind: 'rectangle', label: 'A' },
+      }),
+      createExpression({
+        id: 'e1',
+        kind: 'ellipse',
+        data: { kind: 'ellipse', label: 'B' },
+      }),
+    ];
+    client = createMockClient(expressions);
+
+    const result = executeExportDrawio(client);
+    expect(result).toContain('mxGraphModel');
+    // Both expressions should be in the output
+    expect(result).toContain('A');
+    expect(result).toContain('B');
+  });
+});
+
+// ── canvas_import_drawio ──────────────────────────────────
+
+describe('executeImportDrawio', () => {
+  let client: IGatewayClient;
+
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  it('creates expressions from valid draw.io XML', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <mxCell id="cell-1" value="Hello" style="rounded=0;" vertex="1" parent="1">
+      <mxGeometry x="100" y="200" width="160" height="80" as="geometry"/>
+    </mxCell>
+  </root>
+</mxGraphModel>`;
+
+    const result = await executeImportDrawio(client, { xml });
+    expect(client.sendBatchCreate).toHaveBeenCalledOnce();
+
+    // Verify the batch contains the parsed expression
+    const batchArg = vi.mocked(client.sendBatchCreate).mock.calls[0]![0];
+    expect(batchArg).toHaveLength(1);
+    expect(batchArg[0]!.position).toEqual({ x: 100, y: 200 });
+    expect(batchArg[0]!.size).toEqual({ width: 160, height: 80 });
+
+    expect(result).toContain('1');
+    expect(result).toContain('imported');
+  });
+
+  it('imports multiple expressions', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <mxCell id="cell-1" value="First" style="" vertex="1" parent="1">
+      <mxGeometry x="0" y="0" width="100" height="50" as="geometry"/>
+    </mxCell>
+    <mxCell id="cell-2" value="Second" style="" vertex="1" parent="1">
+      <mxGeometry x="200" y="0" width="100" height="50" as="geometry"/>
+    </mxCell>
+  </root>
+</mxGraphModel>`;
+
+    const result = await executeImportDrawio(client, { xml });
+    const batchArg = vi.mocked(client.sendBatchCreate).mock.calls[0]![0];
+    expect(batchArg).toHaveLength(2);
+    expect(result).toContain('2');
+  });
+
+  it('returns error message for invalid XML', async () => {
+    const invalidXml = '<not-valid><<<>>>';
+    const result = await executeImportDrawio(client, { xml: invalidXml });
+    expect(result.toLowerCase()).toMatch(/error|failed|invalid/);
+    expect(client.sendBatchCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns error message for empty XML', async () => {
+    const result = await executeImportDrawio(client, { xml: '' });
+    expect(result.toLowerCase()).toMatch(/error|failed|invalid|empty/);
+    expect(client.sendBatchCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns success message with expression count', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <mxCell id="cell-1" value="Test" style="" vertex="1" parent="1">
+      <mxGeometry x="0" y="0" width="120" height="60" as="geometry"/>
+    </mxCell>
+  </root>
+</mxGraphModel>`;
+
+    const result = await executeImportDrawio(client, { xml });
+    expect(result).toContain('1');
+    expect(result).toContain('import');
+  });
+
+  it('handles XML with no drawable cells gracefully', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+  </root>
+</mxGraphModel>`;
+
+    const result = await executeImportDrawio(client, { xml });
+    // Should succeed but import 0 expressions
+    expect(result).toContain('0');
+    // Should not call sendBatchCreate with empty array or not at all
+  });
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -72,6 +72,10 @@ import {
   executeListWaypoints,
   executeRemoveWaypoint,
 } from './tools/waypointTools.js';
+import {
+  executeExportDrawio,
+  executeImportDrawio,
+} from './tools/drawioTools.js';
 
 // ── Zod schemas for tool parameters ────────────────────────
 
@@ -689,6 +693,28 @@ export function createMcpServer(gatewayClient: IGatewayClient): McpServer {
     },
     async (params) => ({
       content: [{ type: 'text' as const, text: executeRemoveWaypoint(gatewayClient, params) }],
+    }),
+  );
+
+  // ── draw.io export/import tools ────────────────────────────
+
+  server.tool(
+    'canvas_export_drawio',
+    'Export the current canvas as draw.io XML. Returns mxGraphModel XML that can be opened in draw.io/diagrams.net. No parameters needed.',
+    {},
+    async () => ({
+      content: [{ type: 'text' as const, text: executeExportDrawio(gatewayClient) }],
+    }),
+  );
+
+  server.tool(
+    'canvas_import_drawio',
+    'Import a draw.io XML file onto the canvas. Parses mxGraphModel XML and creates visual expressions for each cell. Returns the count of imported expressions.',
+    {
+      xml: z.string().min(1).describe('The draw.io XML content (mxGraphModel format)'),
+    },
+    async (args) => ({
+      content: [{ type: 'text' as const, text: await executeImportDrawio(gatewayClient, args) }],
     }),
   );
 

--- a/packages/mcp-server/src/tools/drawioTools.ts
+++ b/packages/mcp-server/src/tools/drawioTools.ts
@@ -1,0 +1,61 @@
+/**
+ * draw.io export/import tools — serialize canvas to/from mxGraphModel XML.
+ *
+ * Export: reads current canvas state and converts to draw.io XML.
+ * Import: parses draw.io XML and creates expressions on the canvas.
+ *
+ * Uses the draw.io serializer from @infinicanvas/protocol.
+ *
+ * @module
+ */
+
+import { expressionsToDrawio, drawioToExpressions } from '@infinicanvas/protocol';
+import type { IGatewayClient } from '../gatewayClient.js';
+
+/**
+ * Export the current canvas state as draw.io XML.
+ *
+ * Reads all expressions from the gateway client and serializes them
+ * into mxGraphModel XML format compatible with draw.io/diagrams.net.
+ */
+export function executeExportDrawio(client: IGatewayClient): string {
+  const expressions = client.getState();
+  return expressionsToDrawio(expressions);
+}
+
+/**
+ * Import draw.io XML and create expressions on the canvas.
+ *
+ * Parses the provided mxGraphModel XML, converts cells to
+ * VisualExpressions, and batch-creates them via the gateway client.
+ *
+ * @returns Human-readable result message with count of imported expressions.
+ */
+export async function executeImportDrawio(
+  client: IGatewayClient,
+  params: { xml: string },
+): Promise<string> {
+  if (!params.xml || params.xml.trim().length === 0) {
+    return 'Import failed: empty XML input.';
+  }
+
+  // Pre-flight: reject input that isn't draw.io XML before parsing
+  if (!params.xml.includes('<mxGraphModel')) {
+    return 'Import failed: XML does not contain a <mxGraphModel> element.';
+  }
+
+  let expressions;
+  try {
+    expressions = drawioToExpressions(params.xml);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `Import failed: invalid draw.io XML — ${message}`;
+  }
+
+  if (expressions.length === 0) {
+    return 'Imported 0 expressions — the draw.io file contained no drawable cells.';
+  }
+
+  await client.sendBatchCreate(expressions);
+  return `Successfully imported ${expressions.length} expression(s) from draw.io XML.`;
+}

--- a/packages/protocol/src/drawio/serializer.ts
+++ b/packages/protocol/src/drawio/serializer.ts
@@ -400,6 +400,9 @@ interface ParsedPoint {
 /** Maximum input size for XML import (10 MB). */
 const MAX_INPUT_SIZE = 10_000_000;
 
+/** Maximum number of expressions to import. */
+const MAX_EXPRESSION_COUNT = 5_000;
+
 /** Sanitize a numeric value: replace NaN/Infinity with a fallback. */
 function sanitizeNum(value: number, fallback: number): number {
   return Number.isFinite(value) ? value : fallback;
@@ -572,6 +575,14 @@ export function drawioToExpressions(xml: string): VisualExpression[] {
 
   const cells = parsed.mxGraphModel?.root?.mxCell;
   if (!cells) return [];
+
+  // Guard against excessively large imports
+  if (cells.length > MAX_EXPRESSION_COUNT) {
+    throw new Error(
+      `draw.io file contains ${cells.length} cells, exceeding the limit of ${MAX_EXPRESSION_COUNT}. ` +
+      `Reduce the diagram size or split into smaller files.`,
+    );
+  }
 
   const expressions: VisualExpression[] = [];
   const now = Date.now();


### PR DESCRIPTION
## Summary

Wires the draw.io XML serializer (#90) into the MCP server and app UI, enabling AI agents and users to export/import draw.io files.

### Epic: #87

### What's included
- **MCP Tools:** `canvas_export_drawio` + `canvas_import_drawio` for AI agent workflows
- **App UI:** Export/Import .drawio options in ExportMenu dropdown
- Batch import via single `replaceState()` (no N re-renders)
- Validation-before-parse ordering for fast rejection
- Expression count limit (5,000 max) prevents DoS
- `FileReader.onerror` handlers on both draw.io and JSON import

### Review Gate Results
- ✅ QA Guardian: 38 integration tests, 0 regressions
- ✅ Security Guardian: Semgrep 0, validation order fixed, count limit added
- ✅ Code Review Guardian: All high findings fixed

Closes #91

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>