### PR TITLE
feat: clean self-loop + fix midpoint handles

### DIFF
--- a/packages/app/src/components/panels/FloatingConnectorPanel.tsx
+++ b/packages/app/src/components/panels/FloatingConnectorPanel.tsx
@@ -417,46 +417,47 @@ export function FloatingConnectorPanel() {
         </div>
       </div>
 
-      {/* Edge Properties — only for orthogonal routing */}
+      {/* Edge Properties — Smooth/Rounded only for orthogonal routing */}
       {isArrowSelected && (currentRouting === 'orthogonal' || currentRouting === 'orthogonalCurved') && (
-        <>
-          <div data-testid="edge-properties-row" style={{ display: 'flex', gap: 8, marginTop: 4, flexWrap: 'wrap' }}>
-            <label style={CHECKBOX_LABEL_STYLE}>
-              <input
-                type="checkbox"
-                checked={currentCurved}
-                onChange={(e) => handleEdgeToggle('curved', e.target.checked)}
-              />
-              Smooth
-            </label>
-            <label style={CHECKBOX_LABEL_STYLE}>
-              <input
-                type="checkbox"
-                checked={currentRounded}
-                onChange={(e) => handleEdgeToggle('rounded', e.target.checked)}
-              />
-              Rounded
-            </label>
-          </div>
-          <div data-testid="spacing-row" style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}>
-            <label style={CHECKBOX_LABEL_STYLE}>
-              Spacing
-              <input
-                type="number"
-                min={0}
-                max={9999}
-                value={isArrowSelected ? (typeof arrowData?.jettySize === 'number' ? arrowData.jettySize : 20) : 20}
-                onChange={(e) => {
-                  const val = parseInt(e.target.value, 10);
-                  if (!isNaN(val) && isArrowSelected && firstExpr) {
-                    updateArrowData(firstExpr.id, { jettySize: Math.max(0, val) });
-                  }
-                }}
-                style={{ width: 50, marginLeft: 4, padding: '2px 4px', fontSize: 12 }}
-              />
-            </label>
-          </div>
-        </>
+        <div data-testid="edge-properties-row" style={{ display: 'flex', gap: 8, marginTop: 4, flexWrap: 'wrap' }}>
+          <label style={CHECKBOX_LABEL_STYLE}>
+            <input
+              type="checkbox"
+              checked={currentCurved}
+              onChange={(e) => handleEdgeToggle('curved', e.target.checked)}
+            />
+            Smooth
+          </label>
+          <label style={CHECKBOX_LABEL_STYLE}>
+            <input
+              type="checkbox"
+              checked={currentRounded}
+              onChange={(e) => handleEdgeToggle('rounded', e.target.checked)}
+            />
+            Rounded
+          </label>
+        </div>
+      )}
+      {/* Spacing — shown for all non-straight routing modes (self-loops need it for loop size) */}
+      {isArrowSelected && currentRouting && currentRouting !== 'straight' && (
+        <div data-testid="spacing-row" style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}>
+          <label style={CHECKBOX_LABEL_STYLE}>
+            Spacing
+            <input
+              type="number"
+              min={0}
+              max={9999}
+              value={isArrowSelected ? (typeof arrowData?.jettySize === 'number' ? arrowData.jettySize : 20) : 20}
+              onChange={(e) => {
+                const val = parseInt(e.target.value, 10);
+                if (!isNaN(val) && isArrowSelected && firstExpr) {
+                  updateArrowData(firstExpr.id, { jettySize: Math.max(0, val) });
+                }
+              }}
+              style={{ width: 50, marginLeft: 4, padding: '2px 4px', fontSize: 12 }}
+            />
+          </label>
+        </div>
       )}
     </div>
   );

--- a/packages/engine/src/__tests__/hitTest.test.ts
+++ b/packages/engine/src/__tests__/hitTest.test.ts
@@ -807,3 +807,85 @@ describe('hitTestArrow with routed paths', () => {
     expect(hitTestArrow({ x: 50, y: 20 }, arrow, 5)).toBe(false);
   });
 });
+
+// ── hitTestArrow with self-loops ─────────────────────────────
+
+describe('hitTestArrow with self-loops', () => {
+  /** Create a self-loop arrow bound to a shape. */
+  function makeSelfLoopArrow(
+    points: [number, number][],
+    routing: string | undefined,
+    jettySize?: number,
+  ): VisualExpression {
+    const xs = points.map(([px]) => px);
+    const ys = points.map(([, py]) => py);
+    const minX = Math.min(...xs);
+    const minY = Math.min(...ys);
+    const maxX = Math.max(...xs);
+    const maxY = Math.max(...ys);
+    return {
+      id: 'selfloop-arrow-1',
+      kind: 'arrow',
+      position: { x: minX, y: minY },
+      size: { width: maxX - minX || 1, height: maxY - minY || 1 },
+      angle: 0,
+      style: DEFAULT_STYLE,
+      meta: DEFAULT_META,
+      data: {
+        kind: 'arrow',
+        points,
+        routing,
+        jettySize,
+        startBinding: { expressionId: 'shape-1', anchor: 'right' as const },
+        endBinding: { expressionId: 'shape-1', anchor: 'right' as const },
+      },
+    };
+  }
+
+  /** Target shape for self-loop — 100x80 at (200, 100). */
+  const targetShape: VisualExpression = {
+    id: 'shape-1',
+    kind: 'rectangle',
+    position: { x: 200, y: 100 },
+    size: { width: 100, height: 80 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: { kind: 'rectangle' },
+  };
+
+  const expressions: Record<string, VisualExpression> = {
+    'shape-1': targetShape,
+  };
+
+  it('orthogonal self-loop — point on outward segment hits', () => {
+    // Start and end on right edge (x=300), loop extends rightward
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'orthogonal', 30);
+    // Point on the outward vertical segment at x=330 (300+30)
+    expect(hitTestArrow({ x: 330, y: 140 }, arrow, 8, expressions)).toBe(true);
+  });
+
+  it('orthogonal self-loop — point on horizontal segment hits', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'orthogonal', 30);
+    // Point on the top horizontal segment (y=120, between x=300 and x=330)
+    expect(hitTestArrow({ x: 315, y: 120 }, arrow, 8, expressions)).toBe(true);
+  });
+
+  it('orthogonal self-loop — point far from loop misses', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'orthogonal', 30);
+    // Point well outside the loop path
+    expect(hitTestArrow({ x: 200, y: 140 }, arrow, 8, expressions)).toBe(false);
+  });
+
+  it('elbow self-loop — hits on the loop path', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'elbow', 30);
+    // Point on the outward segment
+    expect(hitTestArrow({ x: 330, y: 140 }, arrow, 8, expressions)).toBe(true);
+  });
+
+  it('curved self-loop — point on start/end segment hits', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'curved', 30);
+    // Point near start should still hit (fallback to segment test)
+    expect(hitTestArrow({ x: 300, y: 120 }, arrow, 8, expressions)).toBe(true);
+  });
+});

--- a/packages/engine/src/__tests__/selfLoopPath.test.ts
+++ b/packages/engine/src/__tests__/selfLoopPath.test.ts
@@ -1,0 +1,662 @@
+/**
+ * Unit tests for computeSelfLoopPath — self-loop routing helper.
+ *
+ * Tests written FIRST following TDD [Red → Green → Refactor].
+ * Covers:
+ *  1. Curved/straight/undefined routing → returns 2 points with isCurved=true
+ *  2. Orthogonal routing → right-angle loop with 4 points, isCurved=false
+ *  3. Elbow routing → same as orthogonal for self-loops
+ *  4. Loop direction — outward from shape center
+ *  5. jettySize controls how far the loop extends
+ *  6. Fallback when target is undefined
+ *  7. All segments in orthogonal loop are axis-aligned
+ *
+ * @module
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeSelfLoopPath } from '../connectors/orthogonalRouter.js';
+import {
+  getSelfLoopHandlePosition,
+  getJettyHandlePosition,
+  getSegmentMidpointHandles,
+} from '../interaction/manipulationHelpers.js';
+import type { VisualExpression, ExpressionStyle } from '@infinicanvas/protocol';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+/** Shape target for testing — a 100x80 rectangle at (200, 100). */
+const TARGET_SHAPE = {
+  position: { x: 200, y: 100 },
+  size: { width: 100, height: 80 },
+};
+
+/** Assert all segments in a path are horizontal or vertical. */
+function assertOrthogonal(points: [number, number][]): void {
+  for (let i = 1; i < points.length; i++) {
+    const [x1, y1] = points[i - 1]!;
+    const [x2, y2] = points[i]!;
+    const isHorizontal = y1 === y2;
+    const isVertical = x1 === x2;
+    expect(
+      isHorizontal || isVertical,
+      `Segment ${i - 1}→${i} is diagonal: (${x1},${y1})→(${x2},${y2})`,
+    ).toBe(true);
+  }
+}
+
+// ══════════════════════════════════════════════════════════════
+// 1. Curved / straight / undefined routing → bezier passthrough
+// ══════════════════════════════════════════════════════════════
+
+describe('computeSelfLoopPath — curved routing', () => {
+  it('returns start and end with isCurved=true for undefined routing', () => {
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const result = computeSelfLoopPath(start, end, undefined, TARGET_SHAPE, 30);
+
+    expect(result.isCurved).toBe(true);
+    expect(result.points).toHaveLength(2);
+    expect(result.points[0]).toEqual(start);
+    expect(result.points[1]).toEqual(end);
+  });
+
+  it('returns start and end with isCurved=true for straight routing', () => {
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const result = computeSelfLoopPath(start, end, 'straight', TARGET_SHAPE, 30);
+
+    expect(result.isCurved).toBe(true);
+    expect(result.points).toHaveLength(2);
+  });
+
+  it('returns start and end with isCurved=true for curved routing', () => {
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const result = computeSelfLoopPath(start, end, 'curved', TARGET_SHAPE, 30);
+
+    expect(result.isCurved).toBe(true);
+    expect(result.points).toHaveLength(2);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// 2. Orthogonal routing → right-angle loop
+// ══════════════════════════════════════════════════════════════
+
+describe('computeSelfLoopPath — orthogonal routing', () => {
+  it('returns 4 points with isCurved=false', () => {
+    // Start and end on the right side of the shape
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const result = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 30);
+
+    expect(result.isCurved).toBe(false);
+    expect(result.points).toHaveLength(4);
+  });
+
+  it('starts at start point and ends at end point', () => {
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const result = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 30);
+
+    expect(result.points[0]).toEqual(start);
+    expect(result.points[result.points.length - 1]).toEqual(end);
+  });
+
+  it('produces all horizontal/vertical segments', () => {
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const result = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 30);
+
+    assertOrthogonal(result.points);
+  });
+
+  it('loops outward to the right when points are on right edge', () => {
+    // Shape center = (250, 140). Points at x=300 are to the right.
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const result = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 30);
+
+    // The outward X should be max(300, 300) + 30 = 330
+    expect(result.points[1]![0]).toBe(330);
+    expect(result.points[2]![0]).toBe(330);
+    // Y values should match start and end
+    expect(result.points[1]![1]).toBe(120);
+    expect(result.points[2]![1]).toBe(160);
+  });
+
+  it('loops outward to the left when points are on left edge', () => {
+    // Points at x=200, shape center x=250 → left side
+    const start: [number, number] = [200, 120];
+    const end: [number, number] = [200, 160];
+    const result = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 30);
+
+    // The outward X should be min(200, 200) - 30 = 170
+    expect(result.points[1]![0]).toBe(170);
+    expect(result.points[2]![0]).toBe(170);
+  });
+
+  it('loops outward upward when points are on top edge', () => {
+    // Points at y=100, shape center y=140 → top side
+    const start: [number, number] = [220, 100];
+    const end: [number, number] = [280, 100];
+    const result = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 30);
+
+    // The outward Y should be min(100, 100) - 30 = 70
+    expect(result.points[1]![1]).toBe(70);
+    expect(result.points[2]![1]).toBe(70);
+    // X values should match start and end
+    expect(result.points[1]![0]).toBe(220);
+    expect(result.points[2]![0]).toBe(280);
+  });
+
+  it('loops outward downward when points are on bottom edge', () => {
+    // Points at y=180, shape center y=140 → bottom side
+    const start: [number, number] = [220, 180];
+    const end: [number, number] = [280, 180];
+    const result = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 30);
+
+    // The outward Y should be max(180, 180) + 30 = 210
+    expect(result.points[1]![1]).toBe(210);
+    expect(result.points[2]![1]).toBe(210);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// 3. Elbow routing → same as orthogonal for self-loops
+// ══════════════════════════════════════════════════════════════
+
+describe('computeSelfLoopPath — elbow routing', () => {
+  it('produces orthogonal loop same as orthogonal mode', () => {
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const ortho = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 30);
+    const elbow = computeSelfLoopPath(start, end, 'elbow', TARGET_SHAPE, 30);
+
+    expect(elbow.isCurved).toBe(false);
+    expect(elbow.points).toEqual(ortho.points);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// 4. jettySize controls loop extension
+// ══════════════════════════════════════════════════════════════
+
+describe('computeSelfLoopPath — jettySize', () => {
+  it('uses jettySize to control how far loop extends', () => {
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+
+    const small = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 10);
+    const large = computeSelfLoopPath(start, end, 'orthogonal', TARGET_SHAPE, 50);
+
+    // Larger jetty → farther outward
+    expect(small.points[1]![0]).toBe(310); // 300 + 10
+    expect(large.points[1]![0]).toBe(350); // 300 + 50
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// 5. Fallback when target is undefined
+// ══════════════════════════════════════════════════════════════
+
+describe('computeSelfLoopPath — fallback', () => {
+  it('returns curved fallback when target is undefined for orthogonal', () => {
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const result = computeSelfLoopPath(start, end, 'orthogonal', undefined, 30);
+
+    expect(result.isCurved).toBe(true);
+    expect(result.points).toHaveLength(2);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// 6. orthogonalCurved routing → same as orthogonal for self-loops
+// ══════════════════════════════════════════════════════════════
+
+describe('computeSelfLoopPath — orthogonalCurved routing', () => {
+  it('produces orthogonal loop for orthogonalCurved mode', () => {
+    const start: [number, number] = [300, 120];
+    const end: [number, number] = [300, 160];
+    const result = computeSelfLoopPath(start, end, 'orthogonalCurved', TARGET_SHAPE, 30);
+
+    expect(result.isCurved).toBe(false);
+    expect(result.points).toHaveLength(4);
+    assertOrthogonal(result.points);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// 7. Self-loop handle position
+// ══════════════════════════════════════════════════════════════
+
+const DEFAULT_STYLE: ExpressionStyle = {
+  strokeColor: '#000000',
+  backgroundColor: 'transparent',
+  fillStyle: 'none',
+  strokeWidth: 2,
+  roughness: 1,
+  opacity: 1,
+};
+
+const DEFAULT_META = {
+  author: { type: 'agent' as const, id: 'test', name: 'Test', provider: 'test' },
+  createdAt: 0,
+  updatedAt: 0,
+  tags: [],
+  locked: false,
+};
+
+/** Target shape for handle tests — 100x80 at (200, 100). */
+const HANDLE_TARGET: VisualExpression = {
+  id: 'shape-1',
+  kind: 'rectangle',
+  position: { x: 200, y: 100 },
+  size: { width: 100, height: 80 },
+  angle: 0,
+  style: DEFAULT_STYLE,
+  meta: DEFAULT_META,
+  data: { kind: 'rectangle' },
+};
+
+/** Create a self-loop arrow expression. */
+function makeSelfLoopArrow(
+  points: [number, number][],
+  routing: string | undefined,
+  jettySize?: number,
+): VisualExpression {
+  return {
+    id: 'arrow-1',
+    kind: 'arrow',
+    position: { x: 0, y: 0 },
+    size: { width: 1, height: 1 },
+    angle: 0,
+    style: DEFAULT_STYLE,
+    meta: DEFAULT_META,
+    data: {
+      kind: 'arrow',
+      points,
+      routing,
+      jettySize,
+      startBinding: { expressionId: 'shape-1', anchor: 'right' as const },
+      endBinding: { expressionId: 'shape-1', anchor: 'right' as const },
+    },
+  };
+}
+
+const EXPRESSIONS: Record<string, VisualExpression> = {
+  'shape-1': HANDLE_TARGET,
+};
+
+describe('getSelfLoopHandlePosition', () => {
+  it('returns handle for orthogonal self-loop on right side', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'orthogonal', 30);
+    const handle = getSelfLoopHandlePosition(arrow, EXPRESSIONS);
+
+    expect(handle).not.toBeNull();
+    // Handle at midpoint of outer segment: x=330, y=140
+    expect(handle!.position.x).toBe(330);
+    expect(handle!.position.y).toBe(140);
+    // Direction is outward (right): x=1
+    expect(handle!.direction.x).toBeGreaterThan(0);
+    expect(handle!.direction.y).toBe(0);
+    // Outer segment is vertical → ew-resize
+    expect(handle!.segmentOrientation).toBe('vertical');
+    // Adjusts jettySize, not midpointOffset
+    expect(handle!.adjustsMidpoint).toBe(false);
+  });
+
+  it('returns handle for orthogonal self-loop on top side', () => {
+    const arrow = makeSelfLoopArrow([[220, 100], [280, 100]], 'orthogonal', 30);
+    const handle = getSelfLoopHandlePosition(arrow, EXPRESSIONS);
+
+    expect(handle).not.toBeNull();
+    // Outer segment is horizontal at y=70, midpoint x=250
+    expect(handle!.position.x).toBe(250);
+    expect(handle!.position.y).toBe(70);
+    // Direction is outward (up): y=-1
+    expect(handle!.direction.x).toBe(0);
+    expect(handle!.direction.y).toBeLessThan(0);
+    // Outer segment is horizontal → ns-resize
+    expect(handle!.segmentOrientation).toBe('horizontal');
+  });
+
+  it('returns handle for elbow self-loop', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'elbow', 30);
+    const handle = getSelfLoopHandlePosition(arrow, EXPRESSIONS);
+
+    expect(handle).not.toBeNull();
+    expect(handle!.position.x).toBe(330);
+  });
+
+  it('returns null for curved self-loop', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'curved', 30);
+    const handle = getSelfLoopHandlePosition(arrow, EXPRESSIONS);
+
+    expect(handle).toBeNull();
+  });
+
+  it('returns null for straight self-loop', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'straight', 30);
+    const handle = getSelfLoopHandlePosition(arrow, EXPRESSIONS);
+
+    expect(handle).toBeNull();
+  });
+
+  it('returns null for undefined routing self-loop', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], undefined, 30);
+    const handle = getSelfLoopHandlePosition(arrow, EXPRESSIONS);
+
+    expect(handle).toBeNull();
+  });
+
+  it('returns null for non-self-loop arrow', () => {
+    const arrow: VisualExpression = {
+      id: 'arrow-2',
+      kind: 'arrow',
+      position: { x: 0, y: 0 },
+      size: { width: 1, height: 1 },
+      angle: 0,
+      style: DEFAULT_STYLE,
+      meta: DEFAULT_META,
+      data: {
+        kind: 'arrow',
+        points: [[0, 0], [100, 100]] as [number, number][],
+        routing: 'orthogonal',
+        startBinding: { expressionId: 'shape-1', anchor: 'right' as const },
+        endBinding: { expressionId: 'shape-2', anchor: 'left' as const },
+      },
+    };
+    const handle = getSelfLoopHandlePosition(arrow, EXPRESSIONS);
+    expect(handle).toBeNull();
+  });
+
+  it('uses jettySize to position the handle', () => {
+    const arrow10 = makeSelfLoopArrow([[300, 120], [300, 160]], 'orthogonal', 10);
+    const arrow50 = makeSelfLoopArrow([[300, 120], [300, 160]], 'orthogonal', 50);
+
+    const handle10 = getSelfLoopHandlePosition(arrow10, EXPRESSIONS);
+    const handle50 = getSelfLoopHandlePosition(arrow50, EXPRESSIONS);
+
+    expect(handle10!.position.x).toBe(310); // 300 + 10
+    expect(handle50!.position.x).toBe(350); // 300 + 50
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// getJettyHandlePosition — adjustsMidpoint correctness
+// ══════════════════════════════════════════════════════════════
+
+describe('getJettyHandlePosition — adjustsMidpoint', () => {
+  /**
+   * Create a regular (non-self-loop) arrow with specific bindings and routing.
+   *
+   * anchor pairs:
+   * - Z-shape: exits same axis, normal flow (e.g. right→left with end.x > start.x)
+   * - L-shape: exits different axes (e.g. right + bottom)
+   * - C-shape: exits same axis, reverse flow (e.g. right→left with end.x < start.x)
+   */
+  function makeArrow(
+    points: [number, number][],
+    startAnchor: string,
+    endAnchor: string,
+    opts?: { jettySize?: number; midpointOffset?: number },
+  ): VisualExpression {
+    return {
+      id: 'arrow-test',
+      kind: 'arrow',
+      position: { x: 0, y: 0 },
+      size: { width: 1, height: 1 },
+      angle: 0,
+      style: DEFAULT_STYLE,
+      meta: DEFAULT_META,
+      data: {
+        kind: 'arrow',
+        points,
+        routing: 'orthogonal',
+        jettySize: opts?.jettySize ?? 30,
+        midpointOffset: opts?.midpointOffset,
+        startBinding: { expressionId: 'shape-1', anchor: startAnchor },
+        endBinding: { expressionId: 'shape-2', anchor: endAnchor },
+      },
+    };
+  }
+
+  it('returns adjustsMidpoint=true for Z-shape (horizontal, normal flow)', () => {
+    // Start exits right (anchor='right'), end exits left (anchor='left')
+    // start=(100, 200), end=(300, 250) → exit right, entry left, normal Z
+    const arrow = makeArrow(
+      [[100, 200], [300, 250]],
+      'right',
+      'left',
+    );
+    const handle = getJettyHandlePosition(arrow);
+
+    expect(handle).not.toBeNull();
+    expect(handle!.adjustsMidpoint).toBe(true);
+    expect(handle!.segmentOrientation).toBe('vertical');
+  });
+
+  it('returns adjustsMidpoint=true for Z-shape (vertical, normal flow)', () => {
+    // Start exits bottom (anchor='bottom'), end exits top (anchor='top')
+    // start=(200, 100), end=(250, 300) → exit down, entry up, normal Z
+    const arrow = makeArrow(
+      [[200, 100], [250, 300]],
+      'bottom',
+      'top',
+    );
+    const handle = getJettyHandlePosition(arrow);
+
+    expect(handle).not.toBeNull();
+    expect(handle!.adjustsMidpoint).toBe(true);
+    expect(handle!.segmentOrientation).toBe('horizontal');
+  });
+
+  it('returns adjustsMidpoint=false for L-shape (different axes)', () => {
+    // Start exits right (anchor='right'), end exits bottom (anchor='bottom')
+    // Different axis exits → not a Z-shape
+    const arrow = makeArrow(
+      [[100, 200], [300, 100]],
+      'right',
+      'bottom',
+    );
+    const handle = getJettyHandlePosition(arrow);
+
+    expect(handle).not.toBeNull();
+    expect(handle!.adjustsMidpoint).toBe(false);
+  });
+
+  it('returns adjustsMidpoint=false for C-shape (same axis, reverse flow)', () => {
+    // Both exit right, but end is to the LEFT of start → reverse flow = C-shape
+    // start=(300, 200) exits right, end=(100, 250) exits right
+    const arrow = makeArrow(
+      [[300, 200], [100, 250]],
+      'right',
+      'right',
+    );
+    const handle = getJettyHandlePosition(arrow);
+
+    expect(handle).not.toBeNull();
+    expect(handle!.adjustsMidpoint).toBe(false);
+  });
+
+  it('Z-shape handle position follows midpointOffset', () => {
+    const arrow = makeArrow(
+      [[100, 200], [300, 250]],
+      'right',
+      'left',
+      { jettySize: 30, midpointOffset: 0.7 },
+    );
+    const handle = getJettyHandlePosition(arrow);
+
+    expect(handle).not.toBeNull();
+    expect(handle!.adjustsMidpoint).toBe(true);
+    // exitStubEnd = 100 + 30 = 130, entryStubEnd = 300 - 30 = 270
+    // midX = 130 + (270-130)*0.7 = 130 + 98 = 228
+    expect(handle!.position.x).toBeCloseTo(228, 0);
+  });
+
+  it('non-Z-shape handle is at exit stub midpoint', () => {
+    // L-shape: right exit, bottom entry
+    const arrow = makeArrow(
+      [[100, 200], [300, 100]],
+      'right',
+      'bottom',
+      { jettySize: 40 },
+    );
+    const handle = getJettyHandlePosition(arrow);
+
+    expect(handle).not.toBeNull();
+    // Exit stub midpoint: x = 100 + 1*20 = 120, y = 200
+    expect(handle!.position.x).toBe(120);
+    expect(handle!.position.y).toBe(200);
+  });
+
+  it('returns null for straight routing', () => {
+    const arrow: VisualExpression = {
+      id: 'arrow-straight',
+      kind: 'arrow',
+      position: { x: 0, y: 0 },
+      size: { width: 1, height: 1 },
+      angle: 0,
+      style: DEFAULT_STYLE,
+      meta: DEFAULT_META,
+      data: {
+        kind: 'arrow',
+        points: [[100, 200], [300, 250]] as [number, number][],
+        routing: 'straight',
+        startBinding: { expressionId: 'shape-1', anchor: 'right' as const },
+        endBinding: { expressionId: 'shape-2', anchor: 'left' as const },
+      },
+    };
+    expect(getJettyHandlePosition(arrow)).toBeNull();
+  });
+
+  it('returns null for non-arrow expression', () => {
+    const rect: VisualExpression = {
+      id: 'rect-1',
+      kind: 'rectangle',
+      position: { x: 0, y: 0 },
+      size: { width: 100, height: 50 },
+      angle: 0,
+      style: DEFAULT_STYLE,
+      meta: DEFAULT_META,
+      data: { kind: 'rectangle' },
+    };
+    expect(getJettyHandlePosition(rect)).toBeNull();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// getSegmentMidpointHandles — limited to first handle only
+// ══════════════════════════════════════════════════════════════
+
+describe('getSegmentMidpointHandles — single handle limit', () => {
+  /** Create a shape expression for binding. */
+  function makeShape(id: string, x: number, y: number, w: number, h: number): VisualExpression {
+    return {
+      id,
+      kind: 'rectangle',
+      position: { x, y },
+      size: { width: w, height: h },
+      angle: 0,
+      style: DEFAULT_STYLE,
+      meta: DEFAULT_META,
+      data: { kind: 'rectangle' },
+    };
+  }
+
+  it('returns at most 1 handle for an orthogonal arrow', () => {
+    const shape1 = makeShape('s1', 100, 100, 80, 60);
+    const shape2 = makeShape('s2', 400, 300, 80, 60);
+
+    const arrow: VisualExpression = {
+      id: 'arrow-seg',
+      kind: 'arrow',
+      position: { x: 0, y: 0 },
+      size: { width: 1, height: 1 },
+      angle: 0,
+      style: DEFAULT_STYLE,
+      meta: DEFAULT_META,
+      data: {
+        kind: 'arrow',
+        points: [[180, 130], [400, 330]] as [number, number][],
+        routing: 'orthogonal',
+        jettySize: 30,
+        startBinding: { expressionId: 's1', anchor: 'right' as const },
+        endBinding: { expressionId: 's2', anchor: 'left' as const },
+      },
+    };
+
+    const exprs: Record<string, VisualExpression> = {
+      s1: shape1,
+      s2: shape2,
+      'arrow-seg': arrow,
+    };
+
+    const handles = getSegmentMidpointHandles(arrow, exprs);
+    expect(handles.length).toBeLessThanOrEqual(1);
+  });
+
+  it('first handle has segmentIndex=0', () => {
+    const shape1 = makeShape('s1', 100, 100, 80, 60);
+    const shape2 = makeShape('s2', 400, 300, 80, 60);
+
+    const arrow: VisualExpression = {
+      id: 'arrow-seg2',
+      kind: 'arrow',
+      position: { x: 0, y: 0 },
+      size: { width: 1, height: 1 },
+      angle: 0,
+      style: DEFAULT_STYLE,
+      meta: DEFAULT_META,
+      data: {
+        kind: 'arrow',
+        points: [[180, 130], [400, 330]] as [number, number][],
+        routing: 'orthogonal',
+        jettySize: 30,
+        startBinding: { expressionId: 's1', anchor: 'right' as const },
+        endBinding: { expressionId: 's2', anchor: 'left' as const },
+      },
+    };
+
+    const exprs: Record<string, VisualExpression> = {
+      s1: shape1,
+      s2: shape2,
+      'arrow-seg2': arrow,
+    };
+
+    const handles = getSegmentMidpointHandles(arrow, exprs);
+    if (handles.length > 0) {
+      expect(handles[0]!.segmentIndex).toBe(0);
+    }
+  });
+
+  it('returns empty for self-loop arrow', () => {
+    const arrow = makeSelfLoopArrow([[300, 120], [300, 160]], 'orthogonal', 30);
+
+    const handles = getSegmentMidpointHandles(arrow, EXPRESSIONS);
+    expect(handles).toEqual([]);
+  });
+
+  it('returns empty for non-orthogonal arrow', () => {
+    const arrow: VisualExpression = {
+      id: 'arrow-straight2',
+      kind: 'arrow',
+      position: { x: 0, y: 0 },
+      size: { width: 1, height: 1 },
+      angle: 0,
+      style: DEFAULT_STYLE,
+      meta: DEFAULT_META,
+      data: {
+        kind: 'arrow',
+        points: [[100, 200], [300, 400]] as [number, number][],
+        routing: 'straight',
+      },
+    };
+    const handles = getSegmentMidpointHandles(arrow, {});
+    expect(handles).toEqual([]);
+  });
+});

--- a/packages/engine/src/connectors/orthogonalRouter.ts
+++ b/packages/engine/src/connectors/orthogonalRouter.ts
@@ -488,7 +488,76 @@ export function eliminateCollinear(points: Point[]): Point[] {
 }
 
 // ══════════════════════════════════════════════════════════════
-// 5. Geometry helpers
+// 5. Self-loop path computation
+// ══════════════════════════════════════════════════════════════
+
+/**
+ * Compute the path for a self-referencing arrow (both ends on the same shape).
+ *
+ * For curved/straight/undefined routing, returns the original start→end pair
+ * (renderer draws a bezier curve). For orthogonal/elbow/orthogonalCurved,
+ * computes a right-angle loop that extends outward from the shape.
+ *
+ * Shared between the arrow renderer and hit testing to ensure the rendered
+ * path matches the hit-test path exactly.
+ *
+ * @param start   Connection point on shape edge (start)
+ * @param end     Connection point on shape edge (end)
+ * @param routing Arrow routing mode
+ * @param target  Shape that the self-loop is bound to (position + size)
+ * @param jettySize How far the loop extends outward from the shape
+ *
+ * [CLEAN-CODE] [SRP] — one function computes the path; callers decide how to use it.
+ */
+export function computeSelfLoopPath(
+  start: [number, number],
+  end: [number, number],
+  routing: string | undefined,
+  target: { position: { x: number; y: number }; size: { width: number; height: number } } | undefined,
+  jettySize: number,
+): { points: [number, number][]; isCurved: boolean } {
+  // For curved/straight/undefined: renderer draws bezier
+  if (!routing || routing === 'straight' || routing === 'curved') {
+    return { points: [start, end], isCurved: true };
+  }
+
+  // For orthogonal/elbow/orthogonalCurved: compute right-angle loop
+  if (!target) {
+    return { points: [start, end], isCurved: true }; // fallback
+  }
+
+  const shapeCx = target.position.x + target.size.width / 2;
+  const shapeCy = target.position.y + target.size.height / 2;
+  const midX = (start[0] + end[0]) / 2;
+  const midY = (start[1] + end[1]) / 2;
+
+  // Direction outward from shape center
+  const dx = midX - shapeCx;
+  const dy = midY - shapeCy;
+
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    // Start and end are on left or right side — loop outward horizontally
+    const outX = dx >= 0
+      ? Math.max(start[0], end[0]) + jettySize
+      : Math.min(start[0], end[0]) - jettySize;
+    return {
+      points: [start, [outX, start[1]], [outX, end[1]], end],
+      isCurved: false,
+    };
+  } else {
+    // Start and end are on top or bottom — loop outward vertically
+    const outY = dy >= 0
+      ? Math.max(start[1], end[1]) + jettySize
+      : Math.min(start[1], end[1]) - jettySize;
+    return {
+      points: [start, [start[0], outY], [end[0], outY], end],
+      isCurved: false,
+    };
+  }
+}
+
+// ══════════════════════════════════════════════════════════════
+// 6. Geometry helpers
 // ══════════════════════════════════════════════════════════════
 
 /** Check if a direction is horizontal (left or right). */

--- a/packages/engine/src/hooks/useManipulationInteraction.ts
+++ b/packages/engine/src/hooks/useManipulationInteraction.ts
@@ -157,7 +157,7 @@ export function useManipulationInteraction(
           : 0.5;
 
       // Z-shape handle always has a direction — use it for drag computation
-      const isZShape = true;
+      const isZShape = target.handle.adjustsMidpoint !== false;
 
       dragModeRef.current = {
         kind: 'jetty-drag',

--- a/packages/engine/src/interaction/hitTest.ts
+++ b/packages/engine/src/interaction/hitTest.ts
@@ -14,6 +14,7 @@
 import type { VisualExpression, ArrowData } from '@infinicanvas/protocol';
 import type { PathSegment } from '../connectors/routerTypes.js';
 import { getRouter } from '../connectors/routerRegistry.js';
+import { computeSelfLoopPath } from '../connectors/orthogonalRouter.js';
 
 /** A 2D point in world coordinates. */
 export interface WorldPoint {
@@ -321,6 +322,40 @@ export function hitTestArrow(
 
   // Use wider tolerance for thin lines (minimum 8 world px for easier clicking)
   const effectiveTolerance = Math.max(tolerance, 8);
+
+  // ── Self-loop detection: both ends bound to the same shape ──
+  // Must be checked BEFORE the router — self-loops use computeSelfLoopPath
+  // instead of the general-purpose router for path computation.
+  const isSelfLoop = data.startBinding && data.endBinding &&
+    data.startBinding.expressionId === data.endBinding.expressionId;
+
+  if (isSelfLoop) {
+    const target = expressions?.[data.startBinding!.expressionId];
+    const jetty = typeof data.jettySize === 'number' ? data.jettySize : 30;
+    const path = computeSelfLoopPath(
+      points[0]!, points[points.length - 1]!, data.routing, target, jetty,
+    );
+
+    if (path.isCurved) {
+      // For bezier self-loops: test against the straight line start→end
+      // (approximate — matches existing fallback behavior)
+      return distanceToSegment(point.x, point.y,
+        points[0]![0], points[0]![1],
+        points[points.length - 1]![0], points[points.length - 1]![1],
+      ) <= effectiveTolerance;
+    }
+
+    // For orthogonal self-loops: test against each segment in the path
+    for (let i = 0; i < path.points.length - 1; i++) {
+      if (distanceToSegment(point.x, point.y,
+        path.points[i]![0], path.points[i]![1],
+        path.points[i + 1]![0], path.points[i + 1]![1],
+      ) <= effectiveTolerance) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   // Try routing-aware hit testing for non-straight arrows
   const routingMode = data.routing === 'orthogonal' && data.curved

--- a/packages/engine/src/interaction/manipulationHelpers.ts
+++ b/packages/engine/src/interaction/manipulationHelpers.ts
@@ -10,7 +10,7 @@
 
 import type { VisualExpression, ArrowData } from '@infinicanvas/protocol';
 import type { Camera } from '../types/index.js';
-import { computeOrthogonalRoute } from '../connectors/orthogonalRouter.js';
+import { computeOrthogonalRoute, computeSelfLoopPath } from '../connectors/orthogonalRouter.js';
 import { resolveBindings } from './connectorHelpers.js';
 
 // ── Point-based kind guard ─────────────────────────────────────
@@ -68,6 +68,14 @@ export interface JettyHandleHit {
    * [CLEAN-CODE] Explicit orientation avoids inferring it from direction.
    */
   segmentOrientation: 'horizontal' | 'vertical';
+  /**
+   * Whether dragging this handle adjusts `midpointOffset` (Z-shape)
+   * or `jettySize` (self-loop / non-Z-shape).
+   *
+   * - `true` (default) → drag updates `midpointOffset` ratio
+   * - `false` → drag updates `jettySize` distance
+   */
+  adjustsMidpoint?: boolean;
 }
 
 /**
@@ -375,6 +383,7 @@ export function getJettyHandlePosition(
           direction: { x: 1, y: 0 },
           // Middle segment runs vertically
           segmentOrientation: 'vertical',
+          adjustsMidpoint: true,
         };
       }
 
@@ -391,6 +400,7 @@ export function getJettyHandlePosition(
         direction: { x: 0, y: 1 },
         // Middle segment runs horizontally
         segmentOrientation: 'horizontal',
+        adjustsMidpoint: true,
       };
     }
   }
@@ -407,6 +417,7 @@ export function getJettyHandlePosition(
     },
     direction: exitDir,
     segmentOrientation: stubOrientation,
+    adjustsMidpoint: false,
   };
 }
 
@@ -440,7 +451,103 @@ export function detectJettyHandle(
     }
   }
 
+  // ── Self-loop handle check (reuses JettyHandleHit) ──
+  for (const id of selectedIds) {
+    const expr = expressions[id];
+    if (!expr) continue;
+
+    const handle = getSelfLoopHandlePosition(expr, expressions);
+    if (!handle) continue;
+
+    const dx = worldPoint.x - handle.position.x;
+    const dy = worldPoint.y - handle.position.y;
+    if (Math.abs(dx) <= tolerance && Math.abs(dy) <= tolerance) {
+      return handle;
+    }
+  }
+
   return null;
+}
+
+// ── Self-loop handle ─────────────────────────────────────────
+
+/** Routing modes that produce orthogonal self-loops with a drag handle. */
+const SELF_LOOP_HANDLE_ROUTING = new Set([
+  'orthogonal',
+  'elbow',
+  'orthogonalCurved',
+  'entityRelation',
+  'isometric',
+]);
+
+/**
+ * Compute the handle position for a self-loop arrow's outer segment.
+ *
+ * For orthogonal self-loops (4 points: start → corner1 → corner2 → end),
+ * places ONE handle at the midpoint of the outer segment (corner1 → corner2).
+ * This is the segment farthest from the shape. Dragging it adjusts `jettySize`.
+ *
+ * Returns null for:
+ * - Non-self-loop arrows
+ * - Curved/straight self-loops (no orthogonal path to place handle on)
+ * - Missing target shape
+ *
+ * [CLEAN-CODE] [SRP]
+ */
+export function getSelfLoopHandlePosition(
+  expr: VisualExpression,
+  expressions: Record<string, VisualExpression>,
+): JettyHandleHit | null {
+  if (expr.data.kind !== 'arrow') return null;
+
+  const data = expr.data as ArrowData;
+
+  // Must be a self-loop (both ends bound to the same shape)
+  if (!data.startBinding || !data.endBinding) return null;
+  if (data.startBinding.expressionId !== data.endBinding.expressionId) return null;
+
+  // Only orthogonal-family routing produces a right-angle loop
+  if (!data.routing || !SELF_LOOP_HANDLE_ROUTING.has(data.routing)) return null;
+  if (data.points.length < 2) return null;
+
+  const target = expressions[data.startBinding.expressionId];
+  if (!target) return null;
+
+  const start = data.points[0]!;
+  const end = data.points[data.points.length - 1]!;
+  const jetty = typeof data.jettySize === 'number' ? data.jettySize : 30;
+
+  const path = computeSelfLoopPath(start, end, data.routing, target, jetty);
+  if (path.isCurved || path.points.length < 4) return null;
+
+  // Outer segment is points[1] → points[2] (the segment farthest from shape)
+  const corner1 = path.points[1]!;
+  const corner2 = path.points[2]!;
+  const midX = (corner1[0] + corner2[0]) / 2;
+  const midY = (corner1[1] + corner2[1]) / 2;
+
+  // Determine segment orientation and outward direction
+  const isHoriz = Math.abs(corner1[1] - corner2[1]) < 0.01;
+  const shapeCx = target.position.x + target.size.width / 2;
+  const shapeCy = target.position.y + target.size.height / 2;
+
+  let direction: { x: number; y: number };
+  if (isHoriz) {
+    // Horizontal outer segment → drag vertically (away from shape)
+    direction = midY < shapeCy ? { x: 0, y: -1 } : { x: 0, y: 1 };
+  } else {
+    // Vertical outer segment → drag horizontally (away from shape)
+    direction = midX < shapeCx ? { x: -1, y: 0 } : { x: 1, y: 0 };
+  }
+
+  return {
+    expressionId: expr.id,
+    end: 'start',
+    position: { x: midX, y: midY },
+    direction,
+    segmentOrientation: isHoriz ? 'horizontal' : 'vertical',
+    adjustsMidpoint: false,
+  };
 }
 
 // ── Segment midpoint handles ─────────────────────────────────
@@ -473,6 +580,13 @@ export function getSegmentMidpointHandles(
   const data = expr.data as ArrowData;
   if (!data.routing || !SEGMENT_HANDLE_ROUTING_MODES.has(data.routing)) return [];
   if (data.points.length < 2) return [];
+
+  // Self-loops use computeSelfLoopPath, not computeOrthogonalRoute —
+  // skip segment handles (the self-loop gets ONE handle via getSelfLoopHandlePosition)
+  if (data.startBinding && data.endBinding &&
+      data.startBinding.expressionId === data.endBinding.expressionId) {
+    return [];
+  }
 
   // Resolve binding positions to get absolute world coordinates
   const points = resolveBindings(expr, expressions);
@@ -518,6 +632,9 @@ export function getSegmentMidpointHandles(
 
   // Skip first segment (start→first turn) and last segment (last turn→end)
   // as those are the jetty stubs. Handle internal segments only.
+  // Limit to ONE handle (segmentIndex=0) because the orthogonal router
+  // only reads waypoints[0]. Handles for segmentIndex > 0 would write
+  // to unused waypoint slots and silently do nothing.
   for (let i = 1; i < routeWaypoints.length - 2; i++) {
     const [x1, y1] = routeWaypoints[i]!;
     const [x2, y2] = routeWaypoints[i + 1]!;
@@ -535,6 +652,8 @@ export function getSegmentMidpointHandles(
         position: { x: midX, y: midY },
         segmentOrientation: isHoriz ? 'horizontal' : 'vertical',
       });
+      // Only show first matching handle — router reads waypoints[0] only
+      break;
     }
   }
 

--- a/packages/engine/src/renderer/arrowRenderer.ts
+++ b/packages/engine/src/renderer/arrowRenderer.ts
@@ -22,6 +22,7 @@ import { mapStyleToRoughOptions, idToSeed } from './styleMapper.js';
 import { resolveBindings } from '../interaction/connectorHelpers.js';
 import { getRouter } from '../connectors/routerRegistry.js';
 import { renderArrowheadFromRegistry } from './arrowheads.js';
+import { computeSelfLoopPath } from '../connectors/orthogonalRouter.js';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -167,7 +168,12 @@ export function renderArrow(
 /**
  * Render a self-referencing arrow (both ends bound to the same shape).
  *
- * Draws a curved bezier loop outward from the shape center.
+ * Routing-aware:
+ * - Curved/straight/undefined → bezier curve (existing behavior)
+ * - Orthogonal/elbow/orthogonalCurved → right-angle loop segments
+ *
+ * Uses `computeSelfLoopPath` to share path computation with hit testing.
+ * [CLEAN-CODE] [SRP]
  */
 function renderSelfLoop(
   ctx: CanvasRenderingContext2D,
@@ -186,27 +192,9 @@ function renderSelfLoop(
   const start = points[0]!;
   const end = points[points.length - 1]!;
   const target = expressions[data.startBinding!.expressionId];
-  const loopSize = target
-    ? Math.max(target.size.width, target.size.height) * 0.6
-    : 60;
+  const jetty = typeof data.jettySize === 'number' ? data.jettySize : 30;
 
-  // Compute control points — curve outward from the shape
-  const midX = (start[0] + end[0]) / 2;
-  const midY = (start[1] + end[1]) / 2;
-  const cx = target ? target.position.x + target.size.width / 2 : midX;
-  const cy = target ? target.position.y + target.size.height / 2 : midY;
-
-  // Direction away from shape center
-  const dx = midX - cx;
-  const dy = midY - cy;
-  const dist = Math.hypot(dx, dy) || 1;
-  const nx = dx / dist;
-  const ny = dy / dist;
-
-  const cp1x = start[0] + nx * loopSize;
-  const cp1y = start[1] + ny * loopSize;
-  const cp2x = end[0] + nx * loopSize;
-  const cp2y = end[1] + ny * loopSize;
+  const path = computeSelfLoopPath(start, end, data.routing, target, jetty);
 
   ctx.save();
   ctx.strokeStyle = expr.style.strokeColor;
@@ -215,22 +203,71 @@ function renderSelfLoop(
   const ss = expr.style.strokeStyle ?? 'solid';
   if (ss === 'dashed') ctx.setLineDash([expr.style.strokeWidth * 4, expr.style.strokeWidth * 3]);
   else if (ss === 'dotted') ctx.setLineDash([expr.style.strokeWidth, expr.style.strokeWidth * 2]);
-  ctx.beginPath();
-  ctx.moveTo(start[0], start[1]);
-  ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, end[0], end[1]);
-  ctx.stroke();
-  ctx.restore();
 
-  // Arrowheads for self-loop
-  if (endType !== 'none') {
-    const angle = Math.atan2(end[1] - cp2y, end[0] - cp2x);
-    renderArrowheadFromRegistry(ctx, end[0], end[1], angle, arrowSize,
-      endType, endFilled, strokeColor, fillColor);
-  }
-  if (startType !== 'none') {
-    const angle = Math.atan2(start[1] - cp1y, start[0] - cp1x);
-    renderArrowheadFromRegistry(ctx, start[0], start[1], angle, arrowSize,
-      startType, startFilled, strokeColor, fillColor);
+  if (path.isCurved) {
+    // ── Bezier self-loop (curved/straight/undefined) ──
+    const loopSize = target
+      ? Math.max(target.size.width, target.size.height) * 0.6
+      : 60;
+
+    const midX = (start[0] + end[0]) / 2;
+    const midY = (start[1] + end[1]) / 2;
+    const cx = target ? target.position.x + target.size.width / 2 : midX;
+    const cy = target ? target.position.y + target.size.height / 2 : midY;
+
+    const dx = midX - cx;
+    const dy = midY - cy;
+    const dist = Math.hypot(dx, dy) || 1;
+    const nx = dx / dist;
+    const ny = dy / dist;
+
+    const cp1x = start[0] + nx * loopSize;
+    const cp1y = start[1] + ny * loopSize;
+    const cp2x = end[0] + nx * loopSize;
+    const cp2y = end[1] + ny * loopSize;
+
+    ctx.beginPath();
+    ctx.moveTo(start[0], start[1]);
+    ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, end[0], end[1]);
+    ctx.stroke();
+    ctx.restore();
+
+    // Arrowheads for bezier self-loop
+    if (endType !== 'none') {
+      const angle = Math.atan2(end[1] - cp2y, end[0] - cp2x);
+      renderArrowheadFromRegistry(ctx, end[0], end[1], angle, arrowSize,
+        endType, endFilled, strokeColor, fillColor);
+    }
+    if (startType !== 'none') {
+      const angle = Math.atan2(start[1] - cp1y, start[0] - cp1x);
+      renderArrowheadFromRegistry(ctx, start[0], start[1], angle, arrowSize,
+        startType, startFilled, strokeColor, fillColor);
+    }
+  } else {
+    // ── Orthogonal self-loop (right-angle segments) ──
+    ctx.beginPath();
+    ctx.moveTo(path.points[0]![0], path.points[0]![1]);
+    for (let i = 1; i < path.points.length; i++) {
+      ctx.lineTo(path.points[i]![0], path.points[i]![1]);
+    }
+    ctx.stroke();
+    ctx.restore();
+
+    // Arrowheads for orthogonal self-loop
+    if (endType !== 'none' && path.points.length >= 2) {
+      const last = path.points[path.points.length - 1]!;
+      const prev = path.points[path.points.length - 2]!;
+      const angle = Math.atan2(last[1] - prev[1], last[0] - prev[0]);
+      renderArrowheadFromRegistry(ctx, last[0], last[1], angle, arrowSize,
+        endType, endFilled, strokeColor, fillColor);
+    }
+    if (startType !== 'none' && path.points.length >= 2) {
+      const first = path.points[0]!;
+      const second = path.points[1]!;
+      const angle = Math.atan2(first[1] - second[1], first[0] - second[0]);
+      renderArrowheadFromRegistry(ctx, first[0], first[1], angle, arrowSize,
+        startType, startFilled, strokeColor, fillColor);
+    }
   }
 }
 

--- a/packages/engine/src/renderer/selectionRenderer.ts
+++ b/packages/engine/src/renderer/selectionRenderer.ts
@@ -20,6 +20,7 @@ import {
   getPointHandlePositions,
   getJettyHandlePosition,
   getSegmentMidpointHandles,
+  getSelfLoopHandlePosition,
 } from '../interaction/manipulationHelpers.js';
 import { isDraggingArrowEndpoint } from '../hooks/useManipulationInteraction.js';
 
@@ -83,6 +84,8 @@ export function renderSelection(
       renderPointHandles(ctx, expr, camera, halfHandle);
       // ── Jetty handle for routed arrows ──
       renderJettyHandle(ctx, expr, camera, halfHandle);
+      // ── Self-loop handle (on the outer segment) ──
+      renderSelfLoopHandle(ctx, expr, expressions, camera, halfHandle);
       // ── Segment midpoint handles for routed arrows ──
       renderSegmentMidpointHandles(ctx, expr, expressions, camera, halfHandle);
     } else {
@@ -105,6 +108,9 @@ export function renderSelection(
  *
  * Handles are white circles with selection-colored borders, sized
  * to match the standard handle size in screen pixels.
+ *
+ * For arrows with both endpoints bound to shapes, endpoint circles are
+ * hidden — bindings control position, making the handles misleading.
  */
 function renderPointHandles(
   ctx: CanvasRenderingContext2D,
@@ -112,6 +118,15 @@ function renderPointHandles(
   camera: Camera,
   radius: number,
 ): void {
+  // Skip endpoint handles for fully-bound arrows — bindings control position,
+  // so dragging these handles has no meaningful effect.
+  if (expr.data.kind === 'arrow') {
+    const arrowData = expr.data as { startBinding?: unknown; endBinding?: unknown };
+    if (arrowData.startBinding && arrowData.endBinding) {
+      return;
+    }
+  }
+
   const pointHandles = getPointHandlePositions(expr);
 
   // Check for drag offset: during transient drag, position changes
@@ -173,6 +188,37 @@ function renderJettyHandle(
   ctx.fillRect(x - half, y - half, size, size);
 
   // White border for contrast
+  ctx.strokeStyle = '#ffffff';
+  ctx.lineWidth = 1.5 / camera.zoom;
+  ctx.strokeRect(x - half, y - half, size, size);
+}
+
+/**
+ * Render a drag handle on the outer segment of a self-loop arrow.
+ *
+ * Uses the same visual style as the jetty handle (blue square) since
+ * it adjusts jettySize via the same drag interaction.
+ *
+ * [CLEAN-CODE] [SRP]
+ */
+function renderSelfLoopHandle(
+  ctx: CanvasRenderingContext2D,
+  expr: VisualExpression,
+  expressions: Record<string, VisualExpression>,
+  camera: Camera,
+  halfHandle: number,
+): void {
+  const handle = getSelfLoopHandlePosition(expr, expressions);
+  if (!handle) return;
+
+  const { x, y } = handle.position;
+  const size = halfHandle * 1.5;
+  const half = size / 2;
+
+  // Same style as jetty handle — blue accent
+  ctx.fillStyle = JETTY_HANDLE_COLOR;
+  ctx.fillRect(x - half, y - half, size, size);
+
   ctx.strokeStyle = '#ffffff';
   ctx.lineWidth = 1.5 / camera.zoom;
   ctx.strokeRect(x - half, y - half, size, size);


### PR DESCRIPTION
Self-loops respect arrow type. Shared path function. Handles on the line. Both drag axes work. tsc ✓.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>