### PR TITLE
feat: arrowhead renderer — 22 draw.io types (#148)

### DIFF
--- a/packages/engine/src/__tests__/arrowheads.test.ts
+++ b/packages/engine/src/__tests__/arrowheads.test.ts
@@ -1,0 +1,459 @@
+/**
+ * Unit tests for arrowhead registry and renderers.
+ *
+ * Covers: all 22+ ArrowheadType renderings, filled vs outline,
+ * angle rotation, 'none' skip, thin variants, ER markers,
+ * backward compat aliases, and registry completeness.
+ *
+ * @module
+ */
+
+import type { ArrowheadType } from '@infinicanvas/protocol';
+import {
+  renderArrowheadFromRegistry,
+  getArrowheadRenderer,
+  ALL_ARROWHEAD_TYPES,
+} from '../renderer/arrowheads.js';
+
+// ── Mock Canvas Context ─────────────────────────────────────
+
+function createMockCtx() {
+  return {
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    setLineDash: vi.fn(),
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    lineWidth: 2,
+    globalAlpha: 1,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+// ── Registry Completeness ───────────────────────────────────
+
+describe('arrowhead registry completeness', () => {
+  /**
+   * Every ArrowheadType defined in the protocol must have a renderer
+   * registered. This ensures no type goes unhandled at runtime.
+   */
+  const protocolTypes: ArrowheadType[] = [
+    'triangle', 'chevron',
+    'none', 'classic', 'classicThin', 'open', 'openThin',
+    'block', 'blockThin', 'oval', 'diamond', 'diamondThin', 'circle',
+    'ERone', 'ERmany', 'ERmandOne', 'ERoneToMany', 'ERzeroToOne', 'ERzeroToMany',
+    'openAsync', 'dash', 'cross',
+    'box', 'halfCircle', 'doubleBlock',
+  ];
+
+  it.each(protocolTypes)('has a renderer for "%s"', (type) => {
+    const renderer = getArrowheadRenderer(type);
+    expect(renderer).toBeDefined();
+  });
+
+  it('exports ALL_ARROWHEAD_TYPES matching the protocol types', () => {
+    for (const type of protocolTypes) {
+      expect(ALL_ARROWHEAD_TYPES).toContain(type);
+    }
+  });
+});
+
+// ── 'none' type ─────────────────────────────────────────────
+
+describe('arrowhead type "none"', () => {
+  it('produces no draw calls', () => {
+    const ctx = createMockCtx();
+    renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'none', true, '#000', '#fff');
+
+    expect(ctx.beginPath).not.toHaveBeenCalled();
+    expect(ctx.moveTo).not.toHaveBeenCalled();
+    expect(ctx.lineTo).not.toHaveBeenCalled();
+    expect(ctx.fill).not.toHaveBeenCalled();
+    expect(ctx.stroke).not.toHaveBeenCalled();
+    expect(ctx.arc).not.toHaveBeenCalled();
+  });
+});
+
+// ── Standard Arrowheads ─────────────────────────────────────
+
+describe('standard arrowheads', () => {
+  describe('classic (filled triangle)', () => {
+    it('renders without error at angle 0', () => {
+      const ctx = createMockCtx();
+      expect(() => {
+        renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'classic', true, '#000', '#fff');
+      }).not.toThrow();
+    });
+
+    it('calls fill when filled=true', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'classic', true, '#000', '#fff');
+      expect(ctx.fill).toHaveBeenCalled();
+    });
+
+    it('calls stroke (not fill) when filled=false', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'classic', false, '#000', '#fff');
+      expect(ctx.stroke).toHaveBeenCalled();
+    });
+
+    it('draws a triangle path (moveTo + 2 lineTo + closePath)', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'classic', true, '#000', '#fff');
+      expect(ctx.beginPath).toHaveBeenCalled();
+      expect(ctx.moveTo).toHaveBeenCalled();
+      expect(ctx.lineTo).toHaveBeenCalledTimes(2);
+      expect(ctx.closePath).toHaveBeenCalled();
+    });
+  });
+
+  describe('triangle (alias for classic)', () => {
+    it('renders identically to classic', () => {
+      const ctxClassic = createMockCtx();
+      const ctxTriangle = createMockCtx();
+      renderArrowheadFromRegistry(ctxClassic, 100, 100, Math.PI / 4, 10, 'classic', true, '#000', '#fff');
+      renderArrowheadFromRegistry(ctxTriangle, 100, 100, Math.PI / 4, 10, 'triangle', true, '#000', '#fff');
+
+      // Both should produce moveTo at same position
+      expect(ctxClassic.moveTo).toHaveBeenCalledWith(
+        ...ctxTriangle.moveTo.mock.calls[0]!,
+      );
+    });
+  });
+
+  describe('classicThin', () => {
+    it('renders without error', () => {
+      const ctx = createMockCtx();
+      expect(() => {
+        renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'classicThin', true, '#000', '#fff');
+      }).not.toThrow();
+    });
+
+    it('draws a narrower triangle than classic', () => {
+      const ctxClassic = createMockCtx();
+      const ctxThin = createMockCtx();
+      renderArrowheadFromRegistry(ctxClassic, 100, 100, Math.PI / 2, 10, 'classic', true, '#000', '#fff');
+      renderArrowheadFromRegistry(ctxThin, 100, 100, Math.PI / 2, 10, 'classicThin', true, '#000', '#fff');
+
+      // Both should have lineTo calls but with different positions (thin is narrower)
+      expect(ctxThin.lineTo).toHaveBeenCalledTimes(2);
+      // Thin variant X positions should differ from classic
+      const classicCalls = ctxClassic.lineTo.mock.calls;
+      const thinCalls = ctxThin.lineTo.mock.calls;
+      const classicWidth = Math.abs((classicCalls[0]![0] as number) - (classicCalls[1]![0] as number));
+      const thinWidth = Math.abs((thinCalls[0]![0] as number) - (thinCalls[1]![0] as number));
+      expect(thinWidth).toBeLessThan(classicWidth);
+    });
+  });
+
+  describe('open (outline triangle)', () => {
+    it('calls stroke, not fill', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'open', true, '#000', '#fff');
+      // 'open' is always outline — ignores filled param
+      expect(ctx.stroke).toHaveBeenCalled();
+      expect(ctx.fill).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('openThin', () => {
+    it('calls stroke, not fill', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'openThin', true, '#000', '#fff');
+      expect(ctx.stroke).toHaveBeenCalled();
+      expect(ctx.fill).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('block (filled rectangle)', () => {
+    it('renders without error', () => {
+      const ctx = createMockCtx();
+      expect(() => {
+        renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'block', true, '#000', '#fff');
+      }).not.toThrow();
+    });
+
+    it('draws a rectangular path (4 lineTo calls)', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'block', true, '#000', '#fff');
+      expect(ctx.beginPath).toHaveBeenCalled();
+      expect(ctx.lineTo.mock.calls.length).toBeGreaterThanOrEqual(3);
+      expect(ctx.closePath).toHaveBeenCalled();
+    });
+  });
+
+  describe('blockThin', () => {
+    it('renders without error', () => {
+      const ctx = createMockCtx();
+      expect(() => {
+        renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'blockThin', true, '#000', '#fff');
+      }).not.toThrow();
+    });
+  });
+
+  describe('oval', () => {
+    it('draws an arc (circle)', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'oval', true, '#000', '#fff');
+      expect(ctx.arc).toHaveBeenCalled();
+    });
+
+    it('fills when filled=true', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'oval', true, '#000', '#fff');
+      expect(ctx.fill).toHaveBeenCalled();
+    });
+
+    it('strokes when filled=false', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'oval', false, '#000', '#fff');
+      expect(ctx.stroke).toHaveBeenCalled();
+    });
+  });
+
+  describe('circle (alias for oval)', () => {
+    it('draws an arc', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'circle', true, '#000', '#fff');
+      expect(ctx.arc).toHaveBeenCalled();
+    });
+  });
+
+  describe('diamond', () => {
+    it('renders without error', () => {
+      const ctx = createMockCtx();
+      expect(() => {
+        renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'diamond', true, '#000', '#fff');
+      }).not.toThrow();
+    });
+
+    it('draws a diamond path (4 vertices)', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'diamond', true, '#000', '#fff');
+      expect(ctx.beginPath).toHaveBeenCalled();
+      expect(ctx.moveTo).toHaveBeenCalled();
+      // 3 lineTo calls (moveTo is 1st vertex, then 3 lineTo for remaining)
+      expect(ctx.lineTo).toHaveBeenCalledTimes(3);
+      expect(ctx.closePath).toHaveBeenCalled();
+    });
+  });
+
+  describe('diamondThin', () => {
+    it('renders without error', () => {
+      const ctx = createMockCtx();
+      expect(() => {
+        renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'diamondThin', true, '#000', '#fff');
+      }).not.toThrow();
+    });
+  });
+
+  describe('box (alias for block)', () => {
+    it('renders without error', () => {
+      const ctx = createMockCtx();
+      expect(() => {
+        renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'box', true, '#000', '#fff');
+      }).not.toThrow();
+    });
+  });
+});
+
+// ── ER Diagram Arrowheads ───────────────────────────────────
+
+describe('ER diagram arrowheads', () => {
+  const erTypes: ArrowheadType[] = [
+    'ERone', 'ERmany', 'ERmandOne', 'ERoneToMany', 'ERzeroToOne', 'ERzeroToMany',
+  ];
+
+  it.each(erTypes)('"%s" renders without error', (type) => {
+    const ctx = createMockCtx();
+    expect(() => {
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 15, type, true, '#000', '#fff');
+    }).not.toThrow();
+  });
+
+  it.each(erTypes)('"%s" produces draw calls', (type) => {
+    const ctx = createMockCtx();
+    renderArrowheadFromRegistry(ctx, 100, 100, 0, 15, type, true, '#000', '#fff');
+    // All ER types should draw something
+    const totalCalls = ctx.moveTo.mock.calls.length +
+      ctx.lineTo.mock.calls.length +
+      ctx.arc.mock.calls.length;
+    expect(totalCalls).toBeGreaterThan(0);
+  });
+
+  describe('ERone (single bar)', () => {
+    it('draws a perpendicular line', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 15, 'ERone', true, '#000', '#fff');
+      expect(ctx.stroke).toHaveBeenCalled();
+    });
+  });
+
+  describe('ERmany (crow\'s foot)', () => {
+    it('draws three diverging lines', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 15, 'ERmany', true, '#000', '#fff');
+      // Crow's foot: 3 lines from tip diverging backward
+      expect(ctx.moveTo.mock.calls.length).toBeGreaterThanOrEqual(3);
+      expect(ctx.stroke).toHaveBeenCalled();
+    });
+  });
+
+  describe('ERmandOne (double bar)', () => {
+    it('draws two perpendicular lines', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 15, 'ERmandOne', true, '#000', '#fff');
+      expect(ctx.stroke).toHaveBeenCalled();
+    });
+  });
+
+  describe('ERzeroToOne (circle + bar)', () => {
+    it('draws both an arc and lines', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 15, 'ERzeroToOne', true, '#000', '#fff');
+      expect(ctx.arc).toHaveBeenCalled();
+      expect(ctx.stroke).toHaveBeenCalled();
+    });
+  });
+
+  describe('ERzeroToMany (circle + crow\'s foot)', () => {
+    it('draws both an arc and lines', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 15, 'ERzeroToMany', true, '#000', '#fff');
+      expect(ctx.arc).toHaveBeenCalled();
+      expect(ctx.stroke).toHaveBeenCalled();
+    });
+  });
+});
+
+// ── UML & Other Arrowheads ──────────────────────────────────
+
+describe('UML and other arrowheads', () => {
+  describe('openAsync (open chevron)', () => {
+    it('renders with stroke only', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'openAsync', true, '#000', '#fff');
+      expect(ctx.stroke).toHaveBeenCalled();
+      expect(ctx.fill).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('chevron (alias for openAsync)', () => {
+    it('renders without error', () => {
+      const ctx = createMockCtx();
+      expect(() => {
+        renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'chevron', true, '#000', '#fff');
+      }).not.toThrow();
+      expect(ctx.stroke).toHaveBeenCalled();
+    });
+  });
+
+  describe('dash (perpendicular line)', () => {
+    it('renders a short perpendicular stroke', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'dash', true, '#000', '#fff');
+      expect(ctx.stroke).toHaveBeenCalled();
+    });
+  });
+
+  describe('cross (X mark)', () => {
+    it('draws two crossing lines', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'cross', true, '#000', '#fff');
+      expect(ctx.stroke).toHaveBeenCalled();
+      // X = 2 strokes from moveTo→lineTo
+      expect(ctx.moveTo.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('halfCircle', () => {
+    it('draws a semicircle arc', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'halfCircle', true, '#000', '#fff');
+      expect(ctx.arc).toHaveBeenCalled();
+    });
+  });
+
+  describe('doubleBlock', () => {
+    it('renders without error', () => {
+      const ctx = createMockCtx();
+      expect(() => {
+        renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'doubleBlock', true, '#000', '#fff');
+      }).not.toThrow();
+    });
+
+    it('draws a path with fill or stroke', () => {
+      const ctx = createMockCtx();
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'doubleBlock', true, '#000', '#fff');
+      const drew = ctx.fill.mock.calls.length > 0 || ctx.stroke.mock.calls.length > 0;
+      expect(drew).toBe(true);
+    });
+  });
+});
+
+// ── Angle Rotation ──────────────────────────────────────────
+
+describe('angle rotation', () => {
+  const angles = [0, Math.PI / 4, Math.PI / 2, Math.PI, -Math.PI / 2, 3 * Math.PI / 4];
+
+  it.each(angles)('classic renders correctly at angle %f rad', (angle) => {
+    const ctx = createMockCtx();
+    expect(() => {
+      renderArrowheadFromRegistry(ctx, 100, 100, angle, 10, 'classic', true, '#000', '#fff');
+    }).not.toThrow();
+    expect(ctx.moveTo).toHaveBeenCalled();
+  });
+
+  it('tip position changes with angle for classic', () => {
+    const ctx0 = createMockCtx();
+    const ctx90 = createMockCtx();
+    renderArrowheadFromRegistry(ctx0, 100, 100, 0, 10, 'classic', true, '#000', '#fff');
+    renderArrowheadFromRegistry(ctx90, 100, 100, Math.PI / 2, 10, 'classic', true, '#000', '#fff');
+
+    // The lineTo positions should differ between angle 0 and angle PI/2
+    const lineTo0 = ctx0.lineTo.mock.calls[0]!;
+    const lineTo90 = ctx90.lineTo.mock.calls[0]!;
+    expect(lineTo0[0]).not.toBeCloseTo(lineTo90[0] as number, 3);
+  });
+});
+
+// ── Unknown Type Fallback ───────────────────────────────────
+
+describe('unknown arrowhead type fallback', () => {
+  it('falls back to classic for unknown type', () => {
+    const ctx = createMockCtx();
+    expect(() => {
+      renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'unknownType' as ArrowheadType, true, '#000', '#fff');
+    }).not.toThrow();
+    // Should still draw something (classic fallback)
+    expect(ctx.beginPath).toHaveBeenCalled();
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+});
+
+// ── Color Handling ──────────────────────────────────────────
+
+describe('color handling', () => {
+  it('sets fillStyle to strokeColor when filled', () => {
+    const ctx = createMockCtx();
+    renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'classic', true, '#ff0000', '#ffffff');
+    // ctx.save/restore wraps it; check fillStyle was set
+    expect(ctx.save).toHaveBeenCalled();
+    expect(ctx.restore).toHaveBeenCalled();
+  });
+
+  it('sets fillStyle to fillColor (background) when not filled', () => {
+    const ctx = createMockCtx();
+    renderArrowheadFromRegistry(ctx, 100, 100, 0, 10, 'classic', false, '#ff0000', '#ffffff');
+    expect(ctx.save).toHaveBeenCalled();
+    expect(ctx.restore).toHaveBeenCalled();
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -45,6 +45,11 @@ export {
   clearDrawableCache,
   clearImageCache,
 } from './renderer/primitiveRenderer.js';
+export {
+  renderArrowheadFromRegistry,
+  getArrowheadRenderer,
+  ALL_ARROWHEAD_TYPES,
+} from './renderer/arrowheads.js';
 export { mapStyleToRoughOptions, computeStyleHash, computeRenderHash } from './renderer/styleMapper.js';
 export { isVisible, getWorldViewport } from './renderer/viewportCulling.js';
 export type { BoundingBox, WorldViewport } from './renderer/viewportCulling.js';

--- a/packages/engine/src/renderer/arrowheads.ts
+++ b/packages/engine/src/renderer/arrowheads.ts
@@ -1,0 +1,605 @@
+/**
+ * Arrowhead registry and renderers.
+ *
+ * Provides Canvas2D rendering for all 22+ ArrowheadType values defined
+ * in the protocol schema. Each arrowhead type has a dedicated renderer
+ * function registered in a lookup map.
+ *
+ * Usage:
+ *   renderArrowheadFromRegistry(ctx, tipX, tipY, angle, size, type, filled, strokeColor, fillColor);
+ *
+ * @module
+ */
+
+// ArrowheadType values are defined in @infinicanvas/protocol.
+// This module uses string keys for the registry to allow flexible lookups.
+
+// ── Types ────────────────────────────────────────────────────
+
+/**
+ * Renderer function for a single arrowhead type.
+ *
+ * @param ctx        - Canvas 2D rendering context
+ * @param tipX       - X position of the arrowhead tip
+ * @param tipY       - Y position of the arrowhead tip
+ * @param angle      - Direction angle in radians (where the arrow points)
+ * @param size       - Arrowhead size in world pixels
+ * @param filled     - Whether to fill (true) or stroke-only (false)
+ * @param strokeColor - Stroke/border color
+ * @param fillColor   - Fill color (used for outline arrowheads' interior)
+ */
+type ArrowheadRenderer = (
+  ctx: CanvasRenderingContext2D,
+  tipX: number,
+  tipY: number,
+  angle: number,
+  size: number,
+  filled: boolean,
+  strokeColor: string,
+  fillColor: string,
+) => void;
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Standard half-angle for triangle-based arrowheads (30°). */
+const HALF_ANGLE = Math.PI / 6;
+
+/** Thin variant width multiplier (60% of normal). */
+const THIN_FACTOR = 0.6;
+
+// ── Registry ─────────────────────────────────────────────────
+
+const ARROWHEAD_REGISTRY = new Map<string, ArrowheadRenderer>();
+
+// ── Helper functions ─────────────────────────────────────────
+
+/** Fill or stroke the current path based on the `filled` flag. */
+function fillOrStroke(
+  ctx: CanvasRenderingContext2D,
+  filled: boolean,
+  strokeColor: string,
+  fillColor: string,
+): void {
+  if (filled) {
+    ctx.fillStyle = strokeColor;
+    ctx.fill();
+  } else {
+    ctx.fillStyle = fillColor;
+    ctx.fill();
+    ctx.strokeStyle = strokeColor;
+    ctx.stroke();
+  }
+}
+
+/**
+ * Draw a triangle arrowhead path.
+ *
+ * @param widthFactor - Multiplier for the half-angle spread (1.0 = normal, 0.6 = thin)
+ */
+function drawTrianglePath(
+  ctx: CanvasRenderingContext2D,
+  tipX: number,
+  tipY: number,
+  angle: number,
+  size: number,
+  widthFactor: number,
+): void {
+  const halfAngle = HALF_ANGLE * widthFactor;
+  ctx.beginPath();
+  ctx.moveTo(tipX, tipY);
+  ctx.lineTo(
+    tipX - size * Math.cos(angle - halfAngle),
+    tipY - size * Math.sin(angle - halfAngle),
+  );
+  ctx.lineTo(
+    tipX - size * Math.cos(angle + halfAngle),
+    tipY - size * Math.sin(angle + halfAngle),
+  );
+  ctx.closePath();
+}
+
+/**
+ * Draw a block (rectangle) arrowhead path.
+ *
+ * The block is aligned along the arrow direction with the tip
+ * at one edge.
+ *
+ * @param widthFactor - Multiplier for block width (1.0 = normal, 0.6 = thin)
+ */
+function drawBlockPath(
+  ctx: CanvasRenderingContext2D,
+  tipX: number,
+  tipY: number,
+  angle: number,
+  size: number,
+  widthFactor: number,
+): void {
+  const halfW = size * 0.4 * widthFactor;
+  const perpAngle = angle + Math.PI / 2;
+  const backX = tipX - size * Math.cos(angle);
+  const backY = tipY - size * Math.sin(angle);
+  const dx = halfW * Math.cos(perpAngle);
+  const dy = halfW * Math.sin(perpAngle);
+
+  ctx.beginPath();
+  ctx.moveTo(tipX + dx, tipY + dy);
+  ctx.lineTo(tipX - dx, tipY - dy);
+  ctx.lineTo(backX - dx, backY - dy);
+  ctx.lineTo(backX + dx, backY + dy);
+  ctx.closePath();
+}
+
+/**
+ * Draw a diamond arrowhead path.
+ *
+ * @param widthFactor - Multiplier for diamond width (1.0 = normal, 0.6 = thin)
+ */
+function drawDiamondPath(
+  ctx: CanvasRenderingContext2D,
+  tipX: number,
+  tipY: number,
+  angle: number,
+  size: number,
+  widthFactor: number,
+): void {
+  const hSize = size * 0.6;
+  const halfW = hSize * 0.5 * widthFactor;
+  const cx = tipX - hSize * Math.cos(angle);
+  const cy = tipY - hSize * Math.sin(angle);
+  const perpAngle = angle + Math.PI / 2;
+
+  ctx.beginPath();
+  ctx.moveTo(tipX, tipY);
+  ctx.lineTo(
+    cx + halfW * Math.cos(perpAngle),
+    cy + halfW * Math.sin(perpAngle),
+  );
+  ctx.lineTo(cx - hSize * Math.cos(angle), cy - hSize * Math.sin(angle));
+  ctx.lineTo(
+    cx - halfW * Math.cos(perpAngle),
+    cy - halfW * Math.sin(perpAngle),
+  );
+  ctx.closePath();
+}
+
+/**
+ * Draw a perpendicular bar at the given position.
+ *
+ * Used for ER diagram markers (|).
+ */
+function drawBar(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  angle: number,
+  size: number,
+): void {
+  const perpAngle = angle + Math.PI / 2;
+  const halfH = size * 0.5;
+  ctx.moveTo(
+    x + halfH * Math.cos(perpAngle),
+    y + halfH * Math.sin(perpAngle),
+  );
+  ctx.lineTo(
+    x - halfH * Math.cos(perpAngle),
+    y - halfH * Math.sin(perpAngle),
+  );
+}
+
+/**
+ * Draw crow's foot (three diverging lines) from a point.
+ *
+ * Used for ER diagram "many" markers (>).
+ */
+function drawCrowsFoot(
+  ctx: CanvasRenderingContext2D,
+  tipX: number,
+  tipY: number,
+  angle: number,
+  size: number,
+): void {
+  const backX = tipX - size * Math.cos(angle);
+  const backY = tipY - size * Math.sin(angle);
+  const perpAngle = angle + Math.PI / 2;
+  const spread = size * 0.5;
+
+  // Center line
+  ctx.moveTo(tipX, tipY);
+  ctx.lineTo(backX, backY);
+
+  // Upper fork
+  ctx.moveTo(tipX, tipY);
+  ctx.lineTo(
+    backX + spread * Math.cos(perpAngle),
+    backY + spread * Math.sin(perpAngle),
+  );
+
+  // Lower fork
+  ctx.moveTo(tipX, tipY);
+  ctx.lineTo(
+    backX - spread * Math.cos(perpAngle),
+    backY - spread * Math.sin(perpAngle),
+  );
+}
+
+/**
+ * Draw a small circle at the given position.
+ *
+ * Used for ER diagram "zero" markers (o).
+ */
+function drawERCircle(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  radius: number,
+  fillColor: string,
+): void {
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.fillStyle = fillColor;
+  ctx.fill();
+  ctx.stroke();
+}
+
+// ── Arrowhead Renderers ──────────────────────────────────────
+
+// --- none ---
+const renderNone: ArrowheadRenderer = () => {
+  // Intentionally empty — no arrowhead.
+};
+
+// --- classic (filled triangle) ---
+const renderClassic: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, filled, strokeColor, fillColor) => {
+  drawTrianglePath(ctx, tipX, tipY, angle, size, 1.0);
+  fillOrStroke(ctx, filled, strokeColor, fillColor);
+};
+
+// --- classicThin ---
+const renderClassicThin: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, filled, strokeColor, fillColor) => {
+  drawTrianglePath(ctx, tipX, tipY, angle, size, THIN_FACTOR);
+  fillOrStroke(ctx, filled, strokeColor, fillColor);
+};
+
+// --- open (outline-only triangle, always stroked) ---
+const renderOpen: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, _fillColor) => {
+  const halfAngle = HALF_ANGLE;
+  ctx.beginPath();
+  ctx.moveTo(
+    tipX - size * Math.cos(angle - halfAngle),
+    tipY - size * Math.sin(angle - halfAngle),
+  );
+  ctx.lineTo(tipX, tipY);
+  ctx.lineTo(
+    tipX - size * Math.cos(angle + halfAngle),
+    tipY - size * Math.sin(angle + halfAngle),
+  );
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+  ctx.stroke();
+};
+
+// --- openThin ---
+const renderOpenThin: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, _fillColor) => {
+  const halfAngle = HALF_ANGLE * THIN_FACTOR;
+  ctx.beginPath();
+  ctx.moveTo(
+    tipX - size * Math.cos(angle - halfAngle),
+    tipY - size * Math.sin(angle - halfAngle),
+  );
+  ctx.lineTo(tipX, tipY);
+  ctx.lineTo(
+    tipX - size * Math.cos(angle + halfAngle),
+    tipY - size * Math.sin(angle + halfAngle),
+  );
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+  ctx.stroke();
+};
+
+// --- block (filled rectangle) ---
+const renderBlock: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, filled, strokeColor, fillColor) => {
+  drawBlockPath(ctx, tipX, tipY, angle, size, 1.0);
+  fillOrStroke(ctx, filled, strokeColor, fillColor);
+};
+
+// --- blockThin ---
+const renderBlockThin: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, filled, strokeColor, fillColor) => {
+  drawBlockPath(ctx, tipX, tipY, angle, size, THIN_FACTOR);
+  fillOrStroke(ctx, filled, strokeColor, fillColor);
+};
+
+// --- oval (filled circle) ---
+const renderOval: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, filled, strokeColor, fillColor) => {
+  const r = size * 0.35;
+  const cx = tipX - r * Math.cos(angle);
+  const cy = tipY - r * Math.sin(angle);
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, 0, Math.PI * 2);
+  fillOrStroke(ctx, filled, strokeColor, fillColor);
+};
+
+// --- diamond (filled diamond) ---
+const renderDiamond: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, filled, strokeColor, fillColor) => {
+  drawDiamondPath(ctx, tipX, tipY, angle, size, 1.0);
+  fillOrStroke(ctx, filled, strokeColor, fillColor);
+};
+
+// --- diamondThin ---
+const renderDiamondThin: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, filled, strokeColor, fillColor) => {
+  drawDiamondPath(ctx, tipX, tipY, angle, size, THIN_FACTOR);
+  fillOrStroke(ctx, filled, strokeColor, fillColor);
+};
+
+// --- ERone (single bar |) ---
+const renderERone: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, _fillColor) => {
+  ctx.beginPath();
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+  drawBar(ctx, tipX, tipY, angle, size);
+  ctx.stroke();
+};
+
+// --- ERmany (crow's foot >) ---
+const renderERmany: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, _fillColor) => {
+  ctx.beginPath();
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+  drawCrowsFoot(ctx, tipX, tipY, angle, size);
+  ctx.stroke();
+};
+
+// --- ERmandOne (double bar ||) ---
+const renderERmandOne: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, _fillColor) => {
+  ctx.beginPath();
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+  // First bar at tip
+  drawBar(ctx, tipX, tipY, angle, size);
+  // Second bar offset backward
+  const offset = size * 0.25;
+  drawBar(
+    ctx,
+    tipX - offset * Math.cos(angle),
+    tipY - offset * Math.sin(angle),
+    angle,
+    size,
+  );
+  ctx.stroke();
+};
+
+// --- ERoneToMany (bar + crow's foot |>) ---
+const renderERoneToMany: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, _fillColor) => {
+  ctx.beginPath();
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+  // Crow's foot at tip
+  drawCrowsFoot(ctx, tipX, tipY, angle, size);
+  // Bar behind crow's foot
+  const barOffset = size * 1.1;
+  drawBar(
+    ctx,
+    tipX - barOffset * Math.cos(angle),
+    tipY - barOffset * Math.sin(angle),
+    angle,
+    size,
+  );
+  ctx.stroke();
+};
+
+// --- ERzeroToOne (circle + bar o|) ---
+const renderERzeroToOne: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, fillColor) => {
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+
+  // Bar at tip
+  ctx.beginPath();
+  drawBar(ctx, tipX, tipY, angle, size);
+  ctx.stroke();
+
+  // Circle behind bar
+  const circleOffset = size * 0.5;
+  const r = size * 0.2;
+  drawERCircle(
+    ctx,
+    tipX - circleOffset * Math.cos(angle),
+    tipY - circleOffset * Math.sin(angle),
+    r,
+    fillColor,
+  );
+};
+
+// --- ERzeroToMany (circle + crow's foot o>) ---
+const renderERzeroToMany: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, fillColor) => {
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+
+  // Crow's foot at tip
+  ctx.beginPath();
+  drawCrowsFoot(ctx, tipX, tipY, angle, size);
+  ctx.stroke();
+
+  // Circle behind crow's foot
+  const circleOffset = size * 1.2;
+  const r = size * 0.2;
+  drawERCircle(
+    ctx,
+    tipX - circleOffset * Math.cos(angle),
+    tipY - circleOffset * Math.sin(angle),
+    r,
+    fillColor,
+  );
+};
+
+// --- openAsync / chevron (open > stroke only) ---
+const renderOpenAsync: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, _fillColor) => {
+  ctx.beginPath();
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+  ctx.moveTo(
+    tipX - size * Math.cos(angle - HALF_ANGLE),
+    tipY - size * Math.sin(angle - HALF_ANGLE),
+  );
+  ctx.lineTo(tipX, tipY);
+  ctx.lineTo(
+    tipX - size * Math.cos(angle + HALF_ANGLE),
+    tipY - size * Math.sin(angle + HALF_ANGLE),
+  );
+  ctx.stroke();
+};
+
+// --- dash (short perpendicular line) ---
+const renderDash: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, _fillColor) => {
+  ctx.beginPath();
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+  drawBar(ctx, tipX, tipY, angle, size * 0.7);
+  ctx.stroke();
+};
+
+// --- cross (X mark) ---
+const renderCross: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, _filled, strokeColor, _fillColor) => {
+  const halfSize = size * 0.35;
+  ctx.beginPath();
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
+
+  // Forward-slash stroke of the X
+  ctx.moveTo(
+    tipX + halfSize * Math.cos(angle + Math.PI / 4),
+    tipY + halfSize * Math.sin(angle + Math.PI / 4),
+  );
+  ctx.lineTo(
+    tipX - halfSize * Math.cos(angle + Math.PI / 4),
+    tipY - halfSize * Math.sin(angle + Math.PI / 4),
+  );
+
+  // Back-slash stroke of the X
+  ctx.moveTo(
+    tipX + halfSize * Math.cos(angle - Math.PI / 4),
+    tipY + halfSize * Math.sin(angle - Math.PI / 4),
+  );
+  ctx.lineTo(
+    tipX - halfSize * Math.cos(angle - Math.PI / 4),
+    tipY - halfSize * Math.sin(angle - Math.PI / 4),
+  );
+
+  ctx.stroke();
+};
+
+// --- halfCircle ---
+const renderHalfCircle: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, filled, strokeColor, _fillColor) => {
+  const r = size * 0.4;
+  ctx.beginPath();
+  // Semicircle: arc from angle-PI/2 to angle+PI/2 (the back half)
+  ctx.arc(tipX, tipY, r, angle + Math.PI / 2, angle - Math.PI / 2);
+  if (filled) {
+    ctx.fillStyle = strokeColor;
+    ctx.fill();
+  } else {
+    ctx.strokeStyle = strokeColor;
+    ctx.stroke();
+  }
+};
+
+// --- doubleBlock (two stacked block arrows) ---
+const renderDoubleBlock: ArrowheadRenderer = (ctx, tipX, tipY, angle, size, filled, strokeColor, fillColor) => {
+  // First block at tip
+  drawBlockPath(ctx, tipX, tipY, angle, size * 0.7, 1.0);
+  fillOrStroke(ctx, filled, strokeColor, fillColor);
+
+  // Second block offset backward
+  const offset = size * 0.75;
+  drawBlockPath(
+    ctx,
+    tipX - offset * Math.cos(angle),
+    tipY - offset * Math.sin(angle),
+    angle,
+    size * 0.7,
+    1.0,
+  );
+  fillOrStroke(ctx, filled, strokeColor, fillColor);
+};
+
+// ── Register all arrowhead types ─────────────────────────────
+
+// Standard
+ARROWHEAD_REGISTRY.set('none', renderNone);
+ARROWHEAD_REGISTRY.set('classic', renderClassic);
+ARROWHEAD_REGISTRY.set('triangle', renderClassic);         // alias
+ARROWHEAD_REGISTRY.set('classicThin', renderClassicThin);
+ARROWHEAD_REGISTRY.set('open', renderOpen);
+ARROWHEAD_REGISTRY.set('openThin', renderOpenThin);
+ARROWHEAD_REGISTRY.set('block', renderBlock);
+ARROWHEAD_REGISTRY.set('blockThin', renderBlockThin);
+ARROWHEAD_REGISTRY.set('oval', renderOval);
+ARROWHEAD_REGISTRY.set('circle', renderOval);               // alias
+ARROWHEAD_REGISTRY.set('diamond', renderDiamond);
+ARROWHEAD_REGISTRY.set('diamondThin', renderDiamondThin);
+ARROWHEAD_REGISTRY.set('box', renderBlock);                  // alias
+
+// ER Diagram
+ARROWHEAD_REGISTRY.set('ERone', renderERone);
+ARROWHEAD_REGISTRY.set('ERmany', renderERmany);
+ARROWHEAD_REGISTRY.set('ERmandOne', renderERmandOne);
+ARROWHEAD_REGISTRY.set('ERoneToMany', renderERoneToMany);
+ARROWHEAD_REGISTRY.set('ERzeroToOne', renderERzeroToOne);
+ARROWHEAD_REGISTRY.set('ERzeroToMany', renderERzeroToMany);
+
+// UML
+ARROWHEAD_REGISTRY.set('openAsync', renderOpenAsync);
+ARROWHEAD_REGISTRY.set('chevron', renderOpenAsync);         // alias
+ARROWHEAD_REGISTRY.set('dash', renderDash);
+ARROWHEAD_REGISTRY.set('cross', renderCross);
+
+// Other
+ARROWHEAD_REGISTRY.set('halfCircle', renderHalfCircle);
+ARROWHEAD_REGISTRY.set('doubleBlock', renderDoubleBlock);
+
+// ── Public API ───────────────────────────────────────────────
+
+/** All registered arrowhead type keys (for test completeness checks). */
+export const ALL_ARROWHEAD_TYPES: readonly string[] = [...ARROWHEAD_REGISTRY.keys()];
+
+/**
+ * Look up the renderer for a given arrowhead type.
+ *
+ * Returns undefined if no renderer is registered (unknown type).
+ */
+export function getArrowheadRenderer(type: string): ArrowheadRenderer | undefined {
+  return ARROWHEAD_REGISTRY.get(type);
+}
+
+/**
+ * Render an arrowhead at the given position using the registry.
+ *
+ * Falls back to 'classic' for unknown types. Wraps ctx.save/restore
+ * to isolate style changes.
+ *
+ * @param ctx         - Canvas 2D rendering context
+ * @param tipX        - X position of the arrowhead tip
+ * @param tipY        - Y position of the arrowhead tip
+ * @param angle       - Direction angle in radians
+ * @param size        - Arrowhead size in world pixels
+ * @param type        - ArrowheadType string
+ * @param filled      - Fill (true) or outline (false)
+ * @param strokeColor - Stroke color
+ * @param fillColor   - Fill color for outline arrowheads
+ */
+export function renderArrowheadFromRegistry(
+  ctx: CanvasRenderingContext2D,
+  tipX: number,
+  tipY: number,
+  angle: number,
+  size: number,
+  type: string,
+  filled: boolean,
+  strokeColor: string,
+  fillColor: string,
+): void {
+  if (type === 'none') return;
+
+  const renderer = ARROWHEAD_REGISTRY.get(type) ?? ARROWHEAD_REGISTRY.get('classic')!;
+  ctx.save();
+  renderer(ctx, tipX, tipY, angle, size, filled, strokeColor, fillColor);
+  ctx.restore();
+}

--- a/packages/engine/src/renderer/primitiveRenderer.ts
+++ b/packages/engine/src/renderer/primitiveRenderer.ts
@@ -23,6 +23,7 @@ import { resolveBindings } from '../interaction/connectorHelpers.js';
 import { computeOrthogonalRoute } from '../connectors/orthogonalRouter.js';
 import { STENCIL_CATALOG, svgToDataUri } from './stencils/index.js';
 import { resolveTextConfig } from '../text/textConfig.js';
+import { renderArrowheadFromRegistry } from './arrowheads.js';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -365,6 +366,12 @@ function renderArrow(
   const minArrowSize = Math.max(expr.style.strokeWidth * 4, 8 / zoom);
   const arrowSize = Math.max(baseArrowSize, minArrowSize);
 
+  // Resolve fill mode and colors for arrowheads
+  const startFilled = data.startFill !== false;
+  const endFilled = data.endFill !== false;
+  const strokeColor = expr.style.strokeColor;
+  const fillColor = expr.style.backgroundColor;
+
   // Resolve binding positions for connected arrows
   let points = resolveBindings(expr, expressions);
   if (points.length < 2) return;
@@ -451,14 +458,13 @@ function renderArrow(
     ctx.restore();
 
     // Arrowheads for self-loop
-    ctx.fillStyle = expr.style.strokeColor;
     if (endType !== 'none') {
       const angle = Math.atan2(end[1] - cp2y, end[0] - cp2x);
-      renderArrowhead(ctx, end[0], end[1], angle, arrowSize, endType);
+      renderArrowheadFromRegistry(ctx, end[0], end[1], angle, arrowSize, endType, endFilled, strokeColor, fillColor);
     }
     if (startType !== 'none') {
       const angle = Math.atan2(start[1] - cp1y, start[0] - cp1x);
-      renderArrowhead(ctx, start[0], start[1], angle, arrowSize, startType);
+      renderArrowheadFromRegistry(ctx, start[0], start[1], angle, arrowSize, startType, startFilled, strokeColor, fillColor);
     }
   } else {
     // Shorten line at ends where arrowheads exist so the line doesn't overlap the tip
@@ -484,20 +490,18 @@ function renderArrow(
     );
     rc.draw(drawable);
 
-    ctx.fillStyle = expr.style.strokeColor;
-
     if (endType !== 'none' && points.length >= 2) {
       const last = points[points.length - 1]!;
       const prev = points[points.length - 2]!;
       const angle = Math.atan2(last[1] - prev[1], last[0] - prev[0]);
-      renderArrowhead(ctx, last[0], last[1], angle, arrowSize, endType);
+      renderArrowheadFromRegistry(ctx, last[0], last[1], angle, arrowSize, endType, endFilled, strokeColor, fillColor);
     }
 
     if (startType !== 'none' && points.length >= 2) {
       const first = points[0]!;
       const second = points[1]!;
       const angle = Math.atan2(first[1] - second[1], first[0] - second[0]);
-      renderArrowhead(ctx, first[0], first[1], angle, arrowSize, startType);
+      renderArrowheadFromRegistry(ctx, first[0], first[1], angle, arrowSize, startType, startFilled, strokeColor, fillColor);
     }
   }
 
@@ -963,10 +967,12 @@ export function renderLabel(
 }
 
 /**
- * Draw a filled triangle arrowhead at the given point.
+ * Draw an arrowhead at the given point.
+ *
+ * @deprecated Use `renderArrowheadFromRegistry` from `./arrowheads.js` for
+ * full ArrowheadType support. This export is kept for backward compatibility.
  *
  * The arrowhead points in the direction of `angle` (radians).
- * The triangle has a base of `size` and height of `size`.
  */
 /**
  * Resolve arrowhead value to a type string.
@@ -986,74 +992,10 @@ export function renderArrowhead(
   size: number,
   type: string = 'triangle',
 ): void {
-  if (type === 'none') return;
-
-  const halfAngle = Math.PI / 6; // 30°
-
-  switch (type) {
-    case 'triangle':
-    default: {
-      ctx.beginPath();
-      ctx.moveTo(tipX, tipY);
-      ctx.lineTo(
-        tipX - size * Math.cos(angle - halfAngle),
-        tipY - size * Math.sin(angle - halfAngle),
-      );
-      ctx.lineTo(
-        tipX - size * Math.cos(angle + halfAngle),
-        tipY - size * Math.sin(angle + halfAngle),
-      );
-      ctx.closePath();
-      ctx.fill();
-      break;
-    }
-    case 'chevron': {
-      ctx.save();
-      ctx.lineWidth = Math.max(ctx.lineWidth, 1.5);
-      ctx.strokeStyle = ctx.fillStyle as string;
-      ctx.beginPath();
-      ctx.moveTo(
-        tipX - size * Math.cos(angle - halfAngle),
-        tipY - size * Math.sin(angle - halfAngle),
-      );
-      ctx.lineTo(tipX, tipY);
-      ctx.lineTo(
-        tipX - size * Math.cos(angle + halfAngle),
-        tipY - size * Math.sin(angle + halfAngle),
-      );
-      ctx.stroke();
-      ctx.restore();
-      break;
-    }
-    case 'diamond': {
-      const hSize = size * 0.6;
-      const cx = tipX - hSize * Math.cos(angle);
-      const cy = tipY - hSize * Math.sin(angle);
-      ctx.beginPath();
-      ctx.moveTo(tipX, tipY);
-      ctx.lineTo(
-        cx - hSize * 0.5 * Math.cos(angle - Math.PI / 2),
-        cy - hSize * 0.5 * Math.sin(angle - Math.PI / 2),
-      );
-      ctx.lineTo(cx - hSize * Math.cos(angle), cy - hSize * Math.sin(angle));
-      ctx.lineTo(
-        cx - hSize * 0.5 * Math.cos(angle + Math.PI / 2),
-        cy - hSize * 0.5 * Math.sin(angle + Math.PI / 2),
-      );
-      ctx.closePath();
-      ctx.fill();
-      break;
-    }
-    case 'circle': {
-      const r = size * 0.35;
-      const cx = tipX - r * Math.cos(angle);
-      const cy = tipY - r * Math.sin(angle);
-      ctx.beginPath();
-      ctx.arc(cx, cy, r, 0, Math.PI * 2);
-      ctx.fill();
-      break;
-    }
-  }
+  // Delegate to the registry-based renderer.
+  // fillStyle is assumed to be set by the caller (backward compat behavior).
+  const strokeColor = ctx.fillStyle as string;
+  renderArrowheadFromRegistry(ctx, tipX, tipY, angle, size, type, true, strokeColor, '#ffffff');
 }
 
 /**


### PR DESCRIPTION
Registry-based Canvas2D renderer for all arrowhead types. Vite ✓.

Closes #148

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>