### PR TITLE
fix: sync draw.io stencil metadata for palette visibility

### DIFF
--- a/packages/engine/src/renderer/stencils/index.ts
+++ b/packages/engine/src/renderer/stencils/index.ts
@@ -7,6 +7,10 @@
 // Side-effect import: registers draw.io stencils into STENCIL_CATALOG
 import './drawio/index.js';
 
+// Re-sync metadata after draw.io side-effect registration
+import { _syncMetaFromCatalog } from './stencilCatalog.js';
+_syncMetaFromCatalog();
+
 export type { StencilEntry, StencilMeta, CategoryLoader } from './stencilCatalog.js';
 export {
   STENCIL_CATALOG,
@@ -20,4 +24,5 @@ export {
   registerCategoryMeta,
   svgToDataUri,
   _resetLazyState,
+  _syncMetaFromCatalog,
 } from './stencilCatalog.js';

--- a/packages/engine/src/renderer/stencils/stencilCatalog.ts
+++ b/packages/engine/src/renderer/stencils/stencilCatalog.ts
@@ -607,15 +607,25 @@ export const STENCIL_CATALOG: Map<string, StencilEntry> = new Map([
 
 // ── Initialize metadata from eager catalog ────────────────
 
-for (const [_id, entry] of STENCIL_CATALOG) {
-  STENCIL_META.set(entry.id, {
-    id: entry.id,
-    label: entry.label,
-    category: entry.category,
-    defaultSize: { width: entry.defaultSize.width, height: entry.defaultSize.height },
-  });
-  LOADED_CATEGORIES.add(entry.category);
+function syncMetaFromCatalog(): void {
+  for (const [_id, entry] of STENCIL_CATALOG) {
+    if (!STENCIL_META.has(entry.id)) {
+      STENCIL_META.set(entry.id, {
+        id: entry.id,
+        label: entry.label,
+        category: entry.category,
+        defaultSize: { width: entry.defaultSize.width, height: entry.defaultSize.height },
+      });
+      LOADED_CATEGORIES.add(entry.category);
+    }
+  }
 }
+
+// Run once for hand-crafted stencils registered above
+syncMetaFromCatalog();
+
+/** Re-sync metadata after late registrations (e.g., draw.io side-effect imports). */
+export { syncMetaFromCatalog as _syncMetaFromCatalog };
 
 // ── Internal: lazy loading engine ─────────────────────────
 


### PR DESCRIPTION
Draw.io stencils registered into STENCIL_CATALOG but metadata wasn't synced — palette only showed hand-crafted stencils. Now re-syncs after side-effect import.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>