### PR TITLE
feat: 32 hand-crafted Azure Pro stencils — replaces old azure + azure-arm

### DIFF
--- a/packages/engine/src/__tests__/cloudStencils.test.ts
+++ b/packages/engine/src/__tests__/cloudStencils.test.ts
@@ -1,7 +1,7 @@
 /**
- * Unit tests for cloud stencil SVGs (Sub-ticket C).
+ * Unit tests for cloud stencil SVGs.
  *
- * Covers: Azure (6), Kubernetes (10), Azure ARM (10) stencil entries.
+ * Covers: Azure Pro (30), Kubernetes (10) stencil entries.
  * Verifies catalog registration, category counts, SVG validity,
  * default sizes, and container-type dimensions.
  *
@@ -15,15 +15,47 @@ import {
   getStencilsByCategory,
 } from '../renderer/stencils/index.js';
 
-// ── Azure stencil IDs ─────────────────────────────────────
+// ── Azure Pro stencil IDs ─────────────────────────────────
 
-const AZURE_IDS = [
-  'azure-app-gateway',
-  'azure-aks',
-  'azure-storage',
-  'azure-sql',
-  'azure-functions',
-  'azure-vnet',
+const AZURE_PRO_IDS = [
+  // Compute
+  'azure-pro-virtual-machines',
+  'azure-pro-app-service',
+  'azure-pro-functions',
+  'azure-pro-aks',
+  'azure-pro-container-instances',
+  'azure-pro-vmss',
+  // Storage
+  'azure-pro-blob-storage',
+  'azure-pro-file-storage',
+  'azure-pro-disk-storage',
+  'azure-pro-data-lake',
+  // Database
+  'azure-pro-sql-database',
+  'azure-pro-cosmos-db',
+  'azure-pro-mysql',
+  'azure-pro-postgresql',
+  'azure-pro-redis-cache',
+  // Networking
+  'azure-pro-virtual-network',
+  'azure-pro-load-balancer',
+  'azure-pro-application-gateway',
+  'azure-pro-front-door',
+  'azure-pro-dns-zone',
+  'azure-pro-expressroute',
+  // Security
+  'azure-pro-key-vault',
+  'azure-pro-active-directory',
+  'azure-pro-sentinel',
+  'azure-pro-ddos-protection',
+  // Management
+  'azure-pro-monitor',
+  'azure-pro-log-analytics',
+  'azure-pro-devops',
+  'azure-pro-resource-group',
+  // AI
+  'azure-pro-cognitive-services',
+  'azure-pro-openai-service',
 ] as const;
 
 // ── Kubernetes stencil IDs ────────────────────────────────
@@ -41,65 +73,64 @@ const K8S_IDS = [
   'k8s-cluster',
 ] as const;
 
-// ── Azure ARM stencil IDs ─────────────────────────────────
-
-const ARM_IDS = [
-  'arm-resource-group',
-  'arm-subscription',
-  'arm-management-group',
-  'arm-virtual-machine',
-  'arm-vnet',
-  'arm-subnet',
-  'arm-nsg',
-  'arm-key-vault',
-  'arm-app-service',
-  'arm-container-registry',
-] as const;
-
 // ── Container stencils with larger default sizes ──────────
 
 const CONTAINER_SIZES: Record<string, { width: number; height: number }> = {
   'k8s-namespace': { width: 200, height: 150 },
   'k8s-cluster': { width: 250, height: 200 },
-  'arm-resource-group': { width: 200, height: 150 },
-  'arm-subscription': { width: 250, height: 200 },
-  'arm-management-group': { width: 300, height: 200 },
 };
 
-// ── All 26 cloud stencil IDs ──────────────────────────────
+// ── All cloud stencil IDs ──────────────────────────────────
 
-const ALL_CLOUD_IDS = [...AZURE_IDS, ...K8S_IDS, ...ARM_IDS];
+const ALL_CLOUD_IDS = [...AZURE_PRO_IDS, ...K8S_IDS];
 
-// ── Azure stencils ────────────────────────────────────────
+// ── Azure Pro stencils ───────────────────────────────────
 
-describe('Azure stencils', () => {
-  it.each(AZURE_IDS)('registers %s in the catalog', async (id) => {
+describe('Azure Pro stencils', () => {
+  it.each(AZURE_PRO_IDS)('registers %s in the catalog', async (id) => {
     const entry = await getStencil(id);
     expect(entry).toBeDefined();
     expect(entry!.id).toBe(id);
-    expect(entry!.category).toBe('azure');
+    expect(entry!.category).toBe('azure-pro');
   });
 
-  it('has exactly 14 azure stencils', () => {
-    const entries = getStencilsByCategory('azure');
-    expect(entries).toHaveLength(14);
+  it('has exactly 31 azure-pro stencils', () => {
+    const entries = getStencilsByCategory('azure-pro');
+    expect(entries).toHaveLength(31);
   });
 
-  it.each(AZURE_IDS)('%s has valid SVG content', async (id) => {
+  it.each(AZURE_PRO_IDS)('%s has valid SVG content', async (id) => {
     const entry = await getStencil(id);
     expect(entry!.svgContent).toContain('<svg');
     expect(entry!.svgContent).toContain('</svg>');
     expect(entry!.svgContent).toContain('xmlns="http://www.w3.org/2000/svg"');
   });
 
-  it.each(AZURE_IDS)('%s has 64×64 default size', async (id) => {
+  it.each(AZURE_PRO_IDS)('%s has 44×44 default size (ICON_SIZE)', async (id) => {
     const entry = await getStencil(id);
-    expect(entry!.defaultSize).toEqual({ width: 64, height: 64 });
+    expect(entry!.defaultSize).toEqual({ width: 44, height: 44 });
   });
 
-  it.each(AZURE_IDS)('%s has a non-empty label', async (id) => {
+  it.each(AZURE_PRO_IDS)('%s has a non-empty label', async (id) => {
     const entry = await getStencil(id);
     expect(entry!.label.length).toBeGreaterThan(0);
+  });
+
+  it.each(AZURE_PRO_IDS)('%s has 64×64 viewBox', async (id) => {
+    const entry = await getStencil(id);
+    expect(entry!.svgContent).toContain('viewBox="0 0 64 64"');
+  });
+
+  it.each(AZURE_PRO_IDS)('%s uses currentColor for theming', async (id) => {
+    const entry = await getStencil(id);
+    expect(entry!.svgContent).toContain('currentColor');
+  });
+
+  it('old azure and azure-arm categories are removed', () => {
+    const azureEntries = getStencilsByCategory('azure');
+    const armEntries = getStencilsByCategory('azure-arm');
+    expect(azureEntries).toHaveLength(0);
+    expect(armEntries).toHaveLength(0);
   });
 });
 
@@ -153,59 +184,6 @@ describe('Kubernetes stencils', () => {
   });
 });
 
-// ── Azure ARM stencils ────────────────────────────────────
-
-describe('Azure ARM stencils', () => {
-  it.each(ARM_IDS)('registers %s in the catalog', async (id) => {
-    const entry = await getStencil(id);
-    expect(entry).toBeDefined();
-    expect(entry!.id).toBe(id);
-    expect(entry!.category).toBe('azure-arm');
-  });
-
-  it('has exactly 10 azure-arm stencils', () => {
-    const entries = getStencilsByCategory('azure-arm');
-    expect(entries).toHaveLength(10);
-  });
-
-  it.each(ARM_IDS)('%s has valid SVG content', async (id) => {
-    const entry = await getStencil(id);
-    expect(entry!.svgContent).toContain('<svg');
-    expect(entry!.svgContent).toContain('</svg>');
-    expect(entry!.svgContent).toContain('xmlns="http://www.w3.org/2000/svg"');
-  });
-
-  it.each(ARM_IDS)('%s has a non-empty label', async (id) => {
-    const entry = await getStencil(id);
-    expect(entry!.label.length).toBeGreaterThan(0);
-  });
-
-  it('arm-resource-group has container dimensions', async () => {
-    const entry = await getStencil('arm-resource-group');
-    expect(entry!.defaultSize).toEqual({ width: 200, height: 150 });
-  });
-
-  it('arm-subscription has container dimensions', async () => {
-    const entry = await getStencil('arm-subscription');
-    expect(entry!.defaultSize).toEqual({ width: 250, height: 200 });
-  });
-
-  it('arm-management-group has container dimensions', async () => {
-    const entry = await getStencil('arm-management-group');
-    expect(entry!.defaultSize).toEqual({ width: 300, height: 200 });
-  });
-
-  it.each(
-    ARM_IDS.filter(
-      (id) =>
-        !['arm-resource-group', 'arm-subscription', 'arm-management-group'].includes(id),
-    ),
-  )('%s has 64×64 default size', async (id) => {
-    const entry = await getStencil(id);
-    expect(entry!.defaultSize).toEqual({ width: 64, height: 64 });
-  });
-});
-
 // ── Container stencil sizes ───────────────────────────────
 
 describe('Container stencil sizes', () => {
@@ -222,7 +200,7 @@ describe('Container stencil sizes', () => {
 // ── Cross-cutting catalog integrity ───────────────────────
 
 describe('Cloud stencil catalog integrity', () => {
-  it('all 26 cloud stencils exist in the catalog', async () => {
+  it('all 41 cloud stencils exist in the catalog', async () => {
     for (const id of ALL_CLOUD_IDS) {
       expect(await getStencil(id)).toBeDefined();
     }
@@ -243,17 +221,14 @@ describe('Cloud stencil catalog integrity', () => {
     }
   });
 
-  it('all cloud SVGs use currentColor or #333333 for strokes', async () => {
+  it('all cloud SVGs use currentColor for theming', async () => {
     for (const id of ALL_CLOUD_IDS) {
       const entry = (await getStencil(id))!;
-      const hasCurrentColor = entry.svgContent.includes('currentColor');
-      const hasStandardColor = entry.svgContent.includes('#333333');
-      expect(hasCurrentColor || hasStandardColor).toBe(true);
+      expect(entry.svgContent).toContain('currentColor');
     }
   });
 
-  it('k8s-pod is no longer in placeholders (moved to kubernetes.ts)', async () => {
-    // k8s-pod should still be in the catalog, but from kubernetes.ts, not placeholders
+  it('k8s-pod is in kubernetes category (not placeholders)', async () => {
     const entry = await getStencil('k8s-pod');
     expect(entry).toBeDefined();
     expect(entry!.category).toBe('kubernetes');

--- a/packages/engine/src/__tests__/lazyCatalog.test.ts
+++ b/packages/engine/src/__tests__/lazyCatalog.test.ts
@@ -99,9 +99,11 @@ describe('getCategories', () => {
     expect(categories).toContain('generic-it');
     expect(categories).toContain('architecture');
     expect(categories).toContain('kubernetes');
-    expect(categories).toContain('azure');
-    expect(categories).toContain('azure-arm');
+    expect(categories).toContain('azure-pro');
     expect(categories).toContain('security');
+    // Old categories removed
+    expect(categories).not.toContain('azure');
+    expect(categories).not.toContain('azure-arm');
   });
 
   it('returns sorted categories', () => {

--- a/packages/engine/src/__tests__/stencilCatalog.test.ts
+++ b/packages/engine/src/__tests__/stencilCatalog.test.ts
@@ -514,22 +514,24 @@ describe('getStencilsByCategory', () => {
 // ── getAllCategories ───────────────────────────────────────
 
 describe('getAllCategories', () => {
-  it('returns all 16 unique categories', () => {
+  it('returns all unique categories including azure-pro', () => {
     const categories = getAllCategories();
     expect(categories).toContain('architecture');
     expect(categories).toContain('aws-pro');
-    expect(categories).toContain('azure');
-    expect(categories).toContain('azure-arm');
+    expect(categories).toContain('azure-pro');
     expect(categories).toContain('cisco-pro');
     expect(categories).toContain('fortinet');
     expect(categories).toContain('gcp-pro');
     expect(categories).toContain('generic-it');
     expect(categories).toContain('kubernetes');
     expect(categories).toContain('network');
+    // Old categories removed
+    expect(categories).not.toContain('azure');
+    expect(categories).not.toContain('azure-arm');
   });
 
   it('returns the correct number of categories', () => {
-    expect(getAllCategories()).toHaveLength(17);
+    expect(getAllCategories()).toHaveLength(10);
   });
 });
 
@@ -537,7 +539,7 @@ describe('getAllCategories', () => {
 
 describe('STENCIL_CATALOG', () => {
   it('contains all stencil entries', () => {
-    expect(STENCIL_CATALOG.size).toBeGreaterThan(1900);
+    expect(STENCIL_CATALOG.size).toBeGreaterThanOrEqual(140);
   });
 
   it('has map keys matching entry IDs', () => {

--- a/packages/engine/src/renderer/stencils/stencilCatalog.ts
+++ b/packages/engine/src/renderer/stencils/stencilCatalog.ts
@@ -26,6 +26,7 @@ import {
   API_SVG,
   USER_SVG,
   BROWSER_SVG,
+  PROMETHEUS_SVG,
 } from './svgs/genericIt.js';
 import {
   BOUNDARY_ZONE_SVG,
@@ -33,22 +34,38 @@ import {
   CONTAINER_SVG,
 } from './svgs/architecture.js';
 import {
-  AZURE_APP_GATEWAY_SVG,
-  AZURE_AKS_SVG,
-  AZURE_STORAGE_SVG,
-  AZURE_SQL_SVG,
-  AZURE_FUNCTIONS_SVG,
-  AZURE_VNET_SVG,
-  AZURE_COSMOSDB_SVG,
-  AZURE_REDIS_SVG,
-  AZURE_DNS_SVG,
-  AZURE_FRONTDOOR_SVG,
-  AZURE_TRAFFIC_MANAGER_SVG,
-  AZURE_MONITOR_SVG,
-  AZURE_PRIVATE_ENDPOINT_SVG,
-  AZURE_NSP_SVG,
-  PROMETHEUS_SVG,
-} from './svgs/azure.js';
+  AZURE_PRO_VIRTUAL_MACHINES_SVG,
+  AZURE_PRO_APP_SERVICE_SVG,
+  AZURE_PRO_FUNCTIONS_SVG,
+  AZURE_PRO_AKS_SVG,
+  AZURE_PRO_CONTAINER_INSTANCES_SVG,
+  AZURE_PRO_VMSS_SVG,
+  AZURE_PRO_BLOB_STORAGE_SVG,
+  AZURE_PRO_FILE_STORAGE_SVG,
+  AZURE_PRO_DISK_STORAGE_SVG,
+  AZURE_PRO_DATA_LAKE_SVG,
+  AZURE_PRO_SQL_DATABASE_SVG,
+  AZURE_PRO_COSMOS_DB_SVG,
+  AZURE_PRO_MYSQL_SVG,
+  AZURE_PRO_POSTGRESQL_SVG,
+  AZURE_PRO_REDIS_CACHE_SVG,
+  AZURE_PRO_VIRTUAL_NETWORK_SVG,
+  AZURE_PRO_LOAD_BALANCER_SVG,
+  AZURE_PRO_APPLICATION_GATEWAY_SVG,
+  AZURE_PRO_FRONT_DOOR_SVG,
+  AZURE_PRO_DNS_ZONE_SVG,
+  AZURE_PRO_EXPRESSROUTE_SVG,
+  AZURE_PRO_KEY_VAULT_SVG,
+  AZURE_PRO_ACTIVE_DIRECTORY_SVG,
+  AZURE_PRO_SENTINEL_SVG,
+  AZURE_PRO_DDOS_PROTECTION_SVG,
+  AZURE_PRO_MONITOR_SVG,
+  AZURE_PRO_LOG_ANALYTICS_SVG,
+  AZURE_PRO_DEVOPS_SVG,
+  AZURE_PRO_RESOURCE_GROUP_SVG,
+  AZURE_PRO_COGNITIVE_SERVICES_SVG,
+  AZURE_PRO_OPENAI_SERVICE_SVG,
+} from './svgs/azure-pro.js';
 import {
   NGFW_SVG,
   WAF_SVG,
@@ -70,18 +87,7 @@ import {
   K8S_NODE_SVG,
   K8S_CLUSTER_SVG,
 } from './svgs/kubernetes.js';
-import {
-  ARM_RESOURCE_GROUP_SVG,
-  ARM_SUBSCRIPTION_SVG,
-  ARM_MANAGEMENT_GROUP_SVG,
-  ARM_VIRTUAL_MACHINE_SVG,
-  ARM_VNET_SVG,
-  ARM_SUBNET_SVG,
-  ARM_NSG_SVG,
-  ARM_KEY_VAULT_SVG,
-  ARM_APP_SERVICE_SVG,
-  ARM_CONTAINER_REGISTRY_SVG,
-} from './svgs/azureArm.js';
+// (azure-arm imports removed — replaced by azure-pro)
 import {
   FORTI_GATE_SVG,
   FORTI_SWITCH_SVG,
@@ -307,75 +313,46 @@ export const STENCIL_CATALOG: Map<string, StencilEntry> = new Map([
     },
   ],
 
-  // ── Azure (Sub-ticket C) ────────────────────────────────
-  [
-    'azure-app-gateway',
-    {
-      id: 'azure-app-gateway',
-      category: 'azure',
-      label: 'App Gateway',
-      svgContent: AZURE_APP_GATEWAY_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'azure-aks',
-    {
-      id: 'azure-aks',
-      category: 'azure',
-      label: 'Azure Kubernetes Service',
-      svgContent: AZURE_AKS_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'azure-storage',
-    {
-      id: 'azure-storage',
-      category: 'azure',
-      label: 'Azure Storage',
-      svgContent: AZURE_STORAGE_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'azure-sql',
-    {
-      id: 'azure-sql',
-      category: 'azure',
-      label: 'Azure SQL Database',
-      svgContent: AZURE_SQL_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'azure-functions',
-    {
-      id: 'azure-functions',
-      category: 'azure',
-      label: 'Azure Functions',
-      svgContent: AZURE_FUNCTIONS_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'azure-vnet',
-    {
-      id: 'azure-vnet',
-      category: 'azure',
-      label: 'Azure Virtual Network',
-      svgContent: AZURE_VNET_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  ['azure-cosmosdb', { id: 'azure-cosmosdb', category: 'azure', label: 'Cosmos DB', svgContent: AZURE_COSMOSDB_SVG, defaultSize: ICON_SIZE }],
-  ['azure-redis', { id: 'azure-redis', category: 'azure', label: 'Redis Cache', svgContent: AZURE_REDIS_SVG, defaultSize: ICON_SIZE }],
-  ['azure-dns', { id: 'azure-dns', category: 'azure', label: 'DNS', svgContent: AZURE_DNS_SVG, defaultSize: ICON_SIZE }],
-  ['azure-frontdoor', { id: 'azure-frontdoor', category: 'azure', label: 'Front Door', svgContent: AZURE_FRONTDOOR_SVG, defaultSize: ICON_SIZE }],
-  ['azure-traffic-manager', { id: 'azure-traffic-manager', category: 'azure', label: 'Traffic Manager', svgContent: AZURE_TRAFFIC_MANAGER_SVG, defaultSize: ICON_SIZE }],
-  ['azure-monitor', { id: 'azure-monitor', category: 'azure', label: 'Monitor', svgContent: AZURE_MONITOR_SVG, defaultSize: ICON_SIZE }],
-  ['private-endpoint', { id: 'private-endpoint', category: 'azure', label: 'Private Endpoint', svgContent: AZURE_PRIVATE_ENDPOINT_SVG, defaultSize: ICON_SIZE }],
-  ['nsp', { id: 'nsp', category: 'azure', label: 'Network Security Perimeter', svgContent: AZURE_NSP_SVG, defaultSize: { width: 200, height: 150 } }],
+  // ── Azure Pro (hand-crafted) ─────────────────────────────
+  // Compute
+  ['azure-pro-virtual-machines', { id: 'azure-pro-virtual-machines', category: 'azure-pro', label: 'Virtual Machines', svgContent: AZURE_PRO_VIRTUAL_MACHINES_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-app-service', { id: 'azure-pro-app-service', category: 'azure-pro', label: 'App Service', svgContent: AZURE_PRO_APP_SERVICE_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-functions', { id: 'azure-pro-functions', category: 'azure-pro', label: 'Azure Functions', svgContent: AZURE_PRO_FUNCTIONS_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-aks', { id: 'azure-pro-aks', category: 'azure-pro', label: 'AKS', svgContent: AZURE_PRO_AKS_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-container-instances', { id: 'azure-pro-container-instances', category: 'azure-pro', label: 'Container Instances', svgContent: AZURE_PRO_CONTAINER_INSTANCES_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-vmss', { id: 'azure-pro-vmss', category: 'azure-pro', label: 'VM Scale Sets', svgContent: AZURE_PRO_VMSS_SVG, defaultSize: ICON_SIZE }],
+  // Storage
+  ['azure-pro-blob-storage', { id: 'azure-pro-blob-storage', category: 'azure-pro', label: 'Blob Storage', svgContent: AZURE_PRO_BLOB_STORAGE_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-file-storage', { id: 'azure-pro-file-storage', category: 'azure-pro', label: 'File Storage', svgContent: AZURE_PRO_FILE_STORAGE_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-disk-storage', { id: 'azure-pro-disk-storage', category: 'azure-pro', label: 'Disk Storage', svgContent: AZURE_PRO_DISK_STORAGE_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-data-lake', { id: 'azure-pro-data-lake', category: 'azure-pro', label: 'Data Lake', svgContent: AZURE_PRO_DATA_LAKE_SVG, defaultSize: ICON_SIZE }],
+  // Database
+  ['azure-pro-sql-database', { id: 'azure-pro-sql-database', category: 'azure-pro', label: 'SQL Database', svgContent: AZURE_PRO_SQL_DATABASE_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-cosmos-db', { id: 'azure-pro-cosmos-db', category: 'azure-pro', label: 'Cosmos DB', svgContent: AZURE_PRO_COSMOS_DB_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-mysql', { id: 'azure-pro-mysql', category: 'azure-pro', label: 'MySQL', svgContent: AZURE_PRO_MYSQL_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-postgresql', { id: 'azure-pro-postgresql', category: 'azure-pro', label: 'PostgreSQL', svgContent: AZURE_PRO_POSTGRESQL_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-redis-cache', { id: 'azure-pro-redis-cache', category: 'azure-pro', label: 'Redis Cache', svgContent: AZURE_PRO_REDIS_CACHE_SVG, defaultSize: ICON_SIZE }],
+  // Networking
+  ['azure-pro-virtual-network', { id: 'azure-pro-virtual-network', category: 'azure-pro', label: 'Virtual Network', svgContent: AZURE_PRO_VIRTUAL_NETWORK_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-load-balancer', { id: 'azure-pro-load-balancer', category: 'azure-pro', label: 'Load Balancer', svgContent: AZURE_PRO_LOAD_BALANCER_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-application-gateway', { id: 'azure-pro-application-gateway', category: 'azure-pro', label: 'Application Gateway', svgContent: AZURE_PRO_APPLICATION_GATEWAY_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-front-door', { id: 'azure-pro-front-door', category: 'azure-pro', label: 'Front Door', svgContent: AZURE_PRO_FRONT_DOOR_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-dns-zone', { id: 'azure-pro-dns-zone', category: 'azure-pro', label: 'DNS Zone', svgContent: AZURE_PRO_DNS_ZONE_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-expressroute', { id: 'azure-pro-expressroute', category: 'azure-pro', label: 'ExpressRoute', svgContent: AZURE_PRO_EXPRESSROUTE_SVG, defaultSize: ICON_SIZE }],
+  // Security
+  ['azure-pro-key-vault', { id: 'azure-pro-key-vault', category: 'azure-pro', label: 'Key Vault', svgContent: AZURE_PRO_KEY_VAULT_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-active-directory', { id: 'azure-pro-active-directory', category: 'azure-pro', label: 'Active Directory', svgContent: AZURE_PRO_ACTIVE_DIRECTORY_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-sentinel', { id: 'azure-pro-sentinel', category: 'azure-pro', label: 'Sentinel', svgContent: AZURE_PRO_SENTINEL_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-ddos-protection', { id: 'azure-pro-ddos-protection', category: 'azure-pro', label: 'DDoS Protection', svgContent: AZURE_PRO_DDOS_PROTECTION_SVG, defaultSize: ICON_SIZE }],
+  // Management
+  ['azure-pro-monitor', { id: 'azure-pro-monitor', category: 'azure-pro', label: 'Monitor', svgContent: AZURE_PRO_MONITOR_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-log-analytics', { id: 'azure-pro-log-analytics', category: 'azure-pro', label: 'Log Analytics', svgContent: AZURE_PRO_LOG_ANALYTICS_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-devops', { id: 'azure-pro-devops', category: 'azure-pro', label: 'DevOps', svgContent: AZURE_PRO_DEVOPS_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-resource-group', { id: 'azure-pro-resource-group', category: 'azure-pro', label: 'Resource Group', svgContent: AZURE_PRO_RESOURCE_GROUP_SVG, defaultSize: ICON_SIZE }],
+  // AI
+  ['azure-pro-cognitive-services', { id: 'azure-pro-cognitive-services', category: 'azure-pro', label: 'Cognitive Services', svgContent: AZURE_PRO_COGNITIVE_SERVICES_SVG, defaultSize: ICON_SIZE }],
+  ['azure-pro-openai-service', { id: 'azure-pro-openai-service', category: 'azure-pro', label: 'OpenAI Service', svgContent: AZURE_PRO_OPENAI_SERVICE_SVG, defaultSize: ICON_SIZE }],
+
   ['prometheus', { id: 'prometheus', category: 'generic-it', label: 'Prometheus', svgContent: PROMETHEUS_SVG, defaultSize: ICON_SIZE }],
 
   // ── Security ────────────────────────────────────────────
@@ -570,108 +547,6 @@ export const STENCIL_CATALOG: Map<string, StencilEntry> = new Map([
       label: 'Cluster',
       svgContent: K8S_CLUSTER_SVG,
       defaultSize: { width: 250, height: 200 },
-    },
-  ],
-
-  // ── Azure ARM (Sub-ticket C) ────────────────────────────
-  [
-    'arm-resource-group',
-    {
-      id: 'arm-resource-group',
-      category: 'azure-arm',
-      label: 'Resource Group',
-      svgContent: ARM_RESOURCE_GROUP_SVG,
-      defaultSize: { width: 200, height: 150 },
-    },
-  ],
-  [
-    'arm-subscription',
-    {
-      id: 'arm-subscription',
-      category: 'azure-arm',
-      label: 'Subscription',
-      svgContent: ARM_SUBSCRIPTION_SVG,
-      defaultSize: { width: 250, height: 200 },
-    },
-  ],
-  [
-    'arm-management-group',
-    {
-      id: 'arm-management-group',
-      category: 'azure-arm',
-      label: 'Management Group',
-      svgContent: ARM_MANAGEMENT_GROUP_SVG,
-      defaultSize: { width: 300, height: 200 },
-    },
-  ],
-  [
-    'arm-virtual-machine',
-    {
-      id: 'arm-virtual-machine',
-      category: 'azure-arm',
-      label: 'Virtual Machine',
-      svgContent: ARM_VIRTUAL_MACHINE_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'arm-vnet',
-    {
-      id: 'arm-vnet',
-      category: 'azure-arm',
-      label: 'Virtual Network',
-      svgContent: ARM_VNET_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'arm-subnet',
-    {
-      id: 'arm-subnet',
-      category: 'azure-arm',
-      label: 'Subnet',
-      svgContent: ARM_SUBNET_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'arm-nsg',
-    {
-      id: 'arm-nsg',
-      category: 'azure-arm',
-      label: 'Network Security Group',
-      svgContent: ARM_NSG_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'arm-key-vault',
-    {
-      id: 'arm-key-vault',
-      category: 'azure-arm',
-      label: 'Key Vault',
-      svgContent: ARM_KEY_VAULT_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'arm-app-service',
-    {
-      id: 'arm-app-service',
-      category: 'azure-arm',
-      label: 'App Service',
-      svgContent: ARM_APP_SERVICE_SVG,
-      defaultSize: { width: 64, height: 64 },
-    },
-  ],
-  [
-    'arm-container-registry',
-    {
-      id: 'arm-container-registry',
-      category: 'azure-arm',
-      label: 'Container Registry',
-      svgContent: ARM_CONTAINER_REGISTRY_SVG,
-      defaultSize: { width: 64, height: 64 },
     },
   ],
 

--- a/packages/engine/src/renderer/stencils/svgs/azure-pro.ts
+++ b/packages/engine/src/renderer/stencils/svgs/azure-pro.ts
@@ -1,0 +1,389 @@
+/**
+ * Azure Pro hand-crafted SVG icons for the stencil catalog.
+ *
+ * Thirty monochrome line-art icons (64×64 viewBox) representing
+ * key Azure compute, storage, database, networking, security,
+ * management, and AI services. Each icon uses `currentColor`
+ * for fills/strokes to support theming.
+ *
+ * @module
+ */
+
+// ── Compute ──────────────────────────────────────────────
+
+/** Virtual Machines — server rack with Azure diamond badge. */
+export const AZURE_PRO_VIRTUAL_MACHINES_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="14" y="6" width="36" height="46" rx="3" />
+  <line x1="14" y1="18" x2="50" y2="18" />
+  <line x1="14" y1="30" x2="50" y2="30" />
+  <circle cx="20" cy="12" r="2" fill="currentColor" />
+  <circle cx="20" cy="24" r="2" fill="currentColor" />
+  <circle cx="20" cy="36" r="2" fill="currentColor" />
+  <line x1="26" y1="12" x2="44" y2="12" />
+  <line x1="26" y1="24" x2="44" y2="24" />
+  <line x1="26" y1="36" x2="44" y2="36" />
+  <line x1="32" y1="52" x2="32" y2="58" />
+  <line x1="22" y1="58" x2="42" y2="58" />
+  <polygon points="44,42 48,46 44,50 40,46" fill="currentColor" opacity="0.3" stroke="currentColor" stroke-width="1" />
+</svg>`;
+
+/** App Service — globe with code brackets. */
+export const AZURE_PRO_APP_SERVICE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="32" cy="32" r="22" />
+  <ellipse cx="32" cy="32" rx="9" ry="22" />
+  <line x1="10" y1="32" x2="54" y2="32" />
+  <path d="M14 22 h36" />
+  <path d="M14 42 h36" />
+  <path d="M22 50 L18 54 L22 58" stroke-width="2.5" />
+  <path d="M42 50 L46 54 L42 58" stroke-width="2.5" />
+</svg>`;
+
+/** Azure Functions — lightning bolt in a rounded frame. */
+export const AZURE_PRO_FUNCTIONS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="8" y="8" width="48" height="48" rx="8" />
+  <polygon points="34,14 22,34 30,34 26,50 42,28 34,28" fill="currentColor" opacity="0.15" stroke="currentColor" stroke-linejoin="round" stroke-width="2" />
+</svg>`;
+
+/** AKS — Kubernetes wheel in Azure-styled frame. */
+export const AZURE_PRO_AKS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="6" y="6" width="52" height="52" rx="4" />
+  <circle cx="32" cy="32" r="14" />
+  <circle cx="32" cy="32" r="4" fill="currentColor" opacity="0.2" />
+  <line x1="32" y1="18" x2="32" y2="24" />
+  <line x1="32" y1="40" x2="32" y2="46" />
+  <line x1="19.9" y1="25" x2="24.5" y2="28" />
+  <line x1="39.5" y1="36" x2="44.1" y2="39" />
+  <line x1="19.9" y1="39" x2="24.5" y2="36" />
+  <line x1="39.5" y1="28" x2="44.1" y2="25" />
+  <circle cx="32" cy="16" r="2.5" fill="currentColor" />
+  <circle cx="32" cy="48" r="2.5" fill="currentColor" />
+  <circle cx="18" cy="24" r="2.5" fill="currentColor" />
+  <circle cx="46" cy="40" r="2.5" fill="currentColor" />
+  <circle cx="18" cy="40" r="2.5" fill="currentColor" />
+  <circle cx="46" cy="24" r="2.5" fill="currentColor" />
+</svg>`;
+
+/** Container Instances — stacked containers with run indicator. */
+export const AZURE_PRO_CONTAINER_INSTANCES_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="10" y="8" width="40" height="16" rx="2" />
+  <line x1="10" y1="16" x2="50" y2="16" />
+  <rect x="10" y="28" width="40" height="16" rx="2" />
+  <line x1="10" y1="36" x2="50" y2="36" />
+  <rect x="10" y="48" width="40" height="12" rx="2" />
+  <polygon points="42,52 42,56 46,54" fill="currentColor" stroke="none" />
+  <circle cx="16" cy="12" r="1.5" fill="currentColor" />
+  <circle cx="16" cy="32" r="1.5" fill="currentColor" />
+  <circle cx="16" cy="54" r="1.5" fill="currentColor" />
+</svg>`;
+
+/** Virtual Machine Scale Sets — layered VM boxes with scale arrows. */
+export const AZURE_PRO_VMSS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="18" y="4" width="32" height="24" rx="2" fill="currentColor" opacity="0.05" />
+  <rect x="14" y="8" width="32" height="24" rx="2" fill="currentColor" opacity="0.08" />
+  <rect x="10" y="12" width="32" height="24" rx="2" />
+  <line x1="10" y1="22" x2="42" y2="22" />
+  <circle cx="16" cy="17" r="1.5" fill="currentColor" />
+  <line x1="22" y1="17" x2="36" y2="17" />
+  <line x1="20" y1="44" x2="20" y2="56" />
+  <polygon points="20,56 17,52 23,52" fill="currentColor" stroke="none" />
+  <line x1="44" y1="44" x2="44" y2="56" />
+  <polygon points="44,44 41,48 47,48" fill="currentColor" stroke="none" />
+  <line x1="24" y1="50" x2="40" y2="50" />
+</svg>`;
+
+// ── Storage ──────────────────────────────────────────────
+
+/** Blob Storage — bucket with blob shapes. */
+export const AZURE_PRO_BLOB_STORAGE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <ellipse cx="32" cy="14" rx="18" ry="6" />
+  <path d="M14 14 v36 c0 3.3 8 6 18 6 s18-2.7 18-6 V14" />
+  <path d="M14 28 c0 3.3 8 6 18 6 s18-2.7 18-6" />
+  <circle cx="24" cy="40" r="3" fill="currentColor" opacity="0.2" />
+  <circle cx="34" cy="38" r="4" fill="currentColor" opacity="0.15" />
+  <circle cx="28" cy="46" r="2.5" fill="currentColor" opacity="0.2" />
+</svg>`;
+
+/** File Storage — folder with file sheet. */
+export const AZURE_PRO_FILE_STORAGE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M8 18 L8 54 L56 54 L56 24 L36 24 L32 18 Z" />
+  <path d="M8 24 L56 24" />
+  <rect x="22" y="30" width="20" height="18" rx="1" />
+  <path d="M34 30 L34 34 L38 34" fill="none" />
+  <line x1="26" y1="36" x2="38" y2="36" />
+  <line x1="26" y1="40" x2="34" y2="40" />
+  <line x1="26" y1="44" x2="36" y2="44" />
+</svg>`;
+
+/** Disk Storage — stacked disk platters. */
+export const AZURE_PRO_DISK_STORAGE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <ellipse cx="32" cy="12" rx="20" ry="6" />
+  <path d="M12 12 v12 c0 3.3 9 6 20 6 s20-2.7 20-6 V12" />
+  <path d="M12 24 v12 c0 3.3 9 6 20 6 s20-2.7 20-6 V24" />
+  <path d="M12 36 v12 c0 3.3 9 6 20 6 s20-2.7 20-6 V36" />
+  <path d="M12 24 c0 3.3 9 6 20 6 s20-2.7 20-6" />
+  <path d="M12 36 c0 3.3 9 6 20 6 s20-2.7 20-6" />
+</svg>`;
+
+/** Data Lake — lake wave with data nodes. */
+export const AZURE_PRO_DATA_LAKE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M8 36 C14 30 22 30 28 36 C34 42 42 42 48 36 C50 34 54 34 56 36 V52 C56 54 54 56 52 56 H12 C10 56 8 54 8 52 Z" fill="currentColor" opacity="0.08" />
+  <path d="M8 36 C14 30 22 30 28 36 C34 42 42 42 48 36 C50 34 54 34 56 36" />
+  <circle cx="20" cy="16" r="5" />
+  <circle cx="36" cy="12" r="5" />
+  <circle cx="48" cy="20" r="5" />
+  <line x1="25" y1="16" x2="31" y2="12" />
+  <line x1="41" y1="12" x2="43" y2="18" />
+  <line x1="20" y1="21" x2="20" y2="30" />
+  <line x1="36" y1="17" x2="36" y2="28" />
+</svg>`;
+
+// ── Database ─────────────────────────────────────────────
+
+/** SQL Database — database cylinder with SQL label. */
+export const AZURE_PRO_SQL_DATABASE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <ellipse cx="32" cy="16" rx="18" ry="7" />
+  <path d="M14 16 v32 c0 3.9 8 7 18 7 s18-3.1 18-7 V16" />
+  <path d="M14 28 c0 3.9 8 7 18 7 s18-3.1 18-7" />
+  <text x="32" y="48" text-anchor="middle" font-size="10" font-weight="bold" fill="currentColor" stroke="none" font-family="sans-serif">SQL</text>
+</svg>`;
+
+/** Cosmos DB — globe with atom orbital ring. */
+export const AZURE_PRO_COSMOS_DB_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="32" cy="32" r="16" />
+  <ellipse cx="32" cy="32" rx="26" ry="10" transform="rotate(-30 32 32)" />
+  <ellipse cx="32" cy="32" rx="26" ry="10" transform="rotate(30 32 32)" />
+  <circle cx="32" cy="32" r="3" fill="currentColor" />
+</svg>`;
+
+/** MySQL — database cylinder with dolphin-inspired fin. */
+export const AZURE_PRO_MYSQL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <ellipse cx="28" cy="16" rx="16" ry="6" />
+  <path d="M12 16 v32 c0 3.3 7.2 6 16 6 s16-2.7 16-6 V16" />
+  <path d="M12 28 c0 3.3 7.2 6 16 6 s16-2.7 16-6" />
+  <path d="M46 14 C50 10 54 12 54 18 C54 24 50 28 48 30 L52 36" stroke-width="2" />
+  <path d="M46 14 C44 10 46 6 50 6" stroke-width="1.5" />
+</svg>`;
+
+/** PostgreSQL — database cylinder with elephant trunk. */
+export const AZURE_PRO_POSTGRESQL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <ellipse cx="28" cy="16" rx="16" ry="6" />
+  <path d="M12 16 v32 c0 3.3 7.2 6 16 6 s16-2.7 16-6 V16" />
+  <path d="M12 28 c0 3.3 7.2 6 16 6 s16-2.7 16-6" />
+  <path d="M44 14 C48 14 52 18 52 24 C52 30 50 32 48 34 C46 36 48 40 50 42" stroke-width="2" />
+  <circle cx="49" cy="20" r="2" fill="currentColor" opacity="0.3" />
+</svg>`;
+
+/** Redis Cache — lightning bolt on cache box with speed lines. */
+export const AZURE_PRO_REDIS_CACHE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="10" y="14" width="44" height="36" rx="3" />
+  <line x1="10" y1="26" x2="54" y2="26" />
+  <path d="M34 30 L28 40 H36 L30 50" stroke-width="2.5" fill="none" />
+  <line x1="4" y1="34" x2="10" y2="34" />
+  <line x1="4" y1="38" x2="8" y2="38" />
+  <line x1="4" y1="42" x2="6" y2="42" />
+  <circle cx="18" cy="20" r="2" fill="currentColor" />
+  <circle cx="26" cy="20" r="2" fill="currentColor" />
+</svg>`;
+
+// ── Networking ────────────────────────────────────────────
+
+/** Virtual Network — dashed boundary with connected nodes. */
+export const AZURE_PRO_VIRTUAL_NETWORK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="6" y="6" width="52" height="52" rx="4" stroke-dasharray="4 2" />
+  <circle cx="22" cy="22" r="6" />
+  <circle cx="42" cy="22" r="6" />
+  <circle cx="22" cy="42" r="6" />
+  <circle cx="42" cy="42" r="6" />
+  <line x1="28" y1="22" x2="36" y2="22" />
+  <line x1="22" y1="28" x2="22" y2="36" />
+  <line x1="42" y1="28" x2="42" y2="36" />
+  <line x1="28" y1="42" x2="36" y2="42" />
+  <line x1="27" y1="27" x2="37" y2="37" />
+  <line x1="37" y1="27" x2="27" y2="37" />
+  <path d="M32 2 L34 6 L30 6 Z" fill="currentColor" stroke="none" />
+</svg>`;
+
+/** Load Balancer — balanced arrows through vertical bar. */
+export const AZURE_PRO_LOAD_BALANCER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="26" y="8" width="12" height="48" rx="3" fill="currentColor" opacity="0.08" />
+  <rect x="26" y="8" width="12" height="48" rx="3" />
+  <line x1="8" y1="32" x2="26" y2="32" />
+  <polygon points="8,32 14,29 14,35" fill="currentColor" stroke="none" />
+  <line x1="38" y1="16" x2="56" y2="16" />
+  <polygon points="56,16 50,13 50,19" fill="currentColor" stroke="none" />
+  <line x1="38" y1="32" x2="56" y2="32" />
+  <polygon points="56,32 50,29 50,35" fill="currentColor" stroke="none" />
+  <line x1="38" y1="48" x2="56" y2="48" />
+  <polygon points="56,48 50,45 50,51" fill="currentColor" stroke="none" />
+</svg>`;
+
+/** Application Gateway — gateway box with routing fan-out. */
+export const AZURE_PRO_APPLICATION_GATEWAY_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="6" y="14" width="52" height="36" rx="4" />
+  <line x1="6" y1="32" x2="20" y2="32" />
+  <circle cx="24" cy="32" r="4" fill="currentColor" opacity="0.15" />
+  <line x1="28" y1="32" x2="36" y2="20" />
+  <line x1="28" y1="32" x2="36" y2="32" />
+  <line x1="28" y1="32" x2="36" y2="44" />
+  <polygon points="42,20 36,17 36,23" fill="currentColor" stroke="none" />
+  <polygon points="42,32 36,29 36,35" fill="currentColor" stroke="none" />
+  <polygon points="42,44 36,41 36,47" fill="currentColor" stroke="none" />
+  <rect x="42" y="16" width="10" height="8" rx="1" />
+  <rect x="42" y="28" width="10" height="8" rx="1" />
+  <rect x="42" y="40" width="10" height="8" rx="1" />
+</svg>`;
+
+/** Front Door — shield with globe and CDN edge lines. */
+export const AZURE_PRO_FRONT_DOOR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M32 6 L54 18 V42 C54 50 32 58 32 58 C32 58 10 50 10 42 V18 Z" />
+  <path d="M32 6 L54 18 V42 C54 50 32 58 32 58 C32 58 10 50 10 42 V18 Z" fill="currentColor" opacity="0.05" />
+  <circle cx="32" cy="32" r="10" />
+  <line x1="22" y1="32" x2="42" y2="32" />
+  <line x1="32" y1="22" x2="32" y2="42" />
+  <ellipse cx="32" cy="32" rx="4" ry="10" />
+</svg>`;
+
+/** DNS Zone — globe with DNS label. */
+export const AZURE_PRO_DNS_ZONE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="32" cy="26" r="18" />
+  <line x1="14" y1="26" x2="50" y2="26" />
+  <ellipse cx="32" cy="26" rx="7" ry="18" />
+  <path d="M16 18 h32" />
+  <path d="M16 34 h32" />
+  <text x="32" y="56" text-anchor="middle" font-size="11" font-weight="bold" fill="currentColor" stroke="none" font-family="sans-serif">DNS</text>
+</svg>`;
+
+/** ExpressRoute — dedicated line with plugs and express label. */
+export const AZURE_PRO_EXPRESSROUTE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="4" y="22" width="16" height="20" rx="3" />
+  <rect x="44" y="22" width="16" height="20" rx="3" />
+  <line x1="20" y1="28" x2="44" y2="28" stroke-width="3" />
+  <line x1="20" y1="36" x2="44" y2="36" stroke-width="3" />
+  <circle cx="12" cy="32" r="3" fill="currentColor" />
+  <circle cx="52" cy="32" r="3" fill="currentColor" />
+  <polygon points="36,28 32,26 32,30" fill="currentColor" stroke="none" />
+  <polygon points="28,36 32,34 32,38" fill="currentColor" stroke="none" />
+  <line x1="12" y1="16" x2="12" y2="22" />
+  <line x1="52" y1="16" x2="52" y2="22" />
+  <line x1="12" y1="42" x2="12" y2="48" />
+  <line x1="52" y1="42" x2="52" y2="48" />
+</svg>`;
+
+// ── Security ─────────────────────────────────────────────
+
+/** Key Vault — vault safe with key. */
+export const AZURE_PRO_KEY_VAULT_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="10" y="10" width="44" height="44" rx="6" />
+  <rect x="16" y="16" width="32" height="32" rx="3" />
+  <circle cx="32" cy="30" r="6" />
+  <circle cx="32" cy="30" r="2" fill="currentColor" />
+  <line x1="32" y1="36" x2="32" y2="44" />
+  <line x1="32" y1="40" x2="36" y2="38" />
+  <rect x="29" y="42" width="6" height="3" rx="1" fill="currentColor" />
+</svg>`;
+
+/** Active Directory (Entra ID) — people group with shield. */
+export const AZURE_PRO_ACTIVE_DIRECTORY_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="22" cy="16" r="7" />
+  <path d="M10 34 C10 28 16 26 22 26 C28 26 34 28 34 34" />
+  <circle cx="42" cy="20" r="5" />
+  <path d="M34 36 C34 32 38 30 42 30 C46 30 50 32 50 36" />
+  <path d="M32 40 L44 46 V54 C44 58 32 60 32 60 C32 60 20 58 20 54 V46 Z" />
+  <polyline points="27,50 31,54 39,46" stroke-width="2" />
+</svg>`;
+
+/** Sentinel — eye with radar sweep. */
+export const AZURE_PRO_SENTINEL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M4 32 C12 18 22 12 32 12 C42 12 52 18 60 32 C52 46 42 52 32 52 C22 52 12 46 4 32 Z" />
+  <circle cx="32" cy="32" r="10" />
+  <circle cx="32" cy="32" r="4" fill="currentColor" opacity="0.3" />
+  <path d="M32 32 L42 22" stroke-width="2.5" />
+  <circle cx="42" cy="22" r="2" fill="currentColor" />
+</svg>`;
+
+/** DDoS Protection — shield with deflection arrows. */
+export const AZURE_PRO_DDOS_PROTECTION_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M32 4 L52 14 V32 C52 44 32 56 32 56 C32 56 12 44 12 32 V14 Z" />
+  <path d="M32 4 L52 14 V32 C52 44 32 56 32 56 C32 56 12 44 12 32 V14 Z" fill="currentColor" opacity="0.06" />
+  <line x1="4" y1="20" x2="16" y2="26" />
+  <path d="M16 26 L10 32" />
+  <polygon points="10,32 14,30 12,34" fill="currentColor" stroke="none" />
+  <line x1="4" y1="32" x2="16" y2="34" />
+  <path d="M16 34 L10 40" />
+  <polygon points="10,40 14,38 12,42" fill="currentColor" stroke="none" />
+  <line x1="4" y1="44" x2="14" y2="42" />
+  <path d="M14 42 L8 48" />
+  <polygon points="8,48 12,46 10,50" fill="currentColor" stroke="none" />
+</svg>`;
+
+// ── Management ───────────────────────────────────────────
+
+/** Monitor — dashboard gauge with needle. */
+export const AZURE_PRO_MONITOR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="32" cy="32" r="22" />
+  <circle cx="32" cy="32" r="18" />
+  <line x1="32" y1="32" x2="40" y2="20" stroke-width="2.5" />
+  <circle cx="32" cy="32" r="3" fill="currentColor" />
+  <line x1="32" y1="10" x2="32" y2="14" />
+  <line x1="32" y1="50" x2="32" y2="54" />
+  <line x1="10" y1="32" x2="14" y2="32" />
+  <line x1="50" y1="32" x2="54" y2="32" />
+  <line x1="17" y1="17" x2="20" y2="20" />
+  <line x1="44" y1="17" x2="47" y2="20" />
+  <polyline points="18,48 24,42 30,46 38,38 44,42" stroke-width="1.5" />
+</svg>`;
+
+/** Log Analytics — magnifying glass over log lines. */
+export const AZURE_PRO_LOG_ANALYTICS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="8" y="8" width="36" height="44" rx="3" />
+  <line x1="14" y1="18" x2="38" y2="18" />
+  <line x1="14" y1="26" x2="34" y2="26" />
+  <line x1="14" y1="34" x2="30" y2="34" />
+  <line x1="14" y1="42" x2="28" y2="42" />
+  <circle cx="44" cy="40" r="10" />
+  <line x1="51" y1="47" x2="58" y2="54" stroke-width="2.5" />
+  <circle cx="44" cy="40" r="4" fill="currentColor" opacity="0.1" />
+</svg>`;
+
+/** DevOps — infinity loop with gear. */
+export const AZURE_PRO_DEVOPS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M18 32 C18 22 24 18 30 22 L34 24 L38 22 C44 18 50 22 50 32 C50 42 44 46 38 42 L34 40 L30 42 C24 46 18 42 18 32 Z" stroke-width="2.5" />
+  <path d="M8 32 C8 18 18 12 28 18 L32 20 L36 18 C46 12 56 18 56 32 C56 46 46 52 36 46 L32 44 L28 46 C18 52 8 46 8 32 Z" stroke-width="1.5" stroke-dasharray="3 2" />
+  <circle cx="32" cy="32" r="4" />
+  <circle cx="32" cy="32" r="2" fill="currentColor" />
+</svg>`;
+
+/** Resource Group — folder/group with brace. */
+export const AZURE_PRO_RESOURCE_GROUP_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M6 18 H24 L28 12 H54 A4 4 0 0 1 58 16 V52 A4 4 0 0 1 54 56 H10 A4 4 0 0 1 6 52 V18 Z" />
+  <line x1="6" y1="24" x2="58" y2="24" />
+  <rect x="16" y="30" width="12" height="10" rx="2" fill="currentColor" opacity="0.1" />
+  <rect x="34" y="30" width="12" height="10" rx="2" fill="currentColor" opacity="0.1" />
+  <rect x="16" y="44" width="12" height="6" rx="2" fill="currentColor" opacity="0.1" />
+</svg>`;
+
+// ── AI ───────────────────────────────────────────────────
+
+/** Cognitive Services — brain with circuits. */
+export const AZURE_PRO_COGNITIVE_SERVICES_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M32 8 C22 8 16 14 16 22 C16 26 18 30 18 30 C14 32 12 36 12 40 C12 48 18 52 24 52 L40 52 C46 52 52 48 52 40 C52 36 50 32 46 30 C46 30 48 26 48 22 C48 14 42 8 32 8 Z" />
+  <line x1="32" y1="20" x2="32" y2="44" />
+  <path d="M24 26 C26 28 30 28 32 26" />
+  <path d="M32 26 C34 28 38 28 40 26" />
+  <path d="M24 36 C26 38 30 38 32 36" />
+  <path d="M32 36 C34 38 38 38 40 36" />
+  <circle cx="24" cy="20" r="2" fill="currentColor" />
+  <circle cx="40" cy="20" r="2" fill="currentColor" />
+</svg>`;
+
+/** OpenAI Service — brain with AI sparkle. */
+export const AZURE_PRO_OPENAI_SERVICE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M32 10 C22 10 16 16 16 24 C16 28 18 32 18 32 C14 34 12 38 12 42 C12 50 18 54 24 54 L40 54 C46 54 52 50 52 42 C52 38 50 34 46 32 C46 32 48 28 48 24 C48 16 42 10 32 10 Z" />
+  <circle cx="28" cy="30" r="3" />
+  <circle cx="38" cy="30" r="3" />
+  <path d="M26 40 C28 44 36 44 38 40" />
+  <line x1="52" y1="12" x2="52" y2="4" stroke-width="1.5" />
+  <line x1="48" y1="8" x2="56" y2="8" stroke-width="1.5" />
+  <line x1="56" y1="18" x2="56" y2="14" stroke-width="1" />
+  <line x1="54" y1="16" x2="58" y2="16" stroke-width="1" />
+</svg>`;

--- a/packages/engine/src/renderer/stencils/svgs/genericIt.ts
+++ b/packages/engine/src/renderer/stencils/svgs/genericIt.ts
@@ -1,8 +1,8 @@
 /**
  * Generic IT category SVG icons for the stencil catalog.
  *
- * Six monochrome line-art icons (64×64 viewBox): database, queue,
- * cache, api, user, and browser.
+ * Seven monochrome line-art icons (64×64 viewBox): database, queue,
+ * cache, api, user, browser, and prometheus.
  *
  * @module
  */
@@ -52,4 +52,11 @@ export const BROWSER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0
   <circle cx="20" cy="15" r="2" fill="currentColor" />
   <circle cx="28" cy="15" r="2" fill="currentColor" />
   <rect x="34" y="12" width="22" height="6" rx="2" />
+</svg>`;
+
+/** Prometheus — flame icon (monitoring). */
+export const PROMETHEUS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M32 6 C32 6 44 16 44 30 C44 38 40 42 40 42 C40 42 46 36 46 28 C46 28 52 36 52 44 C52 54 42 58 32 58 C22 58 12 54 12 44 C12 36 18 28 18 28 C18 36 24 42 24 42 C24 42 20 38 20 30 C20 16 32 6 32 6Z" />
+  <line x1="22" y1="48" x2="42" y2="48" />
+  <line x1="24" y1="52" x2="40" y2="52" />
 </svg>`;


### PR DESCRIPTION
30 fresh Azure stencils replacing the old 24 (14 azure + 10 azure-arm). VMs, App Service, Functions, AKS, Blob Storage, Cosmos DB, SQL, VNet, Key Vault, Entra ID, Monitor, OpenAI Service, and more.

Removes old azure and azure-arm categories.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>