### PR TITLE
fix: show arrow endpoint handles when selected

### DIFF
--- a/packages/engine/src/renderer/selectionRenderer.ts
+++ b/packages/engine/src/renderer/selectionRenderer.ts
@@ -118,13 +118,10 @@ function renderPointHandles(
   camera: Camera,
   radius: number,
 ): void {
-  // Skip endpoint handles for fully-bound arrows — bindings control position,
-  // so dragging these handles has no meaningful effect.
+  // Show endpoint handles for all arrows — even when fully bound.
+  // Users need them to disconnect/rebind endpoints.
   if (expr.data.kind === 'arrow') {
-    const arrowData = expr.data as { startBinding?: unknown; endBinding?: unknown };
-    if (arrowData.startBinding && arrowData.endBinding) {
-      return;
-    }
+    // handled below
   }
 
   const pointHandles = getPointHandlePositions(expr);


### PR DESCRIPTION
Endpoint handles visible for all arrows. Users can see selection and disconnect/rebind. tsc ✓.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>