### PR TITLE
feat: drag both middle segments on L-shape orthogonal arrows

### DIFF
--- a/packages/engine/src/connectors/orthogonalRouter.ts
+++ b/packages/engine/src/connectors/orthogonalRouter.ts
@@ -415,13 +415,32 @@ function buildLShape(
     ? [entryStub[0], exitStub[1]]
     : [exitStub[0], entryStub[1]];
 
-  // Apply waypoint override if available
+  // Alt corner (Z-like path: 2 perpendicular middle segments share one turn point)
+  const alt: Point = exitH
+    ? [exitStub[0], entryStub[1]]
+    : [entryStub[0], exitStub[1]];
+
+  // ── Two-waypoint form (Z-like with independent middles) ──
+  // waypoints[0] controls the first perpendicular-to-exit middle segment,
+  // waypoints[1] controls the second perpendicular-to-first middle segment.
+  if (waypoints && waypoints.length >= 2) {
+    if (exitH) {
+      // Horizontal exit → first middle is vertical (X), second is horizontal (Y)
+      const vx = waypoints[0]!;
+      const hy = waypoints[1]!;
+      return [[vx, exitStub[1]], [vx, hy], [entryStub[0], hy]];
+    }
+    // Vertical exit → first middle is horizontal (Y), second is vertical (X)
+    const hy = waypoints[0]!;
+    const vx = waypoints[1]!;
+    return [[exitStub[0], hy], [vx, hy], [vx, entryStub[1]]];
+  }
+
+  // ── Single-waypoint form: override corner position only ──
   if (waypoints && waypoints.length > 0) {
     if (exitH) {
-      // Horizontal exit → waypoint overrides the X of the corner
       return [[waypoints[0]!, exitStub[1]], [waypoints[0]!, entryStub[1]]];
     }
-    // Vertical exit → waypoint overrides the Y of the corner
     return [[exitStub[0], waypoints[0]!], [entryStub[0], waypoints[0]!]];
   }
 
@@ -431,11 +450,6 @@ function buildLShape(
       !segmentCrossesRect(natural, entryStub, eBounds)) {
     return [natural];
   }
-
-  // Alt corner: the other L-shape variant
-  const alt: Point = exitH
-    ? [exitStub[0], entryStub[1]]
-    : [entryStub[0], exitStub[1]];
 
   if (!segmentCrossesRect(exitStub, alt, sBounds) &&
       !segmentCrossesRect(exitStub, alt, eBounds) &&

--- a/packages/engine/src/hooks/useManipulationInteraction.ts
+++ b/packages/engine/src/hooks/useManipulationInteraction.ts
@@ -31,6 +31,7 @@ import {
   computePointDrag,
   getCursorForTarget,
   isPointBasedKind,
+  getSegmentMidpointHandles,
 } from '../interaction/manipulationHelpers.js';
 import type { HandleHit, PointHandleHit, JettyHandleHit, SegmentHandleHit } from '../interaction/manipulationHelpers.js';
 import { computeSnappedDelta } from '../utils/snapToGrid.js';
@@ -172,12 +173,21 @@ export function useManipulationInteraction(
       if (!expr || expr.meta.locked) return;
 
       const data = expr.data as ArrowData;
-      const originalWaypoints = data.waypoints ? [...data.waypoints] : [];
+      // Seed waypoints from current handle positions so dragging slot 1 before
+      // slot 0 doesn't clobber slot 0 with a default 0.
+      const currentHandles = getSegmentMidpointHandles(expr, expressions);
+      const seeded: number[] = data.waypoints ? [...data.waypoints] : [];
+      for (const h of currentHandles) {
+        if (seeded[h.segmentIndex] === undefined) {
+          seeded[h.segmentIndex] =
+            h.segmentOrientation === 'horizontal' ? h.position.y : h.position.x;
+        }
+      }
 
       dragModeRef.current = {
         kind: 'segment-drag',
         handle: target.handle,
-        originalWaypoints,
+        originalWaypoints: seeded,
         startWorld: worldPoint,
       };
     } else if (target.kind === 'handle') {

--- a/packages/engine/src/interaction/manipulationHelpers.ts
+++ b/packages/engine/src/interaction/manipulationHelpers.ts
@@ -634,22 +634,14 @@ export function getSegmentMidpointHandles(
 
   const handles: SegmentHandleHit[] = [];
 
-  // The router reads waypoints[0] only. For Z/L shapes, waypoints[0] controls
-  // the coordinate of the middle segment that is PERPENDICULAR to the exit stub
-  // (e.g. for a horizontal exit, waypoints[0] is the X of the vertical middle
-  // segment; for a vertical exit, waypoints[0] is the Y of the horizontal
-  // middle segment).
-  //
-  // So: among internal segments (skip exit stub at 0→1 and entry stub at
-  // last→last), pick the one whose orientation is perpendicular to the
-  // exit stub. That's the segment the user drags to adjust midpointOffset.
-  const [sx, sy] = routeWaypoints[0]!;
-  const [s1x, s1y] = routeWaypoints[1]!;
-  const exitIsHoriz = Math.abs(sy - s1y) < 0.01 && Math.abs(sx - s1x) >= 0.01;
-  const targetOrientation: 'horizontal' | 'vertical' = exitIsHoriz
-    ? 'vertical'
-    : 'horizontal';
-
+  // Emit a handle on every internal segment (i.e. every segment between the
+  // exit stub and the entry stub), up to 2 handles. The router supports two
+  // waypoints for L-shape routes:
+  //   waypoints[0] → first perpendicular-to-exit middle segment
+  //   waypoints[1] → second middle segment (perpendicular to the first)
+  // For Z-shape routes, only one waypoint is meaningful and only one handle
+  // is produced.
+  let slot = 0;
   for (let i = 1; i < routeWaypoints.length - 2; i++) {
     const [x1, y1] = routeWaypoints[i]!;
     const [x2, y2] = routeWaypoints[i + 1]!;
@@ -661,36 +653,16 @@ export function getSegmentMidpointHandles(
       : isVert
         ? 'vertical'
         : null;
-
-    if (orientation !== targetOrientation) continue;
+    if (!orientation) continue;
 
     handles.push({
       expressionId: expr.id,
-      segmentIndex: 0, // router only reads waypoints[0]
+      segmentIndex: slot,
       position: { x: (x1 + x2) / 2, y: (y1 + y2) / 2 },
       segmentOrientation: orientation,
     });
-    break;
-  }
-
-  // Fallback: if no perpendicular segment found (degenerate route), use the
-  // first internal segment so the handle still appears.
-  if (handles.length === 0) {
-    for (let i = 1; i < routeWaypoints.length - 2; i++) {
-      const [x1, y1] = routeWaypoints[i]!;
-      const [x2, y2] = routeWaypoints[i + 1]!;
-      const isHoriz = Math.abs(y1 - y2) < 0.01;
-      const isVert = Math.abs(x1 - x2) < 0.01;
-      if (isHoriz || isVert) {
-        handles.push({
-          expressionId: expr.id,
-          segmentIndex: 0,
-          position: { x: (x1 + x2) / 2, y: (y1 + y2) / 2 },
-          segmentOrientation: isHoriz ? 'horizontal' : 'vertical',
-        });
-        break;
-      }
-    }
+    slot += 1;
+    if (slot >= 2) break;
   }
 
   return handles;


### PR DESCRIPTION
L-shape routes (perpendicular exit/entry) have two internal middle segments, but only one was draggable. Now both show a handle and each writes to its own waypoint slot, letting users reposition both segments independently.

Fixes the case in the user's screenshot where the right vertical segment had no handle.