### PR TITLE
feat: scalable stencil palette — search, badges, pagination (#103)

### DIFF
--- a/packages/app/src/__tests__/StencilPaletteScalable.test.tsx
+++ b/packages/app/src/__tests__/StencilPaletteScalable.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for StencilPalette scalable features — search, badges,
+ * show-more pagination, category sorting, and tooltips.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Extends the existing StencilPalette.test.tsx with new feature tests.
+ *
+ * @vitest-environment jsdom
+ * @module
+ */
+
+import { render, cleanup, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { StencilPalette } from '../components/toolbar/StencilPalette.js';
+import { getAllStencilMeta } from '@infinicanvas/engine';
+
+// ── Tests ──────────────────────────────────────────────────
+
+describe('StencilPalette — Scalable features', () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  // ── Search ──────────────────────────────────────────────
+
+  describe('Search input', () => {
+    it('renders a search input when the palette is open', async () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={true} />,
+      );
+
+      await waitFor(() => {
+        const input = container.querySelector('[data-testid="stencil-search-input"]');
+        expect(input).not.toBeNull();
+      });
+    });
+
+    it('does not render search input when palette is closed', () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={false} />,
+      );
+      const input = container.querySelector('[data-testid="stencil-search-input"]');
+      expect(input).toBeNull();
+    });
+
+    it('filters stencils by search query after debounce', async () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={true} />,
+      );
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(container.querySelector('[data-testid^="stencil-item-"]')).not.toBeNull();
+      });
+
+      const input = container.querySelector('[data-testid="stencil-search-input"]') as HTMLInputElement;
+
+      // Type a search query and wait for debounce
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'Server' } });
+      });
+
+      // Wait for debounce (200ms) + state update
+      await waitFor(() => {
+        // Should show Server stencil
+        expect(container.querySelector('[data-testid="stencil-item-server"]')).not.toBeNull();
+        // Should NOT show unrelated stencils like Database
+        expect(container.querySelector('[data-testid="stencil-item-database"]')).toBeNull();
+      }, { timeout: 2000 });
+    });
+
+    it('shows a clear button when search has text', async () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={true} />,
+      );
+
+      const input = container.querySelector('[data-testid="stencil-search-input"]') as HTMLInputElement;
+
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'test' } });
+      });
+
+      // Clear button appears immediately (not debounced — it tracks raw input)
+      const clearButton = container.querySelector('[data-testid="stencil-search-clear"]');
+      expect(clearButton).not.toBeNull();
+    });
+
+    it('clears search when clear button is clicked', async () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={true} />,
+      );
+
+      const input = container.querySelector('[data-testid="stencil-search-input"]') as HTMLInputElement;
+
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'test' } });
+      });
+
+      const clearButton = container.querySelector('[data-testid="stencil-search-clear"]');
+
+      await act(async () => {
+        fireEvent.click(clearButton!);
+      });
+
+      expect(input.value).toBe('');
+    });
+
+    it('search is case-insensitive', async () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={true} />,
+      );
+
+      // Wait for load
+      await waitFor(() => {
+        expect(container.querySelector('[data-testid^="stencil-item-"]')).not.toBeNull();
+      });
+
+      const input = container.querySelector('[data-testid="stencil-search-input"]') as HTMLInputElement;
+
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'server' } });
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector('[data-testid="stencil-item-server"]')).not.toBeNull();
+      }, { timeout: 2000 });
+    });
+  });
+
+  // ── Category badges ─────────────────────────────────────
+
+  describe('Category count badges', () => {
+    it('shows stencil count on category headers from metadata', () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={true} />,
+      );
+
+      // Category count badges appear immediately (sync metadata)
+      const allMeta = getAllStencilMeta();
+      const networkCount = allMeta.filter((m) => m.category === 'network').length;
+
+      const badge = container.querySelector('[data-testid="category-count-network"]');
+      expect(badge).not.toBeNull();
+      expect(badge!.textContent).toBe(String(networkCount));
+    });
+  });
+
+  // ── Show more ────────────────────────────────────────────
+
+  describe('Show more pagination', () => {
+    it('does not show "Show more" button for small categories', async () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={true} />,
+      );
+
+      // Wait for stencils to load
+      await waitFor(() => {
+        expect(container.querySelector('[data-testid^="stencil-item-"]')).not.toBeNull();
+      });
+
+      // Network has ~5 stencils — no show more button expected
+      const showMore = container.querySelector('[data-testid="show-more-network"]');
+      expect(showMore).toBeNull();
+    });
+  });
+
+  // ── Category sort order ─────────────────────────────────
+
+  describe('Category sort order', () => {
+    it('renders categories in priority order', () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={true} />,
+      );
+
+      const headers = container.querySelectorAll('[data-testid^="category-header-"]');
+      const categoryOrder = [...headers].map(
+        (h) => h.getAttribute('data-testid')!.replace('category-header-', ''),
+      );
+
+      // Network should appear before azure-arm
+      const networkIdx = categoryOrder.indexOf('network');
+      const azureArmIdx = categoryOrder.indexOf('azure-arm');
+      expect(networkIdx).toBeLessThan(azureArmIdx);
+    });
+  });
+
+  // ── Tooltips ────────────────────────────────────────────
+
+  describe('Stencil tooltips', () => {
+    it('stencil items have title attribute for tooltip', async () => {
+      const { container } = render(
+        <StencilPalette onInsert={vi.fn()} isOpen={true} />,
+      );
+
+      await waitFor(() => {
+        const serverItem = container.querySelector('[data-testid="stencil-item-server"]');
+        expect(serverItem).not.toBeNull();
+        expect(serverItem!.getAttribute('title')).toBe('Server');
+      });
+    });
+  });
+});

--- a/packages/app/src/__tests__/stencilPaletteUtils.test.ts
+++ b/packages/app/src/__tests__/stencilPaletteUtils.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for stencilPaletteUtils — pure utility functions for
+ * StencilPalette search, sorting, and filtering.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ *
+ * @vitest-environment jsdom
+ * @module
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { StencilMeta } from '@infinicanvas/engine';
+import {
+  filterStencilsBySearch,
+  sortCategories,
+  getCategoryCounts,
+  getCategoryDisplayName,
+  INITIAL_RENDER_LIMIT,
+  SEARCH_DEBOUNCE_MS,
+} from '../components/toolbar/stencilPaletteUtils.js';
+
+// ── Test fixtures ──────────────────────────────────────────
+
+const MOCK_META: StencilMeta[] = [
+  { id: 'server', category: 'network', label: 'Server', defaultSize: { width: 44, height: 44 } },
+  { id: 'firewall', category: 'network', label: 'Firewall', defaultSize: { width: 44, height: 44 } },
+  { id: 'router', category: 'network', label: 'Router', defaultSize: { width: 44, height: 44 } },
+  { id: 'database', category: 'generic-it', label: 'Database', defaultSize: { width: 44, height: 44 } },
+  { id: 'k8s-pod', category: 'kubernetes', label: 'Kubernetes Pod', defaultSize: { width: 44, height: 44 } },
+  { id: 'k8s-service', category: 'kubernetes', label: 'Kubernetes Service', defaultSize: { width: 44, height: 44 } },
+  { id: 'azure-aks', category: 'azure', label: 'AKS', defaultSize: { width: 44, height: 44 } },
+  { id: 'microservice', category: 'architecture', label: 'Microservice', defaultSize: { width: 44, height: 44 } },
+  { id: 'drawio-ec2', category: 'drawio-aws', label: 'EC2 Instance', defaultSize: { width: 44, height: 44 } },
+  { id: 'drawio-s3', category: 'drawio-aws', label: 'S3 Bucket', defaultSize: { width: 44, height: 44 } },
+  { id: 'drawio-gce', category: 'drawio-gcp', label: 'GCE Instance', defaultSize: { width: 44, height: 44 } },
+];
+
+// ── filterStencilsBySearch ─────────────────────────────────
+
+describe('filterStencilsBySearch', () => {
+  it('returns all stencils grouped by category when query is empty', () => {
+    const result = filterStencilsBySearch(MOCK_META, '');
+    const totalCount = [...result.values()].reduce((sum, arr) => sum + arr.length, 0);
+    expect(totalCount).toBe(MOCK_META.length);
+  });
+
+  it('returns empty map when no stencils match', () => {
+    const result = filterStencilsBySearch(MOCK_META, 'nonexistent-xyz');
+    expect(result.size).toBe(0);
+  });
+
+  it('matches case-insensitively', () => {
+    const result = filterStencilsBySearch(MOCK_META, 'SERVER');
+    expect(result.has('network')).toBe(true);
+    expect(result.get('network')![0]!.id).toBe('server');
+  });
+
+  it('matches partial substrings', () => {
+    const result = filterStencilsBySearch(MOCK_META, 'serv');
+    expect(result.has('network')).toBe(true);
+    expect(result.get('network')!.some((m) => m.id === 'server')).toBe(true);
+    // Also matches 'Kubernetes Service'
+    expect(result.has('kubernetes')).toBe(true);
+    expect(result.get('kubernetes')!.some((m) => m.id === 'k8s-service')).toBe(true);
+  });
+
+  it('searches across all categories', () => {
+    // 'a' appears in Server, Firewall, Database, AKS, Microservice, EC2 Instance, S3 Bucket, GCE Instance
+    const result = filterStencilsBySearch(MOCK_META, 'a');
+    expect(result.size).toBeGreaterThan(1);
+  });
+
+  it('groups results by category', () => {
+    const result = filterStencilsBySearch(MOCK_META, 'kubernetes');
+    expect(result.has('kubernetes')).toBe(true);
+    expect(result.get('kubernetes')!.length).toBe(2);
+    // Should not include other categories
+    expect(result.has('network')).toBe(false);
+  });
+
+  it('trims whitespace from query', () => {
+    const result = filterStencilsBySearch(MOCK_META, '  server  ');
+    expect(result.has('network')).toBe(true);
+    expect(result.get('network')![0]!.id).toBe('server');
+  });
+
+  it('returns categories in sorted order', () => {
+    const result = filterStencilsBySearch(MOCK_META, '');
+    const keys = [...result.keys()];
+    // Priority categories should come first
+    const networkIdx = keys.indexOf('network');
+    const drawioIdx = keys.indexOf('drawio-aws');
+    expect(networkIdx).toBeLessThan(drawioIdx);
+  });
+});
+
+// ── sortCategories ────────────────────────────────────────
+
+describe('sortCategories', () => {
+  it('puts hand-crafted categories before drawio categories', () => {
+    const input = ['drawio-aws', 'network', 'kubernetes'];
+    const sorted = sortCategories(input);
+    expect(sorted.indexOf('network')).toBeLessThan(sorted.indexOf('drawio-aws'));
+    expect(sorted.indexOf('kubernetes')).toBeLessThan(sorted.indexOf('drawio-aws'));
+  });
+
+  it('preserves priority order among hand-crafted categories', () => {
+    const input = ['generic-it', 'azure', 'network', 'architecture', 'kubernetes'];
+    const sorted = sortCategories(input);
+    expect(sorted).toEqual([
+      'network',
+      'architecture',
+      'kubernetes',
+      'azure',
+      'generic-it',
+    ]);
+  });
+
+  it('sorts drawio categories alphabetically', () => {
+    const input = ['drawio-gcp', 'drawio-aws', 'drawio-azure'];
+    const sorted = sortCategories(input);
+    expect(sorted).toEqual(['drawio-aws', 'drawio-azure', 'drawio-gcp']);
+  });
+
+  it('handles empty input', () => {
+    expect(sortCategories([])).toEqual([]);
+  });
+
+  it('handles single category', () => {
+    expect(sortCategories(['network'])).toEqual(['network']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = ['drawio-aws', 'network'];
+    const inputCopy = [...input];
+    sortCategories(input);
+    expect(input).toEqual(inputCopy);
+  });
+
+  it('handles mix of known and unknown categories', () => {
+    const input = ['custom-category', 'network', 'drawio-aws', 'azure'];
+    const sorted = sortCategories(input);
+    // network, azure (priority), then custom-category, drawio-aws (alpha)
+    expect(sorted[0]).toBe('network');
+    expect(sorted[1]).toBe('azure');
+    expect(sorted.indexOf('custom-category')).toBeLessThan(sorted.indexOf('drawio-aws'));
+  });
+});
+
+// ── getCategoryCounts ─────────────────────────────────────
+
+describe('getCategoryCounts', () => {
+  it('returns correct count per category', () => {
+    const counts = getCategoryCounts(MOCK_META);
+    expect(counts.get('network')).toBe(3);
+    expect(counts.get('kubernetes')).toBe(2);
+    expect(counts.get('generic-it')).toBe(1);
+    expect(counts.get('azure')).toBe(1);
+    expect(counts.get('drawio-aws')).toBe(2);
+    expect(counts.get('drawio-gcp')).toBe(1);
+  });
+
+  it('returns empty map for empty input', () => {
+    const counts = getCategoryCounts([]);
+    expect(counts.size).toBe(0);
+  });
+});
+
+// ── getCategoryDisplayName ────────────────────────────────
+
+describe('getCategoryDisplayName', () => {
+  it('returns mapped name for known categories', () => {
+    expect(getCategoryDisplayName('network')).toBe('Network');
+    expect(getCategoryDisplayName('azure-arm')).toBe('Azure ARM');
+    expect(getCategoryDisplayName('generic-it')).toBe('Generic IT');
+  });
+
+  it('title-cases unknown categories', () => {
+    expect(getCategoryDisplayName('drawio-aws')).toBe('Drawio Aws');
+    expect(getCategoryDisplayName('my-custom-cat')).toBe('My Custom Cat');
+  });
+
+  it('handles single word', () => {
+    expect(getCategoryDisplayName('misc')).toBe('Misc');
+  });
+});
+
+// ── Constants ─────────────────────────────────────────────
+
+describe('Constants', () => {
+  it('INITIAL_RENDER_LIMIT is 50', () => {
+    expect(INITIAL_RENDER_LIMIT).toBe(50);
+  });
+
+  it('SEARCH_DEBOUNCE_MS is 200', () => {
+    expect(SEARCH_DEBOUNCE_MS).toBe(200);
+  });
+});

--- a/packages/app/src/components/toolbar/StencilPalette.tsx
+++ b/packages/app/src/components/toolbar/StencilPalette.tsx
@@ -5,23 +5,40 @@
  * showing a grid of stencil thumbnails. Supports click-to-place
  * (at viewport center) and drag-to-place (at drop position).
  *
+ * Features:
+ * - Search/filter across all categories (uses sync metadata)
+ * - Category count badges from metadata
+ * - "Show more" pagination for large categories (>50 stencils)
+ * - Priority-based category sort order
+ * - Tooltip on stencil hover
+ * - Debounced search input (200ms)
+ *
  * Categories are listed immediately from metadata. SVGs are loaded
  * lazily when a category is expanded, with a loading indicator.
  *
  * @module
  */
 
-import { useState, useCallback, useEffect, type DragEvent } from 'react';
+import { useState, useCallback, useEffect, useMemo, memo, type DragEvent } from 'react';
 import { nanoid } from 'nanoid';
-import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { ChevronDown, ChevronRight, Loader2, Search, X } from 'lucide-react';
 import type { VisualExpression, ExpressionData } from '@infinicanvas/protocol';
 import { DEFAULT_EXPRESSION_STYLE } from '@infinicanvas/protocol';
 import {
-  getCategories,
   getCategoryStencils,
+  getAllStencilMeta,
   svgToDataUri,
 } from '@infinicanvas/engine';
 import type { StencilEntry } from '@infinicanvas/engine';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue.js';
+import {
+  filterStencilsBySearch,
+  sortCategories,
+  getCategoryCounts,
+  getCategoryDisplayName,
+  INITIAL_RENDER_LIMIT,
+  SEARCH_DEBOUNCE_MS,
+} from './stencilPaletteUtils.js';
 
 // ── Constants ──────────────────────────────────────────────
 
@@ -33,17 +50,6 @@ const THUMBNAIL_SIZE = 48;
 
 /** Number of columns in the stencil grid. */
 const GRID_COLUMNS = 3;
-
-/** Map from kebab-case category IDs to human-readable display names. */
-const CATEGORY_DISPLAY_NAMES: Record<string, string> = {
-  architecture: 'Architecture',
-  azure: 'Azure',
-  'azure-arm': 'Azure ARM',
-  'generic-it': 'Generic IT',
-  kubernetes: 'Kubernetes',
-  network: 'Network',
-  security: 'Security',
-};
 
 // ── Props ──────────────────────────────────────────────────
 
@@ -89,34 +95,24 @@ function createStencilExpression(entry: StencilEntry): VisualExpression {
   };
 }
 
-/**
- * Returns a human-readable display name for a category slug.
- * Falls back to title-casing the slug if not found in the map.
- */
-function getCategoryDisplayName(category: string): string {
-  return (
-    CATEGORY_DISPLAY_NAMES[category] ??
-    category
-      .split('-')
-      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-      .join(' ')
-  );
-}
-
 // ── Component ──────────────────────────────────────────────
 
 /**
- * StencilPalette — scrollable panel with collapsible category sections.
+ * StencilPalette — scrollable panel with search, collapsible categories,
+ * count badges, and "show more" pagination.
  *
  * Each category shows a grid of stencil thumbnails with labels.
  * Clicking a stencil calls onInsert with a new VisualExpression.
  * Dragging a stencil sets transfer data for canvas drop handling.
  *
  * Categories are listed immediately from sync metadata. SVGs load
- * lazily when a category is expanded.
+ * lazily when a category is expanded or matched by search.
  */
 export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
-  const categories = getCategories();
+  const [searchInput, setSearchInput] = useState('');
+  const debouncedQuery = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
+  const isSearching = debouncedQuery.trim().length > 0;
+
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(
     new Set(),
   );
@@ -126,13 +122,61 @@ export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
   const [loadingCategories, setLoadingCategories] = useState<Set<string>>(
     new Set(),
   );
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
+    new Set(),
+  );
 
-  // Load stencils for all expanded categories
+  // Stable reference to all metadata (sync — no SVG content)
+  const allMeta = useMemo(() => getAllStencilMeta(), []);
+
+  // Compute category counts from metadata (stable across renders)
+  const categoryCounts = useMemo(() => getCategoryCounts(allMeta), [allMeta]);
+
+  // Sorted categories from metadata
+  const sortedCategories = useMemo(
+    () => sortCategories([...categoryCounts.keys()]),
+    [categoryCounts],
+  );
+
+  // Filter metadata by search query (operates on sync metadata — instant)
+  const filteredByCategory = useMemo(
+    () => filterStencilsBySearch(allMeta, debouncedQuery),
+    [allMeta, debouncedQuery],
+  );
+
+  // Determine which categories to show
+  const visibleCategories = useMemo(() => {
+    if (isSearching) {
+      return [...filteredByCategory.keys()];
+    }
+    return sortedCategories;
+  }, [isSearching, filteredByCategory, sortedCategories]);
+
+  // Set of stencil IDs that match the current search (for filtering loaded stencils)
+  const matchingStencilIds = useMemo(() => {
+    if (!isSearching) return null;
+    const ids = new Set<string>();
+    for (const metas of filteredByCategory.values()) {
+      for (const meta of metas) {
+        ids.add(meta.id);
+      }
+    }
+    return ids;
+  }, [isSearching, filteredByCategory]);
+
+  // Reset "show more" expansion when search changes
+  useEffect(() => {
+    setExpandedCategories(new Set());
+  }, [debouncedQuery]);
+
+  // Load stencils for visible categories
   useEffect(() => {
     if (!isOpen) return;
+    let cancelled = false;
 
-    for (const category of categories) {
-      if (collapsedCategories.has(category)) continue;
+    for (const category of visibleCategories) {
+      // Skip collapsed categories (but always load if searching)
+      if (!isSearching && collapsedCategories.has(category)) continue;
       if (loadedStencils.has(category)) continue;
       if (loadingCategories.has(category)) continue;
 
@@ -140,6 +184,7 @@ export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
 
       getCategoryStencils(category).then(
         (stencils) => {
+          if (cancelled) return;
           setLoadedStencils((prev) => new Map(prev).set(category, stencils));
           setLoadingCategories((prev) => {
             const next = new Set(prev);
@@ -148,7 +193,7 @@ export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
           });
         },
         () => {
-          // On error, clear loading state so it can be retried
+          if (cancelled) return;
           setLoadingCategories((prev) => {
             const next = new Set(prev);
             next.delete(category);
@@ -157,10 +202,27 @@ export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
         },
       );
     }
-  }, [isOpen, categories, collapsedCategories, loadedStencils, loadingCategories]);
+
+    return () => {
+      cancelled = true;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, visibleCategories, isSearching, collapsedCategories]);
 
   const toggleCategory = useCallback((category: string) => {
     setCollapsedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleShowMore = useCallback((category: string) => {
+    setExpandedCategories((prev) => {
       const next = new Set(prev);
       if (next.has(category)) {
         next.delete(category);
@@ -201,6 +263,10 @@ export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
     [],
   );
 
+  const handleClearSearch = useCallback(() => {
+    setSearchInput('');
+  }, []);
+
   if (!isOpen) {
     return null;
   }
@@ -227,13 +293,109 @@ export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
         fontFamily: 'system-ui, -apple-system, sans-serif',
       }}
     >
-      {categories.map((category) => {
-        const isCollapsed = collapsedCategories.has(category);
+      {/* Search input */}
+      <div style={{ position: 'relative', marginBottom: 8 }}>
+        <Search
+          size={14}
+          style={{
+            position: 'absolute',
+            left: 8,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            color: '#999',
+            pointerEvents: 'none',
+          }}
+        />
+        <input
+          data-testid="stencil-search-input"
+          type="text"
+          placeholder="Search stencils…"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          aria-label="Search stencils"
+          style={{
+            width: '100%',
+            padding: '6px 28px 6px 28px',
+            border: '1px solid var(--border, #e0e0e0)',
+            borderRadius: 6,
+            fontSize: 12,
+            fontFamily: 'inherit',
+            backgroundColor: 'var(--bg-toolbar, #ffffff)',
+            color: 'var(--text-primary, #333333)',
+            outline: 'none',
+            boxSizing: 'border-box',
+          }}
+        />
+        {searchInput && (
+          <button
+            type="button"
+            data-testid="stencil-search-clear"
+            aria-label="Clear search"
+            onClick={handleClearSearch}
+            style={{
+              position: 'absolute',
+              right: 4,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 2,
+              color: '#999',
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <X size={12} />
+          </button>
+        )}
+      </div>
+
+      {/* No results message */}
+      {isSearching && visibleCategories.length === 0 && (
+        <div
+          data-testid="stencil-search-no-results"
+          style={{
+            textAlign: 'center',
+            padding: '16px 0',
+            fontSize: 12,
+            color: '#999',
+          }}
+        >
+          No stencils found
+        </div>
+      )}
+
+      {/* Category list */}
+      {visibleCategories.map((category) => {
+        const isCollapsed = !isSearching && collapsedCategories.has(category);
         const stencils = loadedStencils.get(category);
         const isLoading = loadingCategories.has(category);
         const displayName = getCategoryDisplayName(category);
-        const stencilCount = stencils?.length;
+        const totalCount = categoryCounts.get(category) ?? 0;
+        const isExpanded = expandedCategories.has(category);
         const ChevronIcon = isCollapsed ? ChevronRight : ChevronDown;
+
+        // Filter loaded stencils by search matches
+        const visibleStencils = stencils
+          ? (matchingStencilIds
+              ? stencils.filter((s) => matchingStencilIds.has(s.id))
+              : stencils)
+          : undefined;
+
+        // Apply "show more" limit (only when not searching)
+        const needsShowMore =
+          !isSearching &&
+          visibleStencils !== undefined &&
+          visibleStencils.length > INITIAL_RENDER_LIMIT;
+        const renderedStencils =
+          needsShowMore && !isExpanded
+            ? visibleStencils!.slice(0, INITIAL_RENDER_LIMIT)
+            : visibleStencils;
+        const remainingCount =
+          needsShowMore && visibleStencils
+            ? visibleStencils.length - INITIAL_RENDER_LIMIT
+            : 0;
 
         return (
           <div key={category} style={{ marginBottom: 4 }}>
@@ -271,6 +433,7 @@ export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
               <ChevronIcon size={14} />
               <span>{displayName}</span>
               <span
+                data-testid={`category-count-${category}`}
                 style={{
                   marginLeft: 'auto',
                   fontSize: 10,
@@ -278,7 +441,7 @@ export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
                   fontWeight: 400,
                 }}
               >
-                {stencilCount !== undefined ? stencilCount : ''}
+                {totalCount}
               </span>
             </button>
 
@@ -297,23 +460,76 @@ export function StencilPalette({ onInsert, isOpen }: StencilPaletteProps) {
               </div>
             )}
 
-            {!isCollapsed && stencils && (
+            {!isCollapsed && renderedStencils && (
               <div
                 style={{
-                  display: 'grid',
-                  gridTemplateColumns: `repeat(${GRID_COLUMNS}, 1fr)`,
-                  gap: 4,
-                  padding: '4px 0',
+                  maxHeight: 400,
+                  overflowY: 'auto',
                 }}
               >
-                {stencils.map((entry) => (
-                  <StencilItem
-                    key={entry.id}
-                    entry={entry}
-                    onClick={handleStencilClick}
-                    onDragStart={handleDragStart}
-                  />
-                ))}
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: `repeat(${GRID_COLUMNS}, 1fr)`,
+                    gap: 4,
+                    padding: '4px 0',
+                  }}
+                >
+                  {renderedStencils.map((entry) => (
+                    <StencilItem
+                      key={entry.id}
+                      entry={entry}
+                      onClick={handleStencilClick}
+                      onDragStart={handleDragStart}
+                    />
+                  ))}
+                </div>
+
+                {/* Show more button */}
+                {needsShowMore && !isExpanded && (
+                  <button
+                    type="button"
+                    data-testid={`show-more-${category}`}
+                    onClick={() => toggleShowMore(category)}
+                    style={{
+                      display: 'block',
+                      width: '100%',
+                      padding: '4px 0',
+                      border: 'none',
+                      borderRadius: 4,
+                      cursor: 'pointer',
+                      backgroundColor: 'transparent',
+                      color: '#4A90D9',
+                      fontSize: 11,
+                      fontFamily: 'inherit',
+                      textAlign: 'center',
+                    }}
+                  >
+                    Show {remainingCount} more…
+                  </button>
+                )}
+                {needsShowMore && isExpanded && (
+                  <button
+                    type="button"
+                    data-testid={`show-less-${category}`}
+                    onClick={() => toggleShowMore(category)}
+                    style={{
+                      display: 'block',
+                      width: '100%',
+                      padding: '4px 0',
+                      border: 'none',
+                      borderRadius: 4,
+                      cursor: 'pointer',
+                      backgroundColor: 'transparent',
+                      color: '#4A90D9',
+                      fontSize: 11,
+                      fontFamily: 'inherit',
+                      textAlign: 'center',
+                    }}
+                  >
+                    Show less
+                  </button>
+                )}
               </div>
             )}
           </div>
@@ -333,15 +549,21 @@ interface StencilItemProps {
 }
 
 /**
- * Individual stencil thumbnail with label.
+ * Individual stencil thumbnail with label and tooltip.
  *
  * Renders a small SVG preview (48×48) with the stencil label below.
  * Supports click-to-place and drag-to-place interactions.
+ * Memoized to avoid unnecessary re-renders when parent state changes.
  */
-function StencilItem({ entry, onClick, onDragStart }: StencilItemProps) {
+const StencilItem = memo(function StencilItem({
+  entry,
+  onClick,
+  onDragStart,
+}: StencilItemProps) {
   return (
     <div
       data-testid={`stencil-item-${entry.id}`}
+      title={entry.label}
       draggable="true"
       onClick={() => onClick(entry)}
       onDragStart={(e) => onDragStart(e, entry)}
@@ -399,4 +621,4 @@ function StencilItem({ entry, onClick, onDragStart }: StencilItemProps) {
       </span>
     </div>
   );
-}
+});

--- a/packages/app/src/components/toolbar/stencilPaletteUtils.ts
+++ b/packages/app/src/components/toolbar/stencilPaletteUtils.ts
@@ -1,0 +1,158 @@
+/**
+ * Pure utility functions for StencilPalette search, sorting, and filtering.
+ *
+ * Extracted from the component to enable thorough unit testing
+ * without React dependencies. All functions are stateless and side-effect free.
+ *
+ * @module
+ */
+
+import type { StencilMeta } from '@infinicanvas/engine';
+
+// ── Constants ──────────────────────────────────────────────
+
+/**
+ * Hand-crafted categories shown first in the palette, in display order.
+ * Imported/generated categories (drawio-*) appear after these, sorted alphabetically.
+ */
+const PRIORITY_CATEGORIES: readonly string[] = [
+  'network',
+  'architecture',
+  'kubernetes',
+  'azure',
+  'azure-arm',
+  'generic-it',
+  'security',
+];
+
+/** Maximum stencils to render initially before showing a "Show more" button. */
+export const INITIAL_RENDER_LIMIT = 50;
+
+/** Debounce delay for search input in milliseconds. */
+export const SEARCH_DEBOUNCE_MS = 200;
+
+// ── Search / Filter ────────────────────────────────────────
+
+/**
+ * Filter stencils by a search query across all categories.
+ *
+ * Performs case-insensitive substring matching on the stencil label.
+ * Returns results grouped by category (sorted via `sortCategories`).
+ * Returns all stencils grouped by category when query is empty.
+ *
+ * @param allMeta - All available stencil metadata (sync, no SVG content).
+ * @param query   - Search query string. Empty string returns all.
+ * @returns Map of category → matching StencilMeta[], sorted by category priority.
+ */
+export function filterStencilsBySearch(
+  allMeta: readonly StencilMeta[],
+  query: string,
+): Map<string, StencilMeta[]> {
+  const normalizedQuery = query.trim().toLowerCase();
+  const grouped = new Map<string, StencilMeta[]>();
+
+  for (const meta of allMeta) {
+    if (normalizedQuery && !meta.label.toLowerCase().includes(normalizedQuery)) {
+      continue;
+    }
+    const list = grouped.get(meta.category) ?? [];
+    list.push(meta);
+    grouped.set(meta.category, list);
+  }
+
+  // Return sorted map
+  const sortedCategories = sortCategories([...grouped.keys()]);
+  const sorted = new Map<string, StencilMeta[]>();
+  for (const cat of sortedCategories) {
+    const entries = grouped.get(cat);
+    if (entries) {
+      sorted.set(cat, entries);
+    }
+  }
+
+  return sorted;
+}
+
+// ── Category Sorting ───────────────────────────────────────
+
+/**
+ * Sort categories in logical display order.
+ *
+ * Priority:
+ * 1. Hand-crafted categories in `PRIORITY_CATEGORIES` order.
+ * 2. Remaining categories sorted alphabetically.
+ *
+ * Unknown categories not in the priority list appear after priority ones.
+ *
+ * @param categories - Array of category identifiers to sort.
+ * @returns New sorted array (does not mutate input).
+ */
+export function sortCategories(categories: readonly string[]): string[] {
+  const prioritySet = new Set(PRIORITY_CATEGORIES);
+
+  const priority: string[] = [];
+  const rest: string[] = [];
+
+  for (const cat of categories) {
+    if (prioritySet.has(cat)) {
+      priority.push(cat);
+    } else {
+      rest.push(cat);
+    }
+  }
+
+  // Sort priority categories by their defined order
+  priority.sort(
+    (a, b) => PRIORITY_CATEGORIES.indexOf(a) - PRIORITY_CATEGORIES.indexOf(b),
+  );
+
+  // Sort remaining categories alphabetically
+  rest.sort((a, b) => a.localeCompare(b));
+
+  return [...priority, ...rest];
+}
+
+// ── Category Counts ────────────────────────────────────────
+
+/**
+ * Compute stencil counts per category from metadata.
+ *
+ * @param allMeta - All available stencil metadata.
+ * @returns Map of category → stencil count.
+ */
+export function getCategoryCounts(
+  allMeta: readonly StencilMeta[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const meta of allMeta) {
+    counts.set(meta.category, (counts.get(meta.category) ?? 0) + 1);
+  }
+  return counts;
+}
+
+// ── Display Names ──────────────────────────────────────────
+
+/** Map from kebab-case category IDs to human-readable display names. */
+const CATEGORY_DISPLAY_NAMES: Record<string, string> = {
+  architecture: 'Architecture',
+  azure: 'Azure',
+  'azure-arm': 'Azure ARM',
+  'generic-it': 'Generic IT',
+  kubernetes: 'Kubernetes',
+  network: 'Network',
+  security: 'Security',
+};
+
+/**
+ * Returns a human-readable display name for a category slug.
+ * Falls back to title-casing the slug if not found in the map.
+ */
+export function getCategoryDisplayName(category: string): string {
+  return (
+    CATEGORY_DISPLAY_NAMES[category] ??
+    category
+      .split('-')
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ')
+  );
+}

--- a/packages/app/src/hooks/useDebouncedValue.ts
+++ b/packages/app/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,36 @@
+/**
+ * useDebouncedValue — delays updating a value until a pause in changes.
+ *
+ * Used by StencilPalette to debounce the search input, avoiding
+ * re-filtering on every keystroke.
+ *
+ * @module
+ */
+
+import { useState, useEffect } from 'react';
+
+/**
+ * Returns a debounced version of the input value.
+ *
+ * The returned value only updates after `delay` milliseconds
+ * have passed since the last change to `value`.
+ *
+ * @param value - The value to debounce.
+ * @param delay - Debounce delay in milliseconds.
+ * @returns The debounced value.
+ */
+export function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary

Enhanced stencil palette to handle 1,700+ stencils with search, count badges, pagination, and performance optimizations.

### Epic: #99 — Completes the stencil ingestion epic! 🎉

### Includes
- **Search/filter** with 200ms debounce across all categories (sync metadata, no SVG loading)
- **Category count badges** (e.g., 'AWS (1,037)')
- **'Show more' pagination** — initial 50 per category, load rest on demand
- **Priority sorting** — hand-crafted categories first, draw.io imported after
- **Tooltips** on stencil items
- **Performance:** React.memo on items, useMemo for categories, cleanup on unmount
- **Pure utility extraction** in stencilPaletteUtils.ts (22 unit tests)

### Tests: 48 passing (22 utility + 16 existing + 10 new feature)

Closes #103

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>