### PR TITLE
fix: remove orphaned import block v2

### DIFF
--- a/packages/engine/src/renderer/stencils/stencilCatalog.ts
+++ b/packages/engine/src/renderer/stencils/stencilCatalog.ts
@@ -100,7 +100,6 @@ import {
   K8S_CLUSTER_SVG,
 } from './svgs/kubernetes.js';
 import {
-import {
   FORTI_GATE_SVG,
   FORTI_SWITCH_SVG,
   FORTI_AP_SVG,


### PR DESCRIPTION
Another azure-arm remnant: empty import { line. Removed. Build clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>