### PR TITLE
feat: extended connector schema — arrowheads + routing (#147)

### DIFF
--- a/packages/protocol/src/__tests__/connectorSchema.test.ts
+++ b/packages/protocol/src/__tests__/connectorSchema.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Connector Schema Tests — Ticket #147.
+ *
+ * Validates expanded RoutingMode, ArrowheadType, ArrowData fields,
+ * and ArrowBinding connection-point extensions.
+ *
+ * TDD: These tests are written FIRST, then the implementation follows.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { arrowDataSchema } from '../validation/schemas.js';
+
+// ── Helper ────────────────────────────────────────────────
+
+/** Minimal valid arrow data for schema validation. */
+function minimalArrow(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: 'arrow',
+    points: [[0, 0], [100, 100]],
+    ...overrides,
+  };
+}
+
+// ── RoutingMode expansion ─────────────────────────────────
+
+describe('RoutingMode expansion (#147)', () => {
+  it('accepts existing "straight" routing', () => {
+    const result = arrowDataSchema.safeParse(minimalArrow({ routing: 'straight' }));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts existing "orthogonal" routing', () => {
+    const result = arrowDataSchema.safeParse(minimalArrow({ routing: 'orthogonal' }));
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    'curved',
+    'elbow',
+    'entityRelation',
+    'isometric',
+    'orthogonalCurved',
+  ])('accepts new routing mode "%s"', (mode) => {
+    const result = arrowDataSchema.safeParse(minimalArrow({ routing: mode }));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid routing mode', () => {
+    const result = arrowDataSchema.safeParse(minimalArrow({ routing: 'zigzag' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('routing remains optional', () => {
+    const result = arrowDataSchema.safeParse(minimalArrow());
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── ArrowheadType expansion ───────────────────────────────
+
+describe('ArrowheadType expansion (#147)', () => {
+  // Backward compat: existing types still work
+  describe('backward compatibility', () => {
+    it.each([
+      'triangle',
+      'chevron',
+      'diamond',
+      'circle',
+      'none',
+    ])('accepts existing arrowhead type "%s"', (type) => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ endArrowhead: type }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts boolean arrowhead (true)', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ endArrowhead: true }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts boolean arrowhead (false)', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ endArrowhead: false }),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // New standard types
+  describe('standard arrowhead types', () => {
+    it.each([
+      'classic',
+      'classicThin',
+      'open',
+      'openThin',
+      'block',
+      'blockThin',
+      'oval',
+      'diamondThin',
+    ])('accepts standard arrowhead type "%s"', (type) => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ endArrowhead: type }),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ER diagram types
+  describe('ER diagram arrowhead types', () => {
+    it.each([
+      'ERone',
+      'ERmany',
+      'ERmandOne',
+      'ERoneToMany',
+      'ERzeroToOne',
+      'ERzeroToMany',
+    ])('accepts ER arrowhead type "%s"', (type) => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ startArrowhead: type }),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // UML types
+  describe('UML arrowhead types', () => {
+    it.each([
+      'openAsync',
+      'dash',
+      'cross',
+    ])('accepts UML arrowhead type "%s"', (type) => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ endArrowhead: type }),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // Other types
+  describe('other arrowhead types', () => {
+    it.each([
+      'box',
+      'halfCircle',
+      'doubleBlock',
+    ])('accepts other arrowhead type "%s"', (type) => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ endArrowhead: type }),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it('rejects unknown arrowhead type', () => {
+    const result = arrowDataSchema.safeParse(
+      minimalArrow({ endArrowhead: 'unicorn' }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('arrowhead fields remain optional', () => {
+    const result = arrowDataSchema.safeParse(minimalArrow());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.startArrowhead).toBeUndefined();
+      expect(result.data.endArrowhead).toBeUndefined();
+    }
+  });
+});
+
+// ── New ArrowData fields ──────────────────────────────────
+
+describe('ArrowData new fields (#147)', () => {
+  describe('startFill / endFill', () => {
+    it('accepts startFill: true', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ startFill: true }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts endFill: false', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ endFill: false }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects non-boolean startFill', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ startFill: 'yes' }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('startFill and endFill are optional', () => {
+      const result = arrowDataSchema.safeParse(minimalArrow());
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.startFill).toBeUndefined();
+        expect(result.data.endFill).toBeUndefined();
+      }
+    });
+  });
+
+  describe('curved', () => {
+    it('accepts curved: true', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ curved: true }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts curved: false', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ curved: false }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects non-boolean curved', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ curved: 1 }),
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('rounded', () => {
+    it('accepts rounded: true', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ rounded: true }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts rounded: false', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ rounded: false }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects non-boolean rounded', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ rounded: 'yes' }),
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('jettySize', () => {
+    it('accepts jettySize as number', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ jettySize: 20 }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts jettySize as "auto"', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ jettySize: 'auto' }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects negative jettySize', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ jettySize: -5 }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid jettySize string', () => {
+      const result = arrowDataSchema.safeParse(
+        minimalArrow({ jettySize: 'big' }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('jettySize is optional', () => {
+      const result = arrowDataSchema.safeParse(minimalArrow());
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.jettySize).toBeUndefined();
+      }
+    });
+  });
+});
+
+// ── ArrowBinding extensions ───────────────────────────────
+
+describe('ArrowBinding portX/portY (#147)', () => {
+  it('accepts binding with portX and portY', () => {
+    const result = arrowDataSchema.safeParse(
+      minimalArrow({
+        startBinding: {
+          expressionId: 'shape-1',
+          anchor: 'auto',
+          portX: 0.5,
+          portY: 0.0,
+        },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts binding with only portX', () => {
+    const result = arrowDataSchema.safeParse(
+      minimalArrow({
+        endBinding: {
+          expressionId: 'shape-2',
+          anchor: 'right',
+          portX: 1.0,
+        },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts binding with only portY', () => {
+    const result = arrowDataSchema.safeParse(
+      minimalArrow({
+        endBinding: {
+          expressionId: 'shape-3',
+          anchor: 'bottom',
+          portY: 1.0,
+        },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects portX outside 0-1 range (> 1)', () => {
+    const result = arrowDataSchema.safeParse(
+      minimalArrow({
+        startBinding: {
+          expressionId: 'shape-1',
+          anchor: 'auto',
+          portX: 1.5,
+        },
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects portY outside 0-1 range (< 0)', () => {
+    const result = arrowDataSchema.safeParse(
+      minimalArrow({
+        endBinding: {
+          expressionId: 'shape-1',
+          anchor: 'auto',
+          portY: -0.1,
+        },
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('binding without portX/portY still works (backward compat)', () => {
+    const result = arrowDataSchema.safeParse(
+      minimalArrow({
+        startBinding: {
+          expressionId: 'shape-1',
+          anchor: 'top',
+          ratio: 0.5,
+        },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts portX/portY at boundary values (0 and 1)', () => {
+    const result = arrowDataSchema.safeParse(
+      minimalArrow({
+        startBinding: {
+          expressionId: 'shape-1',
+          anchor: 'auto',
+          portX: 0,
+          portY: 1,
+        },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── Full integration: all new fields combined ─────────────
+
+describe('Full arrow with all new fields (#147)', () => {
+  it('accepts arrow with all new fields set', () => {
+    const result = arrowDataSchema.safeParse({
+      kind: 'arrow',
+      points: [[0, 0], [50, 50], [100, 0]],
+      routing: 'orthogonalCurved',
+      startArrowhead: 'ERone',
+      endArrowhead: 'ERmany',
+      startFill: true,
+      endFill: false,
+      curved: true,
+      rounded: false,
+      jettySize: 15,
+      label: 'has many',
+      startBinding: {
+        expressionId: 'entity-a',
+        anchor: 'right',
+        ratio: 0.5,
+        portX: 1.0,
+        portY: 0.5,
+      },
+      endBinding: {
+        expressionId: 'entity-b',
+        anchor: 'left',
+        portX: 0.0,
+        portY: 0.5,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts arrow with jettySize "auto" and curved routing', () => {
+    const result = arrowDataSchema.safeParse({
+      kind: 'arrow',
+      points: [[0, 0], [100, 100]],
+      routing: 'curved',
+      endArrowhead: 'classic',
+      jettySize: 'auto',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('preserves backward compat — minimal arrow still validates', () => {
+    const result = arrowDataSchema.safeParse({
+      kind: 'arrow',
+      points: [[0, 0], [100, 100]],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('preserves backward compat — arrow with old fields still validates', () => {
+    const result = arrowDataSchema.safeParse({
+      kind: 'arrow',
+      points: [[10, 20], [300, 400]],
+      startArrowhead: false,
+      endArrowhead: 'triangle',
+      routing: 'orthogonal',
+      label: 'old-style arrow',
+      startBinding: { expressionId: 'a', anchor: 'auto' },
+      endBinding: { expressionId: 'b', anchor: 'center', ratio: 0.3 },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/protocol/src/schema/primitives.ts
+++ b/packages/protocol/src/schema/primitives.ts
@@ -43,10 +43,49 @@ export interface ArrowBinding {
   anchor: ArrowAnchor;
   /** Position along the edge (0-1). 0.5 = center. */
   ratio?: number;
+  /** Exact X connection point (0-1 ratio, matches draw.io exitX/entryX). */
+  portX?: number;
+  /** Exact Y connection point (0-1 ratio, matches draw.io exitY/entryY). */
+  portY?: number;
 }
 
-/** Arrowhead tip style. */
-export type ArrowheadType = 'triangle' | 'chevron' | 'diamond' | 'circle' | 'none';
+/**
+ * Arrowhead tip style.
+ *
+ * Covers all draw.io arrowhead types plus legacy InfiniCanvas values.
+ * `'triangle'` is kept as an alias for `'classic'` (backward compat).
+ */
+export type ArrowheadType =
+  // Legacy (backward compat)
+  | 'triangle'      // alias for 'classic'
+  | 'chevron'       // legacy InfiniCanvas
+  // Standard
+  | 'none'          // no arrowhead
+  | 'classic'       // filled triangle (draw.io default)
+  | 'classicThin'   // thinner filled triangle
+  | 'open'          // outline triangle
+  | 'openThin'      // thinner outline triangle
+  | 'block'         // filled rectangle/block
+  | 'blockThin'     // thinner block
+  | 'oval'          // filled circle
+  | 'diamond'       // filled diamond
+  | 'diamondThin'   // thinner diamond
+  | 'circle'        // alias kept for backward compat
+  // ER Diagram
+  | 'ERone'         // single bar (|)
+  | 'ERmany'        // crow's foot (>)
+  | 'ERmandOne'     // mandatory one (||)
+  | 'ERoneToMany'   // one to many (|>)
+  | 'ERzeroToOne'   // zero to one (o|)
+  | 'ERzeroToMany'  // zero to many (o>)
+  // UML
+  | 'openAsync'     // open arrowhead (async message)
+  | 'dash'          // dashed end
+  | 'cross'         // X mark
+  // Other
+  | 'box'           // small filled box
+  | 'halfCircle'    // half circle
+  | 'doubleBlock';  // double block arrows
 
 /** Data for an arrow expression with optional arrowheads. */
 export interface ArrowData {
@@ -57,14 +96,24 @@ export interface ArrowData {
   startArrowhead?: ArrowheadType | boolean;
   /** Arrowhead style at the end ('none' = no arrowhead). */
   endArrowhead?: ArrowheadType | boolean;
+  /** Filled (true) or outline (false) start arrowhead. */
+  startFill?: boolean;
+  /** Filled (true) or outline (false) end arrowhead. */
+  endFill?: boolean;
   /** Binding for the start endpoint to a shape. */
   startBinding?: ArrowBinding;
   /** Binding for the end endpoint to a shape. */
   endBinding?: ArrowBinding;
   /** Optional text label rendered at the arrow midpoint. */
   label?: string;
-  /** Routing mode: 'straight' (default) or 'orthogonal' (right-angle segments). */
+  /** Routing mode for the connector path. */
   routing?: RoutingMode;
+  /** Smooth bezier curves on orthogonal corners (draw.io curved=1). */
+  curved?: boolean;
+  /** Round corners on orthogonal route segments. */
+  rounded?: boolean;
+  /** Exit stub length from shape; 'auto' = calculated. */
+  jettySize?: number | 'auto';
 }
 
 /** Data for a freehand drawing expression. */
@@ -135,8 +184,25 @@ export interface ContainerData {
   collapsed: boolean;
 }
 
-/** Routing mode for arrow connectors. */
-export type RoutingMode = 'straight' | 'orthogonal';
+/**
+ * Routing mode for arrow connectors.
+ *
+ * - `'straight'` — direct line between points
+ * - `'orthogonal'` — right-angle segments
+ * - `'curved'` — smooth bezier curve
+ * - `'elbow'` — single-bend elbow connector
+ * - `'entityRelation'` — ER-style routing with perpendicular exits
+ * - `'isometric'` — 30°/60° isometric routing
+ * - `'orthogonalCurved'` — orthogonal routing with bezier-smoothed corners
+ */
+export type RoutingMode =
+  | 'straight'
+  | 'orthogonal'
+  | 'curved'
+  | 'elbow'
+  | 'entityRelation'
+  | 'isometric'
+  | 'orthogonalCurved';
 
 /** Union of all primitive expression data types. */
 export type PrimitiveData =

--- a/packages/protocol/src/validation/schemas.ts
+++ b/packages/protocol/src/validation/schemas.ts
@@ -113,19 +113,43 @@ const arrowBindingSchema = z.object({
   anchor: z.enum(['center', 'top', 'right', 'bottom', 'left',
     'top-left', 'top-right', 'bottom-left', 'bottom-right', 'auto']),
   ratio: z.number().min(0).max(1).optional(),
+  portX: z.number().min(0).max(1).optional(),
+  portY: z.number().min(0).max(1).optional(),
 });
 
-const arrowheadTypeSchema = z.enum(['none', 'triangle', 'chevron', 'diamond', 'circle']);
+const arrowheadTypeSchema = z.enum([
+  // Legacy (backward compat)
+  'none', 'triangle', 'chevron', 'circle',
+  // Standard
+  'classic', 'classicThin', 'open', 'openThin',
+  'block', 'blockThin', 'oval', 'diamond', 'diamondThin',
+  // ER Diagram
+  'ERone', 'ERmany', 'ERmandOne', 'ERoneToMany', 'ERzeroToOne', 'ERzeroToMany',
+  // UML
+  'openAsync', 'dash', 'cross',
+  // Other
+  'box', 'halfCircle', 'doubleBlock',
+]);
+
+const routingModeSchema = z.enum([
+  'straight', 'orthogonal', 'curved', 'elbow',
+  'entityRelation', 'isometric', 'orthogonalCurved',
+]);
 
 export const arrowDataSchema = z.object({
   kind: z.literal('arrow'),
   points: z.array(point2dSchema).min(2),
   startArrowhead: z.union([z.boolean(), arrowheadTypeSchema]).optional(),
   endArrowhead: z.union([z.boolean(), arrowheadTypeSchema]).optional(),
+  startFill: z.boolean().optional(),
+  endFill: z.boolean().optional(),
   startBinding: arrowBindingSchema.optional(),
   endBinding: arrowBindingSchema.optional(),
   label: z.string().max(500).optional(),
-  routing: z.enum(['straight', 'orthogonal']).optional(),
+  routing: routingModeSchema.optional(),
+  curved: z.boolean().optional(),
+  rounded: z.boolean().optional(),
+  jettySize: z.union([z.number().nonnegative(), z.literal('auto')]).optional(),
 });
 
 const point3dSchema = z.tuple([z.number(), z.number(), z.number()]);


### PR DESCRIPTION
Foundation for draw.io connectors. 7 routing modes, 26 arrowheads, edge properties. Vite ✓.

Closes #147

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>