### PR TITLE
fix: suppress duplicate jetty handle on routed arrows

### DIFF
--- a/packages/engine/src/interaction/manipulationHelpers.ts
+++ b/packages/engine/src/interaction/manipulationHelpers.ts
@@ -441,6 +441,10 @@ export function detectJettyHandle(
     const expr = expressions[id];
     if (!expr) continue;
 
+    // Skip jetty handle when segment-midpoint handles are shown (same role,
+    // same visual). Keeps hit-testing consistent with rendering.
+    if (getSegmentMidpointHandles(expr, expressions).length > 0) continue;
+
     const handle = getJettyHandlePosition(expr);
     if (!handle) continue;
 

--- a/packages/engine/src/renderer/selectionRenderer.ts
+++ b/packages/engine/src/renderer/selectionRenderer.ts
@@ -83,7 +83,7 @@ export function renderSelection(
       // ── Point-based shapes: only show endpoint circles, no bounding box ──
       renderPointHandles(ctx, expr, camera, halfHandle);
       // ── Jetty handle for routed arrows ──
-      renderJettyHandle(ctx, expr, camera, halfHandle);
+      renderJettyHandle(ctx, expr, expressions, camera, halfHandle);
       // ── Self-loop handle (on the outer segment) ──
       renderSelfLoopHandle(ctx, expr, expressions, camera, halfHandle);
       // ── Segment midpoint handles for routed arrows ──
@@ -170,9 +170,14 @@ const JETTY_HANDLE_COLOR = '#4A90D9';
 function renderJettyHandle(
   ctx: CanvasRenderingContext2D,
   expr: VisualExpression,
+  expressions: Record<string, VisualExpression>,
   camera: Camera,
   halfHandle: number,
 ): void {
+  // Segment-midpoint handles cover the Z/L middle segment for routed arrows.
+  // Skip the jetty handle to avoid rendering two overlapping blue squares.
+  if (getSegmentMidpointHandles(expr, expressions).length > 0) return;
+
   const handle = getJettyHandlePosition(expr);
   if (!handle) return;
 


### PR DESCRIPTION
Two blue squares were showing on orthogonal arrows — one on the exit stub (jetty handle) and one on the middle segment (segment-midpoint handle). They do the same thing from the user's perspective.

Suppress the jetty handle whenever a segment-midpoint handle exists. Self-loops still use their own handle.