### PR TITLE
feat: add 20 Fortinet security stencils

### DIFF
--- a/packages/engine/src/__tests__/stencilCatalog.test.ts
+++ b/packages/engine/src/__tests__/stencilCatalog.test.ts
@@ -156,6 +156,63 @@ describe('getStencil — architecture stencils', () => {
   });
 });
 
+// ── getStencil — Fortinet category ────────────────────────
+
+describe('getStencil — fortinet stencils', () => {
+  const fortinetStencils: Array<{ id: string; label: string }> = [
+    { id: 'forti-gate', label: 'FortiGate' },
+    { id: 'forti-switch', label: 'FortiSwitch' },
+    { id: 'forti-ap', label: 'FortiAP' },
+    { id: 'forti-manager', label: 'FortiManager' },
+    { id: 'forti-analyzer', label: 'FortiAnalyzer' },
+    { id: 'forti-web', label: 'FortiWeb' },
+    { id: 'forti-mail', label: 'FortiMail' },
+    { id: 'forti-client', label: 'FortiClient' },
+    { id: 'forti-sandbox', label: 'FortiSandbox' },
+    { id: 'forti-siem', label: 'FortiSIEM' },
+    { id: 'forti-nac', label: 'FortiNAC' },
+    { id: 'forti-edr', label: 'FortiEDR' },
+    { id: 'forti-proxy', label: 'FortiProxy' },
+    { id: 'forti-ddos', label: 'FortiDDoS' },
+    { id: 'forti-adc', label: 'FortiADC' },
+    { id: 'forti-authenticator', label: 'FortiAuthenticator' },
+    { id: 'forti-token', label: 'FortiToken' },
+    { id: 'forti-extender', label: 'FortiExtender' },
+    { id: 'forti-deceptor', label: 'FortiDeceptor' },
+    { id: 'forti-soar', label: 'FortiSOAR' },
+  ];
+
+  for (const { id, label } of fortinetStencils) {
+    it(`returns the ${id} stencil entry`, async () => {
+      const entry = await getStencil(id);
+      expect(entry).toBeDefined();
+      expect(entry!.id).toBe(id);
+      expect(entry!.category).toBe('fortinet');
+      expect(entry!.label).toBe(label);
+      expect(entry!.svgContent).toContain('<svg');
+      expect(entry!.svgContent).toContain('</svg>');
+      expect(entry!.svgContent).toContain('currentColor');
+      expect(entry!.defaultSize).toEqual({ width: 44, height: 44 });
+    });
+  }
+
+  it('all fortinet SVGs use viewBox="0 0 64 64"', async () => {
+    for (const { id } of fortinetStencils) {
+      const entry = await getStencil(id);
+      expect(entry).toBeDefined();
+      expect(entry!.svgContent).toContain('viewBox="0 0 64 64"');
+    }
+  });
+
+  it('all fortinet SVGs contain xmlns attribute', async () => {
+    for (const { id } of fortinetStencils) {
+      const entry = await getStencil(id);
+      expect(entry).toBeDefined();
+      expect(entry!.svgContent).toContain('xmlns="http://www.w3.org/2000/svg"');
+    }
+  });
+});
+
 // ── getStencil — Kubernetes placeholder ───────────────────
 
 describe('getStencil — kubernetes placeholder', () => {
@@ -205,6 +262,34 @@ describe('getStencilsByCategory', () => {
     expect(entries.some((e) => e.id === 'k8s-pod')).toBe(true);
   });
 
+  it('returns 20 stencils in the fortinet category', () => {
+    const entries = getStencilsByCategory('fortinet');
+    expect(entries).toHaveLength(20);
+    const ids = entries.map((e) => e.id).sort();
+    expect(ids).toEqual([
+      'forti-adc',
+      'forti-analyzer',
+      'forti-ap',
+      'forti-authenticator',
+      'forti-client',
+      'forti-ddos',
+      'forti-deceptor',
+      'forti-edr',
+      'forti-extender',
+      'forti-gate',
+      'forti-mail',
+      'forti-manager',
+      'forti-nac',
+      'forti-proxy',
+      'forti-sandbox',
+      'forti-siem',
+      'forti-soar',
+      'forti-switch',
+      'forti-token',
+      'forti-web',
+    ]);
+  });
+
   it('returns empty array for unknown category', () => {
     expect(getStencilsByCategory('nonexistent')).toEqual([]);
   });
@@ -217,26 +302,27 @@ describe('getStencilsByCategory', () => {
 // ── getAllCategories ───────────────────────────────────────
 
 describe('getAllCategories', () => {
-  it('returns all 6 unique categories', () => {
+  it('returns all 8 unique categories', () => {
     const categories = getAllCategories();
     expect(categories).toContain('architecture');
     expect(categories).toContain('azure');
     expect(categories).toContain('azure-arm');
+    expect(categories).toContain('fortinet');
     expect(categories).toContain('generic-it');
     expect(categories).toContain('kubernetes');
     expect(categories).toContain('network');
   });
 
   it('returns the correct number of categories', () => {
-    expect(getAllCategories()).toHaveLength(7);
+    expect(getAllCategories()).toHaveLength(8);
   });
 });
 
 // ── STENCIL_CATALOG integrity ─────────────────────────────
 
 describe('STENCIL_CATALOG', () => {
-  it('contains all 56 eager stencil entries', () => {
-    expect(STENCIL_CATALOG.size).toBe(56);
+  it('contains all 76 eager stencil entries', () => {
+    expect(STENCIL_CATALOG.size).toBe(76);
   });
 
   it('has map keys matching entry IDs', () => {

--- a/packages/engine/src/renderer/stencils/stencilCatalog.ts
+++ b/packages/engine/src/renderer/stencils/stencilCatalog.ts
@@ -82,6 +82,28 @@ import {
   ARM_APP_SERVICE_SVG,
   ARM_CONTAINER_REGISTRY_SVG,
 } from './svgs/azureArm.js';
+import {
+  FORTI_GATE_SVG,
+  FORTI_SWITCH_SVG,
+  FORTI_AP_SVG,
+  FORTI_MANAGER_SVG,
+  FORTI_ANALYZER_SVG,
+  FORTI_WEB_SVG,
+  FORTI_MAIL_SVG,
+  FORTI_CLIENT_SVG,
+  FORTI_SANDBOX_SVG,
+  FORTI_SIEM_SVG,
+  FORTI_NAC_SVG,
+  FORTI_EDR_SVG,
+  FORTI_PROXY_SVG,
+  FORTI_DDOS_SVG,
+  FORTI_ADC_SVG,
+  FORTI_AUTHENTICATOR_SVG,
+  FORTI_TOKEN_SVG,
+  FORTI_EXTENDER_SVG,
+  FORTI_DECEPTOR_SVG,
+  FORTI_SOAR_SVG,
+} from './svgs/fortinet.js';
 
 /**
  * Lightweight stencil metadata — always available, no SVG content.
@@ -559,6 +581,28 @@ export const STENCIL_CATALOG: Map<string, StencilEntry> = new Map([
       defaultSize: { width: 64, height: 64 },
     },
   ],
+
+  // ── Fortinet ──────────────────────────────────────────────
+  ['forti-gate', { id: 'forti-gate', category: 'fortinet', label: 'FortiGate', svgContent: FORTI_GATE_SVG, defaultSize: ICON_SIZE }],
+  ['forti-switch', { id: 'forti-switch', category: 'fortinet', label: 'FortiSwitch', svgContent: FORTI_SWITCH_SVG, defaultSize: ICON_SIZE }],
+  ['forti-ap', { id: 'forti-ap', category: 'fortinet', label: 'FortiAP', svgContent: FORTI_AP_SVG, defaultSize: ICON_SIZE }],
+  ['forti-manager', { id: 'forti-manager', category: 'fortinet', label: 'FortiManager', svgContent: FORTI_MANAGER_SVG, defaultSize: ICON_SIZE }],
+  ['forti-analyzer', { id: 'forti-analyzer', category: 'fortinet', label: 'FortiAnalyzer', svgContent: FORTI_ANALYZER_SVG, defaultSize: ICON_SIZE }],
+  ['forti-web', { id: 'forti-web', category: 'fortinet', label: 'FortiWeb', svgContent: FORTI_WEB_SVG, defaultSize: ICON_SIZE }],
+  ['forti-mail', { id: 'forti-mail', category: 'fortinet', label: 'FortiMail', svgContent: FORTI_MAIL_SVG, defaultSize: ICON_SIZE }],
+  ['forti-client', { id: 'forti-client', category: 'fortinet', label: 'FortiClient', svgContent: FORTI_CLIENT_SVG, defaultSize: ICON_SIZE }],
+  ['forti-sandbox', { id: 'forti-sandbox', category: 'fortinet', label: 'FortiSandbox', svgContent: FORTI_SANDBOX_SVG, defaultSize: ICON_SIZE }],
+  ['forti-siem', { id: 'forti-siem', category: 'fortinet', label: 'FortiSIEM', svgContent: FORTI_SIEM_SVG, defaultSize: ICON_SIZE }],
+  ['forti-nac', { id: 'forti-nac', category: 'fortinet', label: 'FortiNAC', svgContent: FORTI_NAC_SVG, defaultSize: ICON_SIZE }],
+  ['forti-edr', { id: 'forti-edr', category: 'fortinet', label: 'FortiEDR', svgContent: FORTI_EDR_SVG, defaultSize: ICON_SIZE }],
+  ['forti-proxy', { id: 'forti-proxy', category: 'fortinet', label: 'FortiProxy', svgContent: FORTI_PROXY_SVG, defaultSize: ICON_SIZE }],
+  ['forti-ddos', { id: 'forti-ddos', category: 'fortinet', label: 'FortiDDoS', svgContent: FORTI_DDOS_SVG, defaultSize: ICON_SIZE }],
+  ['forti-adc', { id: 'forti-adc', category: 'fortinet', label: 'FortiADC', svgContent: FORTI_ADC_SVG, defaultSize: ICON_SIZE }],
+  ['forti-authenticator', { id: 'forti-authenticator', category: 'fortinet', label: 'FortiAuthenticator', svgContent: FORTI_AUTHENTICATOR_SVG, defaultSize: ICON_SIZE }],
+  ['forti-token', { id: 'forti-token', category: 'fortinet', label: 'FortiToken', svgContent: FORTI_TOKEN_SVG, defaultSize: ICON_SIZE }],
+  ['forti-extender', { id: 'forti-extender', category: 'fortinet', label: 'FortiExtender', svgContent: FORTI_EXTENDER_SVG, defaultSize: ICON_SIZE }],
+  ['forti-deceptor', { id: 'forti-deceptor', category: 'fortinet', label: 'FortiDeceptor', svgContent: FORTI_DECEPTOR_SVG, defaultSize: ICON_SIZE }],
+  ['forti-soar', { id: 'forti-soar', category: 'fortinet', label: 'FortiSOAR', svgContent: FORTI_SOAR_SVG, defaultSize: ICON_SIZE }],
 ]);
 
 // ── Initialize metadata from eager catalog ────────────────

--- a/packages/engine/src/renderer/stencils/svgs/fortinet.ts
+++ b/packages/engine/src/renderer/stencils/svgs/fortinet.ts
@@ -1,0 +1,252 @@
+/**
+ * Fortinet security product SVG icons for the stencil catalog.
+ *
+ * Twenty monochrome line-art icons (64×64 viewBox) representing
+ * key Fortinet security and networking products. Each icon uses
+ * `currentColor` for fills/strokes to support theming.
+ *
+ * @module
+ */
+
+/** FortiGate — shield with firewall grid (flagship NGFW). */
+export const FORTI_GATE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M32 4L8 16v20c0 14 10 22 24 28 14-6 24-14 24-28V16L32 4z" />
+  <line x1="16" y1="24" x2="48" y2="24" />
+  <line x1="16" y1="34" x2="48" y2="34" />
+  <line x1="16" y1="44" x2="48" y2="44" />
+  <line x1="24" y1="16" x2="24" y2="24" />
+  <line x1="40" y1="16" x2="40" y2="24" />
+  <line x1="32" y1="24" x2="32" y2="34" />
+  <line x1="24" y1="34" x2="24" y2="44" />
+  <line x1="40" y1="34" x2="40" y2="44" />
+</svg>`;
+
+/** FortiSwitch — managed network switch with port array. */
+export const FORTI_SWITCH_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="4" y="16" width="56" height="32" rx="3" />
+  <rect x="10" y="22" width="6" height="8" rx="1" />
+  <rect x="19" y="22" width="6" height="8" rx="1" />
+  <rect x="28" y="22" width="6" height="8" rx="1" />
+  <rect x="37" y="22" width="6" height="8" rx="1" />
+  <rect x="46" y="22" width="6" height="8" rx="1" />
+  <circle cx="13" cy="40" r="2" fill="currentColor" />
+  <circle cx="22" cy="40" r="2" fill="currentColor" />
+  <circle cx="31" cy="40" r="2" fill="currentColor" />
+  <circle cx="40" cy="40" r="2" fill="currentColor" />
+  <circle cx="49" cy="40" r="2" fill="currentColor" />
+  <path d="M32 4 L28 12 H36 Z" fill="currentColor" stroke="none" />
+  <line x1="32" y1="12" x2="32" y2="16" />
+</svg>`;
+
+/** FortiAP — wireless access point with radio waves. */
+export const FORTI_AP_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="32" cy="40" r="4" fill="currentColor" />
+  <line x1="32" y1="44" x2="32" y2="56" />
+  <line x1="24" y1="56" x2="40" y2="56" />
+  <path d="M22 34 A14 14 0 0 1 42 34" fill="none" />
+  <path d="M16 28 A20 20 0 0 1 48 28" fill="none" />
+  <path d="M10 22 A26 26 0 0 1 54 22" fill="none" />
+</svg>`;
+
+/** FortiManager — centralized management dashboard with nodes. */
+export const FORTI_MANAGER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="32" cy="28" r="10" />
+  <path d="M28 22 L32 28 L36 22" />
+  <circle cx="32" cy="25" r="2" fill="currentColor" />
+  <circle cx="12" cy="52" r="6" />
+  <circle cx="32" cy="56" r="6" />
+  <circle cx="52" cy="52" r="6" />
+  <line x1="26" y1="36" x2="14" y2="46" />
+  <line x1="32" y1="38" x2="32" y2="50" />
+  <line x1="38" y1="36" x2="50" y2="46" />
+</svg>`;
+
+/** FortiAnalyzer — analytics chart with magnifying glass. */
+export const FORTI_ANALYZER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="6" y="6" width="40" height="36" rx="3" />
+  <polyline points="12,34 20,22 28,28 36,14" />
+  <circle cx="36" cy="14" r="2" fill="currentColor" />
+  <circle cx="48" cy="44" r="12" />
+  <line x1="56" y1="52" x2="62" y2="58" stroke-width="3" />
+  <line x1="6" y1="42" x2="46" y2="42" />
+</svg>`;
+
+/** FortiWeb — web application firewall (globe with shield). */
+export const FORTI_WEB_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="28" cy="32" r="20" />
+  <ellipse cx="28" cy="32" rx="8" ry="20" />
+  <line x1="8" y1="32" x2="48" y2="32" />
+  <line x1="28" y1="12" x2="28" y2="52" />
+  <path d="M48 36 L56 42 V52 C56 56 48 60 48 60 C48 60 40 56 40 52 V42 Z" fill="currentColor" opacity="0.2" />
+  <path d="M48 36 L56 42 V52 C56 56 48 60 48 60 C48 60 40 56 40 52 V42 Z" />
+</svg>`;
+
+/** FortiMail — secure email gateway (envelope with lock). */
+export const FORTI_MAIL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="6" y="14" width="42" height="30" rx="2" />
+  <polyline points="6,14 27,32 48,14" />
+  <rect x="42" y="38" width="16" height="14" rx="2" />
+  <path d="M46 38 V34 C46 30 54 30 54 34 V38" />
+  <circle cx="50" cy="46" r="2" fill="currentColor" />
+</svg>`;
+
+/** FortiClient — endpoint protection (laptop with shield). */
+export const FORTI_CLIENT_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="10" y="8" width="44" height="34" rx="2" />
+  <rect x="14" y="12" width="36" height="26" rx="1" />
+  <rect x="6" y="42" width="52" height="4" rx="2" />
+  <path d="M32 16 L40 20 V28 C40 32 32 36 32 36 C32 36 24 32 24 28 V20 Z" fill="currentColor" opacity="0.15" />
+  <path d="M32 16 L40 20 V28 C40 32 32 36 32 36 C32 36 24 32 24 28 V20 Z" />
+  <polyline points="28,25 31,28 37,22" stroke-width="2" />
+</svg>`;
+
+/** FortiSandbox — sandbox analysis (container with magnifying glass). */
+export const FORTI_SANDBOX_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M8 20 L32 8 L56 20 V40 L32 52 L8 40 Z" />
+  <line x1="32" y1="8" x2="32" y2="52" />
+  <line x1="8" y1="20" x2="56" y2="20" />
+  <circle cx="26" cy="32" r="6" />
+  <line x1="30" y1="36" x2="36" y2="42" stroke-width="2.5" />
+</svg>`;
+
+/** FortiSIEM — security event monitor (screen with alert eye). */
+export const FORTI_SIEM_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="8" y="6" width="48" height="36" rx="3" />
+  <path d="M32 50 C32 50 38 44 38 44 L26 44 C26 44 32 50 32 50Z" fill="currentColor" stroke="none" />
+  <line x1="22" y1="50" x2="42" y2="50" />
+  <path d="M16 24 C16 24 24 16 32 16 C40 16 48 24 48 24 C48 24 40 32 32 32 C24 32 16 24 16 24Z" />
+  <circle cx="32" cy="24" r="4" fill="currentColor" />
+  <circle cx="52" cy="10" r="3" fill="currentColor" opacity="0.5" />
+</svg>`;
+
+/** FortiNAC — network access control (gateway with lock). */
+export const FORTI_NAC_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="22" y="20" width="20" height="28" rx="2" />
+  <path d="M26 20 V14 C26 8 38 8 38 14 V20" />
+  <circle cx="32" cy="34" r="3" fill="currentColor" />
+  <line x1="32" y1="37" x2="32" y2="42" />
+  <line x1="4" y1="34" x2="22" y2="34" />
+  <line x1="42" y1="34" x2="60" y2="34" />
+  <circle cx="8" cy="34" r="4" />
+  <circle cx="56" cy="34" r="4" />
+  <circle cx="8" cy="20" r="4" />
+  <circle cx="56" cy="20" r="4" />
+  <line x1="8" y1="24" x2="8" y2="30" />
+  <line x1="56" y1="24" x2="56" y2="30" />
+</svg>`;
+
+/** FortiEDR — endpoint detection and response (laptop with crosshairs). */
+export const FORTI_EDR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="10" y="10" width="44" height="32" rx="2" />
+  <rect x="6" y="42" width="52" height="4" rx="2" />
+  <circle cx="32" cy="26" r="8" />
+  <line x1="32" y1="14" x2="32" y2="20" />
+  <line x1="32" y1="32" x2="32" y2="38" />
+  <line x1="20" y1="26" x2="26" y2="26" />
+  <line x1="38" y1="26" x2="44" y2="26" />
+  <circle cx="32" cy="26" r="2" fill="currentColor" />
+</svg>`;
+
+/** FortiProxy — secure web proxy (funnel with arrows). */
+export const FORTI_PROXY_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M10 12 H54 L38 32 V48 H26 V32 Z" />
+  <line x1="32" y1="48" x2="32" y2="58" />
+  <polygon points="32,60 28,54 36,54" fill="currentColor" stroke="none" />
+  <line x1="4" y1="8" x2="14" y2="8" />
+  <polygon points="16,8 10,5 10,11" fill="currentColor" stroke="none" />
+  <line x1="50" y1="8" x2="60" y2="8" />
+  <polygon points="48,8 54,5 54,11" fill="currentColor" stroke="none" />
+  <path d="M24 20 L32 26 L40 20" />
+</svg>`;
+
+/** FortiDDoS — DDoS protection (shield deflecting waves). */
+export const FORTI_DDOS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M32 6 L50 16 V36 C50 44 32 54 32 54 C32 54 14 44 14 36 V16 Z" />
+  <line x1="24" y1="22" x2="24" y2="42" stroke-width="1.5" />
+  <line x1="32" y1="18" x2="32" y2="46" stroke-width="1.5" />
+  <line x1="40" y1="22" x2="40" y2="42" stroke-width="1.5" />
+  <path d="M4 22 C6 18 8 22 10 18" />
+  <path d="M4 30 C6 26 8 30 10 26" />
+  <path d="M4 38 C6 34 8 38 10 34" />
+  <path d="M54 22 C56 18 58 22 60 18" />
+  <path d="M54 30 C56 26 58 30 60 26" />
+  <path d="M54 38 C56 34 58 38 60 34" />
+</svg>`;
+
+/** FortiADC — application delivery controller (balanced arrows). */
+export const FORTI_ADC_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="20" y="8" width="24" height="16" rx="3" />
+  <circle cx="32" cy="16" r="3" fill="currentColor" />
+  <line x1="32" y1="24" x2="32" y2="30" />
+  <line x1="32" y1="30" x2="12" y2="42" />
+  <line x1="32" y1="30" x2="32" y2="42" />
+  <line x1="32" y1="30" x2="52" y2="42" />
+  <rect x="4" y="42" width="16" height="14" rx="2" />
+  <rect x="24" y="42" width="16" height="14" rx="2" />
+  <rect x="44" y="42" width="16" height="14" rx="2" />
+  <circle cx="12" cy="49" r="2" fill="currentColor" />
+  <circle cx="32" cy="49" r="2" fill="currentColor" />
+  <circle cx="52" cy="49" r="2" fill="currentColor" />
+</svg>`;
+
+/** FortiAuthenticator — authentication server (user with key). */
+export const FORTI_AUTHENTICATOR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="24" cy="16" r="8" />
+  <path d="M10 42 C10 32 18 28 24 28 C30 28 38 32 38 42" />
+  <circle cx="48" cy="28" r="6" />
+  <line x1="48" y1="34" x2="48" y2="52" />
+  <line x1="48" y1="40" x2="54" y2="38" />
+  <line x1="48" y1="46" x2="54" y2="44" />
+  <line x1="32" y1="36" x2="42" y2="30" />
+</svg>`;
+
+/** FortiToken — multi-factor authentication token (key fob with display). */
+export const FORTI_TOKEN_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="18" y="4" width="28" height="56" rx="6" />
+  <rect x="22" y="14" width="20" height="12" rx="2" />
+  <text x="32" y="24" text-anchor="middle" font-size="8" font-family="monospace" fill="currentColor" stroke="none">123456</text>
+  <circle cx="32" cy="42" r="6" />
+  <circle cx="32" cy="42" r="2" fill="currentColor" />
+  <circle cx="32" cy="54" r="2" fill="currentColor" />
+</svg>`;
+
+/** FortiExtender — WAN extender (antenna with signal extension). */
+export const FORTI_EXTENDER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="20" y="36" width="24" height="20" rx="3" />
+  <line x1="32" y1="36" x2="32" y2="16" stroke-width="2.5" />
+  <circle cx="32" cy="14" r="3" fill="currentColor" />
+  <path d="M22 20 A14 14 0 0 1 42 20" fill="none" />
+  <path d="M16 14 A20 20 0 0 1 48 14" fill="none" />
+  <circle cx="26" cy="44" r="2" fill="currentColor" />
+  <circle cx="38" cy="44" r="2" fill="currentColor" />
+  <line x1="24" y1="50" x2="40" y2="50" />
+</svg>`;
+
+/** FortiDeceptor — deception technology (honeypot trap). */
+export const FORTI_DECEPTOR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M16 42 L32 10 L48 42 Z" />
+  <line x1="24" y1="42" x2="40" y2="42" />
+  <circle cx="32" cy="30" r="4" fill="currentColor" opacity="0.3" />
+  <line x1="32" y1="26" x2="32" y2="20" />
+  <path d="M8 48 C8 44 16 42 24 42" />
+  <path d="M56 48 C56 44 48 42 40 42" />
+  <path d="M8 48 Q32 58 56 48" />
+  <line x1="28" y1="50" x2="28" y2="54" />
+  <line x1="36" y1="50" x2="36" y2="54" />
+  <line x1="32" y1="51" x2="32" y2="56" />
+</svg>`;
+
+/** FortiSOAR — security orchestration & automated response (dashboard with play). */
+export const FORTI_SOAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="4" y="6" width="56" height="40" rx="3" />
+  <line x1="4" y1="16" x2="60" y2="16" />
+  <circle cx="10" cy="11" r="2" fill="currentColor" />
+  <circle cx="18" cy="11" r="2" fill="currentColor" />
+  <circle cx="26" cy="11" r="2" fill="currentColor" />
+  <rect x="10" y="22" width="18" height="8" rx="1" fill="currentColor" opacity="0.15" />
+  <rect x="10" y="34" width="12" height="6" rx="1" fill="currentColor" opacity="0.15" />
+  <polygon points="42,22 42,38 54,30" fill="currentColor" opacity="0.3" />
+  <polygon points="42,22 42,38 54,30" />
+  <line x1="22" y1="52" x2="42" y2="52" />
+  <path d="M32 46 L38 52 H26 Z" fill="currentColor" stroke="none" />
+</svg>`;


### PR DESCRIPTION
## Summary

20 hand-crafted Fortinet product stencils: FortiGate, FortiSwitch, FortiAP, FortiManager, FortiAnalyzer, FortiWeb, FortiMail, FortiClient, FortiSandbox, FortiSIEM, FortiNAC, FortiEDR, FortiProxy, FortiDDoS, FortiADC, FortiAuthenticator, FortiToken, FortiExtender, FortiDeceptor, FortiSOAR.

Clean monochrome line-art using `currentColor`, matching existing stencil style. 22 new tests.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>