### PR TITLE
fix: stencil rendering — transparent backgrounds + resize threshold

### DIFF
--- a/packages/engine/src/renderer/primitiveRenderer.ts
+++ b/packages/engine/src/renderer/primitiveRenderer.ts
@@ -806,7 +806,7 @@ function renderStencil(
   if (img) {
     ctx.save();
     ctx.globalAlpha = opacity;
-    const isContainer = Math.min(width, height) > 80;
+    const isContainer = Math.min(width, height) > 200;
     if (isContainer) {
       // Container: draw dashed border + small icon at top-left
       ctx.strokeStyle = strokeColor;

--- a/packages/protocol/src/drawio/stencilParser.ts
+++ b/packages/protocol/src/drawio/stencilParser.ts
@@ -370,9 +370,12 @@ function convertShapeNodeToSvg(shapeNode: XmlNode, width: number, height: number
   const groups: string[] = [];
 
   // Process <background> section
+  // Background shapes define the outline — use fill="none" so the expression's
+  // backgroundColor controls fill at render time (avoids solid black blobs).
   const bg = shapeNode['background'] as XmlNode | undefined;
   if (bg) {
-    const bgElements = processSection(bg, state);
+    const bgState = { ...state, fillColor: 'none' };
+    const bgElements = processSection(bg, bgState);
     if (bgElements.length > 0) {
       groups.push(`  <g class="background">\n    ${bgElements.join('\n    ')}\n  </g>`);
     }


### PR DESCRIPTION
Fixes two bugs:
1. **Black blobs** — background `<fillstroke/>` now uses `fill=none` instead of `currentColor`
2. **Resize snap-back** — container-mode threshold raised from 80px to 200px

Regenerated all 1,751 stencils.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>