### PR TITLE
fix: self-loop arrow selection + hit testing

### DIFF
--- a/packages/engine/src/connectors/orthogonalRouter.ts
+++ b/packages/engine/src/connectors/orthogonalRouter.ts
@@ -611,3 +611,32 @@ function computeCShapeClearance(
   const avg = (exit[1] + entry[1]) / 2;
   return Math.abs(avg - lo) < Math.abs(avg - hi) ? lo : hi;
 }
+
+/**
+ * Compute orthogonal self-loop waypoints (shared by renderer + hit test).
+ */
+export function computeOrthogonalSelfLoopPoints(
+  start: [number, number],
+  end: [number, number],
+  target: { position: { x: number; y: number }; size: { width: number; height: number } } | undefined,
+  jetty: number,
+): [number, number][] {
+  const cx = target ? target.position.x + target.size.width / 2 : (start[0] + end[0]) / 2;
+  const cy = target ? target.position.y + target.size.height / 2 : (start[1] + end[1]) / 2;
+  const midX = (start[0] + end[0]) / 2;
+  const midY = (start[1] + end[1]) / 2;
+  const dx = midX - cx;
+  const dy = midY - cy;
+
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    const outX = dx >= 0
+      ? Math.max(start[0], end[0]) + jetty
+      : Math.min(start[0], end[0]) - jetty;
+    return [start, [outX, start[1]], [outX, end[1]], end];
+  } else {
+    const outY = dy >= 0
+      ? Math.max(start[1], end[1]) + jetty
+      : Math.min(start[1], end[1]) - jetty;
+    return [start, [start[0], outY], [end[0], outY], end];
+  }
+}

--- a/packages/engine/src/interaction/hitTest.ts
+++ b/packages/engine/src/interaction/hitTest.ts
@@ -11,6 +11,7 @@
  * @module
  */
 
+import { computeOrthogonalSelfLoopPoints } from '../connectors/orthogonalRouter.js';
 import type { VisualExpression, ArrowData } from '@infinicanvas/protocol';
 import type { PathSegment } from '../connectors/routerTypes.js';
 import { getRouter } from '../connectors/routerRegistry.js';
@@ -321,6 +322,26 @@ export function hitTestArrow(
 
   // Use wider tolerance for thin lines (minimum 8 world px for easier clicking)
   const effectiveTolerance = Math.max(tolerance, 8);
+
+  // Self-loop: both ends bound to same shape
+  const isSelfLoop = data.startBinding && data.endBinding &&
+    data.startBinding.expressionId === data.endBinding.expressionId;
+  
+  if (isSelfLoop && (data.routing === 'orthogonal' || data.routing === 'elbow')) {
+    const target = expressions?.[data.startBinding!.expressionId];
+    const loopPts = computeOrthogonalSelfLoopPoints(
+      points[0]!, points[points.length - 1]!, target,
+      typeof data.jettySize === 'number' ? data.jettySize : 30,
+    );
+    for (let i = 0; i < loopPts.length - 1; i++) {
+      if (distanceToSegment(point.x, point.y,
+        loopPts[i]![0], loopPts[i]![1],
+        loopPts[i + 1]![0], loopPts[i + 1]![1]) <= effectiveTolerance) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   // Try routing-aware hit testing for non-straight arrows
   const routingMode = data.routing === 'orthogonal' && data.curved

--- a/packages/engine/src/renderer/arrowRenderer.ts
+++ b/packages/engine/src/renderer/arrowRenderer.ts
@@ -19,6 +19,7 @@ import type { RoughCanvas } from 'roughjs/bin/canvas.js';
 import type { Camera } from '../types/index.js';
 import type { PathSegment } from '../connectors/routerTypes.js';
 import { mapStyleToRoughOptions, idToSeed } from './styleMapper.js';
+import { computeOrthogonalSelfLoopPoints } from '../connectors/orthogonalRouter.js';
 import { resolveBindings } from '../interaction/connectorHelpers.js';
 import { getRouter } from '../connectors/routerRegistry.js';
 import { renderArrowheadFromRegistry } from './arrowheads.js';
@@ -263,39 +264,7 @@ function renderOrthogonalSelfLoop(
   const target = expressions[data.startBinding!.expressionId];
   const jetty = typeof data.jettySize === 'number' ? data.jettySize : 30;
 
-  // Determine loop direction — go outward from shape center
-  const cx = target ? target.position.x + target.size.width / 2 : (start[0] + end[0]) / 2;
-  const cy = target ? target.position.y + target.size.height / 2 : (start[1] + end[1]) / 2;
-  const midX = (start[0] + end[0]) / 2;
-  const midY = (start[1] + end[1]) / 2;
-  const dx = midX - cx;
-  const dy = midY - cy;
-
-  // Build orthogonal loop points
-  let loopPoints: [number, number][];
-  if (Math.abs(dx) >= Math.abs(dy)) {
-    // Loop outward horizontally
-    const outX = dx >= 0
-      ? Math.max(start[0], end[0]) + jetty
-      : Math.min(start[0], end[0]) - jetty;
-    loopPoints = [
-      start,
-      [outX, start[1]],
-      [outX, end[1]],
-      end,
-    ];
-  } else {
-    // Loop outward vertically
-    const outY = dy >= 0
-      ? Math.max(start[1], end[1]) + jetty
-      : Math.min(start[1], end[1]) - jetty;
-    loopPoints = [
-      start,
-      [start[0], outY],
-      [end[0], outY],
-      end,
-    ];
-  }
+  const loopPoints = computeOrthogonalSelfLoopPoints(start, end, target, jetty);
 
   ctx.save();
   ctx.strokeStyle = strokeColor;


### PR DESCRIPTION
Can now click on orthogonal self-loop segments. Shared geometry computation between renderer and hit test. tsc ✓.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>