### PR TITLE
fix: wire draw.io stencil registration into stencil module

### DIFF
--- a/packages/engine/src/renderer/stencils/index.ts
+++ b/packages/engine/src/renderer/stencils/index.ts
@@ -4,6 +4,9 @@
  * @module
  */
 
+// Side-effect import: registers draw.io stencils into STENCIL_CATALOG
+import './drawio/index.js';
+
 export type { StencilEntry, StencilMeta, CategoryLoader } from './stencilCatalog.js';
 export {
   STENCIL_CATALOG,


### PR DESCRIPTION
The 1,751 generated stencils existed but weren't imported. Adds side-effect import.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>