### PR TITLE
fix: remove 8 orphaned azure stencil entries

### DIFF
--- a/packages/engine/src/renderer/stencils/stencilCatalog.ts
+++ b/packages/engine/src/renderer/stencils/stencilCatalog.ts
@@ -329,14 +329,6 @@ export const STENCIL_CATALOG: Map<string, StencilEntry> = new Map([
   ['headset', { id: 'headset', category: 'generic-it', label: 'Headset', svgContent: HEADSET_SVG, defaultSize: ICON_SIZE }],
   ['webcam', { id: 'webcam', category: 'generic-it', label: 'Webcam', svgContent: WEBCAM_SVG, defaultSize: ICON_SIZE }],
 
-  ['azure-cosmosdb', { id: 'azure-cosmosdb', category: 'azure', label: 'Cosmos DB', svgContent: AZURE_COSMOSDB_SVG, defaultSize: ICON_SIZE }],
-  ['azure-redis', { id: 'azure-redis', category: 'azure', label: 'Redis Cache', svgContent: AZURE_REDIS_SVG, defaultSize: ICON_SIZE }],
-  ['azure-dns', { id: 'azure-dns', category: 'azure', label: 'DNS', svgContent: AZURE_DNS_SVG, defaultSize: ICON_SIZE }],
-  ['azure-frontdoor', { id: 'azure-frontdoor', category: 'azure', label: 'Front Door', svgContent: AZURE_FRONTDOOR_SVG, defaultSize: ICON_SIZE }],
-  ['azure-traffic-manager', { id: 'azure-traffic-manager', category: 'azure', label: 'Traffic Manager', svgContent: AZURE_TRAFFIC_MANAGER_SVG, defaultSize: ICON_SIZE }],
-  ['azure-monitor', { id: 'azure-monitor', category: 'azure', label: 'Monitor', svgContent: AZURE_MONITOR_SVG, defaultSize: ICON_SIZE }],
-  ['private-endpoint', { id: 'private-endpoint', category: 'azure', label: 'Private Endpoint', svgContent: AZURE_PRIVATE_ENDPOINT_SVG, defaultSize: ICON_SIZE }],
-  ['nsp', { id: 'nsp', category: 'azure', label: 'Network Security Perimeter', svgContent: AZURE_NSP_SVG, defaultSize: { width: 200, height: 150 } }],
 
   // ── Security ────────────────────────────────────────────
   ['shield', { id: 'shield', category: 'security', label: 'Shield', svgContent: SHIELD_SVG, defaultSize: ICON_SIZE }],


### PR DESCRIPTION
Runtime ReferenceError: AZURE_COSMOSDB_SVG. Removed 8 old entries. Vite build ✓.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>