### PR TITLE
fix: self-loop spacing + handles for all routing modes

### DIFF
--- a/packages/app/src/components/panels/FloatingConnectorPanel.tsx
+++ b/packages/app/src/components/panels/FloatingConnectorPanel.tsx
@@ -417,46 +417,48 @@ export function FloatingConnectorPanel() {
         </div>
       </div>
 
-      {/* Edge Properties — only for orthogonal routing */}
+      {/* Edge Properties — smooth/rounded for orthogonal routing only */}
       {isArrowSelected && (currentRouting === 'orthogonal' || currentRouting === 'orthogonalCurved') && (
-        <>
-          <div data-testid="edge-properties-row" style={{ display: 'flex', gap: 8, marginTop: 4, flexWrap: 'wrap' }}>
-            <label style={CHECKBOX_LABEL_STYLE}>
-              <input
-                type="checkbox"
-                checked={currentCurved}
-                onChange={(e) => handleEdgeToggle('curved', e.target.checked)}
-              />
-              Smooth
-            </label>
-            <label style={CHECKBOX_LABEL_STYLE}>
-              <input
-                type="checkbox"
-                checked={currentRounded}
-                onChange={(e) => handleEdgeToggle('rounded', e.target.checked)}
-              />
-              Rounded
-            </label>
-          </div>
-          <div data-testid="spacing-row" style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}>
-            <label style={CHECKBOX_LABEL_STYLE}>
-              Spacing
-              <input
-                type="number"
-                min={0}
-                max={9999}
-                value={isArrowSelected ? (typeof arrowData?.jettySize === 'number' ? arrowData.jettySize : 20) : 20}
-                onChange={(e) => {
-                  const val = parseInt(e.target.value, 10);
-                  if (!isNaN(val) && isArrowSelected && firstExpr) {
-                    updateArrowData(firstExpr.id, { jettySize: Math.max(0, val) });
-                  }
-                }}
-                style={{ width: 50, marginLeft: 4, padding: '2px 4px', fontSize: 12 }}
-              />
-            </label>
-          </div>
-        </>
+        <div data-testid="edge-properties-row" style={{ display: 'flex', gap: 8, marginTop: 4, flexWrap: 'wrap' }}>
+          <label style={CHECKBOX_LABEL_STYLE}>
+            <input
+              type="checkbox"
+              checked={currentCurved}
+              onChange={(e) => handleEdgeToggle('curved', e.target.checked)}
+            />
+            Smooth
+          </label>
+          <label style={CHECKBOX_LABEL_STYLE}>
+            <input
+              type="checkbox"
+              checked={currentRounded}
+              onChange={(e) => handleEdgeToggle('rounded', e.target.checked)}
+            />
+            Rounded
+          </label>
+        </div>
+      )}
+
+      {/* Spacing — for ALL non-straight routing modes */}
+      {isArrowSelected && currentRouting !== 'straight' && (
+        <div data-testid="spacing-row" style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}>
+          <label style={CHECKBOX_LABEL_STYLE}>
+            Spacing
+            <input
+              type="number"
+              min={0}
+              max={9999}
+              value={isArrowSelected ? (typeof arrowData?.jettySize === 'number' ? arrowData.jettySize : 20) : 20}
+              onChange={(e) => {
+                const val = parseInt(e.target.value, 10);
+                if (!isNaN(val) && isArrowSelected && firstExpr) {
+                  updateArrowData(firstExpr.id, { jettySize: Math.max(0, val) });
+                }
+              }}
+              style={{ width: 50, marginLeft: 4, padding: '2px 4px', fontSize: 12 }}
+            />
+          </label>
+        </div>
       )}
     </div>
   );

--- a/packages/engine/src/__tests__/manipulationHelpers.test.ts
+++ b/packages/engine/src/__tests__/manipulationHelpers.test.ts
@@ -18,7 +18,9 @@ import {
   getCursorForTarget,
   computeResize,
   getJettyHandlePosition,
+  getPointHandlePositions,
   detectJettyHandle,
+  isSelfLoopArrow,
   MIN_SIZE,
 } from '../interaction/manipulationHelpers.js';
 import type { HandleType, PointerTarget, JettyHandleHit } from '../interaction/manipulationHelpers.js';
@@ -853,6 +855,164 @@ describe('computeResize [AC3, AC4, AC5]', () => {
       // Exit stub midpoint: (100 + 20/2, 200) = (110, 200)
       expect(result!.position.x).toBeCloseTo(110, 0);
       expect(result!.position.y).toBeCloseTo(200, 0);
+    });
+  });
+
+  // ── isSelfLoopArrow helper ──────────────────────────────────
+
+  describe('isSelfLoopArrow', () => {
+    it('returns true when both bindings reference the same shape', () => {
+      const arrow = makeArrow('a1', [[100, 100], [120, 80]], {
+        routing: 'orthogonal',
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape1', anchor: 'top' },
+      });
+      expect(isSelfLoopArrow(arrow.data as { startBinding?: { expressionId: string }; endBinding?: { expressionId: string } })).toBe(true);
+    });
+
+    it('returns false when bindings reference different shapes', () => {
+      const arrow = makeArrow('a1', [[100, 100], [400, 300]], {
+        routing: 'orthogonal',
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape2', anchor: 'left' },
+      });
+      expect(isSelfLoopArrow(arrow.data as { startBinding?: { expressionId: string }; endBinding?: { expressionId: string } })).toBe(false);
+    });
+
+    it('returns false when no bindings exist', () => {
+      const arrow = makeArrow('a1', [[100, 100], [400, 300]], {
+        routing: 'orthogonal',
+      });
+      expect(isSelfLoopArrow(arrow.data as { startBinding?: { expressionId: string }; endBinding?: { expressionId: string } })).toBe(false);
+    });
+
+    it('returns false when only start binding exists', () => {
+      const arrow = makeArrow('a1', [[100, 100], [400, 300]], {
+        routing: 'orthogonal',
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+      });
+      expect(isSelfLoopArrow(arrow.data as { startBinding?: { expressionId: string }; endBinding?: { expressionId: string } })).toBe(false);
+    });
+  });
+
+  // ── Self-loop jetty handle ──────────────────────────────────
+
+  describe('getJettyHandlePosition — self-loop', () => {
+    it('returns a handle for a self-loop arrow with orthogonal routing', () => {
+      // Self-loop: both bindings reference the same shape
+      // Start at (200, 100) right edge, end at (150, 60) top edge of a shape at (100, 60, 100, 80)
+      const arrow = makeArrow('a1', [[200, 100], [150, 60]], {
+        routing: 'orthogonal',
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape1', anchor: 'top' },
+      });
+      const result = getJettyHandlePosition(arrow);
+      expect(result).not.toBeNull();
+      expect(result!.expressionId).toBe('a1');
+    });
+
+    it('returns a handle for a self-loop arrow with elbow routing', () => {
+      const arrow = makeArrow('a1', [[200, 100], [150, 60]], {
+        routing: 'elbow',
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape1', anchor: 'top' },
+      });
+      const result = getJettyHandlePosition(arrow);
+      expect(result).not.toBeNull();
+      expect(result!.expressionId).toBe('a1');
+    });
+
+    it('places handle at midpoint of outer segment for horizontal self-loop', () => {
+      // start right edge (200, 100), end top (150, 60) — midpoint of anchor
+      // midX of points = (200+150)/2 = 175
+      // shape center approx (150, 100) → dx = 175-150 = 25, dy = 80-100 = -20
+      // |dx| >= |dy| → horizontal loop, extends right
+      // outX = max(200, 150) + jetty (default 30 for self-loop in computeOrthogonalSelfLoopPoints)
+      // loopPoints = [start, [outX, start.y], [outX, end.y], end]
+      // Outer segment: from [outX, start.y] to [outX, end.y] — vertical segment
+      // Handle midpoint: (outX, (start.y + end.y)/2)
+      const arrow = makeArrow('a1', [[200, 100], [150, 60]], {
+        routing: 'orthogonal',
+        jettySize: 30,
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape1', anchor: 'top' },
+      });
+      const result = getJettyHandlePosition(arrow);
+      expect(result).not.toBeNull();
+      // Outer segment is vertical → orientation is vertical
+      expect(result!.segmentOrientation).toBe('vertical');
+    });
+
+    it('uses jettySize from arrow data for self-loop handle position', () => {
+      const arrow = makeArrow('a1', [[200, 100], [150, 60]], {
+        routing: 'orthogonal',
+        jettySize: 50,
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape1', anchor: 'top' },
+      });
+      const result = getJettyHandlePosition(arrow);
+      expect(result).not.toBeNull();
+      // With larger jetty, handle should be farther from shape
+    });
+
+    it('sets direction for dragging perpendicular to outer segment', () => {
+      const arrow = makeArrow('a1', [[200, 100], [150, 60]], {
+        routing: 'orthogonal',
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape1', anchor: 'top' },
+      });
+      const result = getJettyHandlePosition(arrow);
+      expect(result).not.toBeNull();
+      // Direction should be non-zero (usable for drag)
+      const dirLen = Math.hypot(result!.direction.x, result!.direction.y);
+      expect(dirLen).toBeCloseTo(1, 5);
+    });
+  });
+
+  // ── Elbow routing in JETTY_ROUTING_MODES ──────────────────────
+
+  describe('getJettyHandlePosition — elbow routing', () => {
+    it('returns a handle for non-self-loop elbow arrows', () => {
+      const arrow = makeArrow('a1', [[100, 200], [400, 200]], {
+        routing: 'elbow',
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape2', anchor: 'left' },
+      });
+      const result = getJettyHandlePosition(arrow);
+      expect(result).not.toBeNull();
+      expect(result!.expressionId).toBe('a1');
+    });
+  });
+
+  // ── getPointHandlePositions — self-loop suppression ──────────
+
+  describe('getPointHandlePositions — self-loop', () => {
+    it('returns empty array for self-loop arrows', () => {
+      const arrow = makeArrow('a1', [[200, 100], [150, 60]], {
+        routing: 'orthogonal',
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape1', anchor: 'top' },
+      });
+      const result = getPointHandlePositions(arrow);
+      expect(result).toEqual([]);
+    });
+
+    it('returns handles for non-self-loop arrows', () => {
+      const arrow = makeArrow('a1', [[100, 200], [400, 200]], {
+        routing: 'orthogonal',
+        startBinding: { expressionId: 'shape1', anchor: 'right' },
+        endBinding: { expressionId: 'shape2', anchor: 'left' },
+      });
+      const result = getPointHandlePositions(arrow);
+      expect(result.length).toBe(2);
+    });
+
+    it('returns handles for unbound arrows', () => {
+      const arrow = makeArrow('a1', [[100, 200], [400, 200]], {
+        routing: 'orthogonal',
+      });
+      const result = getPointHandlePositions(arrow);
+      expect(result.length).toBe(2);
     });
   });
 });

--- a/packages/engine/src/__tests__/selectionRenderer.test.ts
+++ b/packages/engine/src/__tests__/selectionRenderer.test.ts
@@ -73,7 +73,12 @@ function makeRect(id: string, x: number, y: number, w: number, h: number): Visua
 function makeArrow(
   id: string,
   points: [number, number][],
-  opts?: { routing?: string; jettySize?: number; startBinding?: { expressionId: string; anchor: string } },
+  opts?: {
+    routing?: string;
+    jettySize?: number;
+    startBinding?: { expressionId: string; anchor: string };
+    endBinding?: { expressionId: string; anchor: string };
+  },
 ): VisualExpression {
   const p0 = points[0] ?? [0, 0];
   const pN = points[points.length - 1] ?? p0;
@@ -97,6 +102,9 @@ function makeArrow(
       jettySize: opts?.jettySize,
       startBinding: opts?.startBinding
         ? { expressionId: opts.startBinding.expressionId, anchor: opts.startBinding.anchor }
+        : undefined,
+      endBinding: opts?.endBinding
+        ? { expressionId: opts.endBinding.expressionId, anchor: opts.endBinding.anchor }
         : undefined,
     },
   };
@@ -304,6 +312,40 @@ describe('renderSelection', () => {
     // Track fillStyle assignments — the jetty handle should use accent color (#4A90D9)
     expect(ctx.fillStyle).toBe('#4A90D9');
     // Jetty handle uses fillRect, not arc+fill
+    const fillRectCalls = ctx._calls.filter((c) => c.method === 'fillRect');
+    expect(fillRectCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Self-loop arrow rendering ─────────────────────────────────
+
+  it('does NOT render point handles (arc) for self-loop arrows', () => {
+    const ctx = createMockCtx();
+    const arrow = makeArrow('a1', [[200, 100], [150, 60]], {
+      routing: 'orthogonal',
+      startBinding: { expressionId: 'shape1', anchor: 'right' },
+      endBinding: { expressionId: 'shape1', anchor: 'top' },
+    });
+    const expressions: Record<string, VisualExpression> = { a1: arrow };
+
+    renderSelection(ctx, new Set(['a1']), expressions, identityCamera);
+
+    // Self-loop arrows should NOT have arc calls (no point handles)
+    const arcCalls = ctx._calls.filter((c) => c.method === 'arc');
+    expect(arcCalls.length).toBe(0);
+  });
+
+  it('renders jetty handle for self-loop arrow with routing', () => {
+    const ctx = createMockCtx();
+    const arrow = makeArrow('a1', [[200, 100], [150, 60]], {
+      routing: 'orthogonal',
+      startBinding: { expressionId: 'shape1', anchor: 'right' },
+      endBinding: { expressionId: 'shape1', anchor: 'top' },
+    });
+    const expressions: Record<string, VisualExpression> = { a1: arrow };
+
+    renderSelection(ctx, new Set(['a1']), expressions, identityCamera);
+
+    // Should have fillRect calls for the jetty handle
     const fillRectCalls = ctx._calls.filter((c) => c.method === 'fillRect');
     expect(fillRectCalls.length).toBeGreaterThanOrEqual(1);
   });

--- a/packages/engine/src/interaction/manipulationHelpers.ts
+++ b/packages/engine/src/interaction/manipulationHelpers.ts
@@ -11,6 +11,7 @@
 import type { VisualExpression, ArrowData } from '@infinicanvas/protocol';
 import type { Camera } from '../types/index.js';
 import { computeOrthogonalRoute } from '../connectors/orthogonalRouter.js';
+import { computeOrthogonalSelfLoopPoints } from '../connectors/orthogonalRouter.js';
 import { resolveBindings } from './connectorHelpers.js';
 
 // ── Point-based kind guard ─────────────────────────────────────
@@ -26,6 +27,23 @@ export type PointBasedKind = 'line' | 'arrow' | 'freehand';
  */
 export function isPointBasedKind(kind: string): kind is PointBasedKind {
   return kind === 'line' || kind === 'arrow' || kind === 'freehand';
+}
+
+// ── Self-loop detection ───────────────────────────────────────
+
+/**
+ * Check if arrow data represents a self-loop (both ends bound to the same shape).
+ *
+ * Self-loops need special handling: endpoint handles are suppressed (both
+ * are on the same shape), and the jetty handle uses the computed loop
+ * geometry instead of the normal Z-shape/L-shape computation. [CLEAN-CODE]
+ */
+export function isSelfLoopArrow(data: {
+  startBinding?: { expressionId: string };
+  endBinding?: { expressionId: string };
+}): boolean {
+  return !!data.startBinding && !!data.endBinding &&
+    data.startBinding.expressionId === data.endBinding.expressionId;
 }
 
 // ── Handle types ──────────────────────────────────────────────
@@ -180,6 +198,12 @@ export function getPointHandlePositions(
 ): Array<{ x: number; y: number; pointIndex: number }> {
   if (!isPointBasedKind(expr.data.kind)) return [];
 
+  // Self-loop arrows: suppress endpoint handles — both are on the same
+  // shape, so dragging them individually is not meaningful. [CLEAN-CODE]
+  if (expr.data.kind === 'arrow' && isSelfLoopArrow(expr.data as ArrowData)) {
+    return [];
+  }
+
   const data = expr.data as { points: [number, number][] | [number, number, number][] };
   const { points } = data;
 
@@ -239,10 +263,10 @@ export function detectPointHandle(
 const DEFAULT_JETTY_SIZE = 20;
 
 /** Routing modes that produce exit stubs where a jetty handle makes sense.
- * 'curved' removed — curved routes have no stubs. [Bug #6]
- * 'elbow' removed — now an alias for orthogonal (already in the set). */
+ * 'curved' removed — curved routes have no stubs. [Bug #6] */
 const JETTY_ROUTING_MODES = new Set([
   'orthogonal',
+  'elbow',
   'entityRelation',
   'isometric',
   'orthogonalCurved',
@@ -291,6 +315,58 @@ function resolveExitDirection(
 }
 
 /**
+ * Compute the jetty handle position for a self-loop arrow.
+ *
+ * Uses `computeOrthogonalSelfLoopPoints` to get the loop geometry,
+ * then places the handle at the midpoint of the OUTER segment
+ * (the segment farthest from the shape). Dragging the handle
+ * adjusts `jettySize` — how far the loop extends from the shape.
+ *
+ * For a horizontal loop extending right:
+ *   loopPts = [start, [outX, startY], [outX, endY], end]
+ *   Outer segment: pts[1]→pts[2] (vertical), handle at midpoint
+ *
+ * For a vertical loop extending down:
+ *   loopPts = [start, [startX, outY], [endX, outY], end]
+ *   Outer segment: pts[1]→pts[2] (horizontal), handle at midpoint
+ *
+ * [CLEAN-CODE] [SRP]
+ */
+function computeSelfLoopJettyHandle(
+  expressionId: string,
+  startPt: { x: number; y: number },
+  endPt: { x: number; y: number },
+  jettySize: number,
+): JettyHandleHit {
+  const loopPts = computeOrthogonalSelfLoopPoints(
+    [startPt.x, startPt.y],
+    [endPt.x, endPt.y],
+    undefined, // No target shape needed — points already resolved
+    jettySize,
+  );
+
+  // Outer segment is pts[1]→pts[2] (the one extending away from shape)
+  const outerStart = loopPts[1]!;
+  const outerEnd = loopPts[2]!;
+
+  const midX = (outerStart[0] + outerEnd[0]) / 2;
+  const midY = (outerStart[1] + outerEnd[1]) / 2;
+
+  // Determine if the outer segment is horizontal or vertical
+  const isHorizontal = Math.abs(outerStart[1] - outerEnd[1]) < 0.01;
+
+  return {
+    expressionId,
+    end: 'start',
+    position: { x: midX, y: midY },
+    // Drag direction is perpendicular to the outer segment
+    // to move the loop in/out (adjusting jettySize)
+    direction: isHorizontal ? { x: 0, y: 1 } : { x: 1, y: 0 },
+    segmentOrientation: isHorizontal ? 'horizontal' : 'vertical',
+  };
+}
+
+/**
  * Compute the jetty handle position for a routed arrow.
  *
  * For Z-shape routes (same-axis exits, normal flow), the handle sits
@@ -332,6 +408,11 @@ export function getJettyHandlePosition(
 
   const jettySize =
     typeof data.jettySize === 'number' ? data.jettySize : DEFAULT_JETTY_SIZE;
+
+  // ── Self-loop: compute handle on the outer segment of the loop ──
+  if (isSelfLoopArrow(data)) {
+    return computeSelfLoopJettyHandle(expr.id, startPt, endPt, jettySize);
+  }
 
   const startAnchor = data.startBinding?.anchor;
   const endAnchor = data.endBinding?.anchor;
@@ -473,6 +554,10 @@ export function getSegmentMidpointHandles(
   const data = expr.data as ArrowData;
   if (!data.routing || !SEGMENT_HANDLE_ROUTING_MODES.has(data.routing)) return [];
   if (data.points.length < 2) return [];
+
+  // Self-loop arrows use the jetty handle on the outer segment instead
+  // of individual segment midpoint handles. [CLEAN-CODE]
+  if (isSelfLoopArrow(data)) return [];
 
   // Resolve binding positions to get absolute world coordinates
   const points = resolveBindings(expr, expressions);


### PR DESCRIPTION
Spacing for all non-straight modes. Self-loop midpoint handle works. No spurious dots. tsc ✓.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>